### PR TITLE
Remove anchors and fix some styles.

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,30 +1,33 @@
-import React from "react";
-import { Router } from "@reach/router";
-import { Provider } from "react-redux";
+import React from "react"
+import { Router } from "@reach/router"
+import { Provider } from "react-redux"
 
 import store from "./store"
-import data from "../staticData";
+import data from "../staticData"
 
-import ChannelView from "./views/ChannelView";
-import ExploreView from "./views/ExploreView";
-import VideoView from "./views/VideoView";
+import ChannelView from "./views/ChannelView"
+import ExploreView from "./views/ExploreView"
+import VideoView from "./views/VideoView"
+import ScrollToTop from "./components/ScrollToTop"
 
-let { channels, videos } = data;
+let { channels, videos } = data
 
 export default function App() {
   return (
     <main className="main-section">
       <Provider store={store}>
-        <Router>
-          <ExploreView path="/" channels={channels} videos={videos} />
-          <ChannelView
-            path="/channels/:channelName"
-            channels={channels}
-            videos={videos}
-          />
-          <VideoView path="/videos/:idx" channels={channels} videos={videos} />
+        <Router primary={false}>
+          <ScrollToTop path="/">
+            <ExploreView path="/" channels={channels} videos={videos} />
+            <ChannelView
+              path="/channels/:channelName"
+              channels={channels}
+              videos={videos}
+            />
+            <VideoView path="/videos/:idx" channels={channels} videos={videos} />
+          </ScrollToTop>
         </Router>
       </Provider>
     </main>
-  );
+  )
 }

--- a/packages/app/src/components/ChannelHeader/ChannelHeader.tsx
+++ b/packages/app/src/components/ChannelHeader/ChannelHeader.tsx
@@ -1,18 +1,19 @@
-import React from "react";
+import React from "react"
+import { navigate } from "@reach/router"
 
-import { Banner, ChannelSummary } from "components";
+import { Banner, ChannelSummary } from "components"
 
 type ChannelHeaderProps = {
-  img?: string;
-  name: string;
-  banner?: string;
-  isPublic?: boolean;
-  isVerified?: boolean;
-  description?: string;
-  channelUrl?: string;
-};
+  img?: string
+  name: string
+  banner?: string
+  isPublic?: boolean
+  isVerified?: boolean
+  description?: string
+  channelUrl?: string
+}
 
-export function ChannelHeader({
+function ChannelHeader({
   img,
   isPublic = true,
   isVerified = false,
@@ -31,8 +32,10 @@ export function ChannelHeader({
         size="large"
         img={img}
         description={description}
-        channelUrl={channelUrl}
+        onClick={() => navigate(channelUrl)}
       />
     </>
-  );
+  )
 }
+
+export default ChannelHeader

--- a/packages/app/src/components/ChannelHeader/index.ts
+++ b/packages/app/src/components/ChannelHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ChannelHeader"

--- a/packages/app/src/components/ScrollToTop/index.js
+++ b/packages/app/src/components/ScrollToTop/index.js
@@ -1,0 +1,8 @@
+import { useEffect } from 'react'
+
+const ScrollToTop = ({ children, location }) => {
+  useEffect(() => window.scrollTo(0, 0), [location.pathname])
+  return children
+}
+
+export default ScrollToTop

--- a/packages/app/src/views/ChannelView/ChannelView.tsx
+++ b/packages/app/src/views/ChannelView/ChannelView.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { RouteComponentProps, useParams } from "@reach/router"
+import { RouteComponentProps, useParams, navigate } from "@reach/router"
 import { GenericSection, VideoPreview, Grid } from "components"
 import ChannelHeader from "./../../components/ChannelHeader"
 
@@ -37,8 +37,8 @@ function ChannelComponent({
           minItemWidth="250"
           items={videos.map((video, idx) => (
             <VideoPreview
-              url={`videos/${idx}`}
-              channelUrl={`channels/${video.channel}`}
+              onClick={() => navigate(`/videos/${idx}`)}
+              onChannelClick={() => navigate(`/channels/${video.channel}`)}
               key={`title-${idx}`}
               title={video.title}
               poster={video.poster}

--- a/packages/app/src/views/ChannelView/ChannelView.tsx
+++ b/packages/app/src/views/ChannelView/ChannelView.tsx
@@ -35,6 +35,7 @@ function ChannelComponent({
       <GenericSection title="Videos">
         <Grid
           minItemWidth="250"
+          maxItemWidth="600"
           items={videos.map((video, idx) => (
             <VideoPreview
               onClick={() => navigate(`/videos/${idx}`)}

--- a/packages/app/src/views/ChannelView/ChannelView.tsx
+++ b/packages/app/src/views/ChannelView/ChannelView.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { GenericSection, VideoPreview, Grid } from "components"
-import { ChannelHeader } from "../../components/ChannelHeader"
 import { RouteComponentProps, useParams } from "@reach/router"
+import { GenericSection, VideoPreview, Grid } from "components"
+import ChannelHeader from "./../../components/ChannelHeader"
 
 type ChannelProps = {
   name: string

--- a/packages/app/src/views/ChannelView/ChannelView.tsx
+++ b/packages/app/src/views/ChannelView/ChannelView.tsx
@@ -32,7 +32,7 @@ function ChannelComponent({
         banner={banner}
         img={img}
       />
-      <GenericSection auto title="Videos">
+      <GenericSection title="Videos">
         <Grid
           minItemWidth="250"
           items={videos.map((video, idx) => (

--- a/packages/app/src/views/ExploreView/ExploreView.tsx
+++ b/packages/app/src/views/ExploreView/ExploreView.tsx
@@ -17,7 +17,7 @@ export default function ExploreView({
 
   return (
     <>
-      <GenericSection topDivider title="Latest Videos" link="#" linkText="All Videos">
+      <GenericSection topDivider title="Latest Videos" linkText="All Videos" onLinkClick={() => {}}>
         <Grid
           minItemWidth="250"
           items={allVideos.map((video, idx) => {
@@ -37,7 +37,7 @@ export default function ExploreView({
           })}
         />
       </GenericSection>
-      <GenericSection topDivider title="Latest video channels" link="#" linkText="All Channels">
+      <GenericSection topDivider title="Latest video channels" linkText="All Channels" onLinkClick={() => {}}>
         <div className="channel-gallery">
           {allChannels.map((channel, idx) => (
             <ChannelSummary

--- a/packages/app/src/views/ExploreView/ExploreView.tsx
+++ b/packages/app/src/views/ExploreView/ExploreView.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { RouteComponentProps } from "@reach/router"
+import { RouteComponentProps, navigate } from "@reach/router"
 import { GenericSection, VideoPreview, ChannelSummary, Grid } from "components"
 
 type ExploreViewProps = {
@@ -9,9 +9,9 @@ type ExploreViewProps = {
 
 export default function ExploreView({
   channels,
-  videos,
-  path,
+  videos
 }: ExploreViewProps) {
+
   let allVideos = Object.values(videos).flat()
   let allChannels: any[] = Object.values(channels)
 
@@ -24,14 +24,14 @@ export default function ExploreView({
             let { img: channelImg } = channels[video.channel] || ""
             return (
               <VideoPreview
-                url={`videos/${idx}`}
                 key={`${video.title}-${idx}`}
                 channelImg={channelImg}
-                channelUrl={`channels/${video.channel}`}
                 channel={video.channel}
                 title={video.title}
                 poster={video.poster}
                 showChannel
+                onClick={() => navigate(`videos/${idx}`)}
+                onChannelClick={() => navigate(`channels/${video.channel}`)}
               />
             )
           })}
@@ -42,12 +42,12 @@ export default function ExploreView({
           {allChannels.map((channel, idx) => (
             <ChannelSummary
               key={`${channel.name}-${idx}`}
-              channelUrl={`channels/${channel.name}`}
               img={channel.img}
               size="default"
               name={channel.name}
               isPublic={channel.isPublic}
               isVerified={channel.isVerified}
+              onClick={() => navigate(`channels/${channel.name}`)}
             />
           ))}
         </div>

--- a/packages/app/src/views/VideoView/VideoView.tsx
+++ b/packages/app/src/views/VideoView/VideoView.tsx
@@ -1,22 +1,22 @@
-import React from "react";
+import React from "react"
 
 import {
-  Video,
+  VideoPlayer,
   GenericSection,
   ChannelSummary,
   DetailsTable,
-} from "components";
-import { useParams, RouteComponentProps } from "@reach/router";
+} from "components"
+import { useParams, RouteComponentProps, navigate } from "@reach/router"
 
 type VideoViewProps = {
-  video: any;
-  channel: any;
-};
+  video: any
+  channel: any
+}
 function VideoViewComponent({ video, channel }: VideoViewProps) {
   return (
     <>
       <GenericSection>
-        <Video src={video.src} poster={video.poster} />
+        <VideoPlayer src={video.src} poster={video.poster} />
       </GenericSection>
       <GenericSection
         topDivider
@@ -26,7 +26,6 @@ function VideoViewComponent({ video, channel }: VideoViewProps) {
         <ChannelSummary
           isPublic={channel.isPublic}
           img={channel.img}
-          channelUrl="/"
           name={channel.name}
           isVerified={channel.isVerified}
           description={video.description}
@@ -41,17 +40,17 @@ function VideoViewComponent({ video, channel }: VideoViewProps) {
         <DetailsTable details={video.details} />
       </GenericSection>
     </>
-  );
+  )
 }
 
 type RouteProps = {
-  videos: any;
-  channels: any;
-} & RouteComponentProps;
+  videos: any
+  channels: any
+} & RouteComponentProps
 
 export default function VideoView({ videos, channels }: RouteProps) {
-  let params = useParams();
-  let video = Object.values(videos).flat()[params.idx];
-  let channel = channels[video.channel];
-  return <VideoViewComponent video={video} channel={channel} />;
+  let params = useParams()
+  let video = Object.values(videos).flat()[params.idx]
+  let channel = channels[video.channel]
+  return <VideoViewComponent video={video} channel={channel} />
 }

--- a/packages/app/src/views/VideoView/VideoView.tsx
+++ b/packages/app/src/views/VideoView/VideoView.tsx
@@ -15,13 +15,12 @@ type VideoViewProps = {
 function VideoViewComponent({ video, channel }: VideoViewProps) {
   return (
     <>
-      <GenericSection auto={false}>
+      <GenericSection>
         <Video src={video.src} poster={video.poster} />
       </GenericSection>
       <GenericSection
         topDivider
         title={video.title}
-        auto={false}
         className="video-details"
       >
         <ChannelSummary
@@ -37,7 +36,6 @@ function VideoViewComponent({ video, channel }: VideoViewProps) {
       <GenericSection
         topDivider
         title="Video details"
-        auto={false}
         className="video-details-table"
       >
         <DetailsTable details={video.details} />

--- a/packages/app/src/views/VideoView/VideoView.tsx
+++ b/packages/app/src/views/VideoView/VideoView.tsx
@@ -30,6 +30,7 @@ function VideoViewComponent({ video, channel }: VideoViewProps) {
           isVerified={channel.isVerified}
           description={video.description}
           size="default"
+          onClick={() => navigate(`/channels/${channel.name}`)}
         />
       </GenericSection>
       <GenericSection

--- a/packages/components/src/components/Avatar/Avatar.style.tsx
+++ b/packages/components/src/components/Avatar/Avatar.style.tsx
@@ -1,10 +1,10 @@
-import { css } from "@emotion/core";
-import { spacing, typography, colors } from "../../theme";
+import { css } from "@emotion/core"
+import { spacing, colors } from "../../theme"
 
 export type AvatarStyleProps = {
-  img?: string;
-  size?: "small" | "default" | "large";
-};
+  img?: string
+  size?: "small" | "default" | "large"
+}
 
 export let makeStyles = ({ img, size = "default" }: AvatarStyleProps) => {
   let width =
@@ -13,13 +13,6 @@ export let makeStyles = ({ img, size = "default" }: AvatarStyleProps) => {
       : size === "default"
       ? spacing.s19
       : spacing.s25;
-
-  let margin =
-    size === "small"
-      ? spacing.s2
-      : size === "default"
-      ? spacing.s4
-      : spacing.s6;
   return css`
     background-image: ${img
       ? `url(${img})`
@@ -31,5 +24,5 @@ export let makeStyles = ({ img, size = "default" }: AvatarStyleProps) => {
     min-height: ${width};
     max-width: ${width};
     max-height: ${width};
-  `;
-};
+  `
+}

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.style.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.style.tsx
@@ -1,13 +1,25 @@
-import { css } from "@emotion/core";
-import { spacing, colors, typography } from "../../theme";
+import { css } from "@emotion/core"
+import { spacing, colors, typography } from "../../theme"
 
-export type ChannelSummaryStyleProps = {};
+export type ChannelSummaryStyleProps = {
+  size?: "small" | "default" | "large"
+}
 
-export let makeStyles = ({}: ChannelSummaryStyleProps) => {
+export let makeStyles = ({
+  size = "default"
+}: ChannelSummaryStyleProps) => {
+
+  let gridSize =
+    size === "small"
+      ? spacing.s9
+      : size === "default"
+      ? spacing.s19
+      : spacing.s25;
+
   return {
     container: css`
       display: grid;
-      grid-template: auto / 80px;
+      grid-template: auto / ${gridSize};
       margin: 30px 0;
     `,
     avatar: css`
@@ -41,5 +53,5 @@ export let makeStyles = ({}: ChannelSummaryStyleProps) => {
     tagInfo: css`
       color: ${colors.other.info}
     `
-  };
-};
+  }
+}

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.style.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.style.tsx
@@ -12,6 +12,7 @@ export let makeStyles = ({}: ChannelSummaryStyleProps) => {
     `,
     avatar: css`
       grid-column: 1 / 1;
+      cursor: pointer;
     `,
     details: css`
       grid-column: 2 / 2;
@@ -25,6 +26,7 @@ export let makeStyles = ({}: ChannelSummaryStyleProps) => {
       color: ${colors.text.accent};
       margin: ${spacing.s3} 0;
       display: inline-block;
+      cursor: pointer;
     `,
     badges: css`
       text-transform: uppercase;

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
@@ -27,12 +27,12 @@ export default function ChannelSummary({
 }: ChannelSummaryProps) {
   let styles = makeStyles(styleProps)
   return (
-    <div css={styles.container} onClick={onClick}>
-      <div css={styles.avatar} onClick={onClick}>
+    <div css={styles.container}>
+      <div css={styles.avatar} onClick={event => { event.stopPropagation(); onClick() }}>
         <Avatar size={size} img={img} />
       </div>
       <div css={styles.details}>
-        <h1 css={styles.title} onClick={onClick}>{name}</h1>
+        <h1 css={styles.title} onClick={event => { event.stopPropagation(); onClick() }}>{name}</h1>
         <div css={styles.badges}>
           {isVerified && (
             <Tag icon={faCheck} text="Verified" color={colors.other.success} />

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
@@ -25,7 +25,7 @@ export default function ChannelSummary({
   onClick,
   ...styleProps
 }: ChannelSummaryProps) {
-  let styles = makeStyles(styleProps)
+  let styles = makeStyles({ size, ...styleProps })
   return (
     <div css={styles.container}>
       <div css={styles.avatar} onClick={event => { event.stopPropagation(); onClick() }}>

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
@@ -8,35 +8,31 @@ import { colors } from "./../../theme"
 type ChannelSummaryProps = {
   name: string
   img?: string
-  channelUrl?: string
   description?: string
   size?: "small" | "default" | "large"
   isPublic?: boolean
   isVerified?: boolean
+  onClick?: any
 } & ChannelSummaryStyleProps
 
 export default function ChannelSummary({
   isPublic,
   isVerified,
   description,
-  channelUrl,
   size,
   name,
   img,
+  onClick,
   ...styleProps
 }: ChannelSummaryProps) {
   let styles = makeStyles(styleProps)
   return (
-    <div css={styles.container}>
-      <div css={styles.avatar}>
-        <a href={channelUrl}>
-          <Avatar size={size} img={img} />
-        </a>
+    <div css={styles.container} onClick={onClick}>
+      <div css={styles.avatar} onClick={onClick}>
+        <Avatar size={size} img={img} />
       </div>
       <div css={styles.details}>
-        <a href={channelUrl}>
-          <h1 css={styles.title}>{name}</h1>
-        </a>
+        <h1 css={styles.title} onClick={onClick}>{name}</h1>
         <div css={styles.badges}>
           {isVerified && (
             <Tag icon={faCheck} text="Verified" color={colors.other.success} />

--- a/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
+++ b/packages/components/src/components/ChannelSummary/ChannelSummary.tsx
@@ -22,7 +22,7 @@ export default function ChannelSummary({
   size,
   name,
   img,
-  onClick,
+  onClick = () => {},
   ...styleProps
 }: ChannelSummaryProps) {
   let styles = makeStyles({ size, ...styleProps })

--- a/packages/components/src/components/GenericSection/GenericSection.style.tsx
+++ b/packages/components/src/components/GenericSection/GenericSection.style.tsx
@@ -41,8 +41,9 @@ export let makeStyles = ({
       font-size: ${typography.sizes.normal};
       line-height: 2rem;
       text-transform: uppercase;
-      & > a {
-        text-decoration: none;
+      & > div {
+        display: inline-block;
+        cursor: pointer;
       }
     `
   }

--- a/packages/components/src/components/GenericSection/GenericSection.tsx
+++ b/packages/components/src/components/GenericSection/GenericSection.tsx
@@ -4,17 +4,17 @@ import { makeStyles, SectionStyleProps } from "./GenericSection.style"
 type SectionProps = {
   children?: React.ReactNode
   title?: string
-  link?: string
   linkText?: string
   className?: string
+  onLinkClick?: any
 } & SectionStyleProps
 
 export default function GenericSection({
   children,
   title,
-  link,
   linkText,
   className,
+  onLinkClick,
   ...styleProps
 }: SectionProps) {
   let styles = makeStyles(styleProps)
@@ -22,9 +22,11 @@ export default function GenericSection({
     <section css={styles.section} className={className}>
       <div css={styles.header}>
         <h2 css={styles.title}>{title}</h2>
-        {!!link && !!linkText &&
+        {!!linkText &&
           <div css={styles.link}>
-            <a href={link}>{linkText}</a>
+            <div onClick={onLinkClick}>
+              {linkText}
+            </div>
           </div>
         }
       </div>

--- a/packages/components/src/components/Grid/Grid.style.ts
+++ b/packages/components/src/components/Grid/Grid.style.ts
@@ -2,15 +2,17 @@ import { css } from "@emotion/core"
 
 export type GridStyleProps = {
   minItemWidth?: string | number
+  maxItemWidth?: string | number
 }
 
 export let makeStyles = ({
-  minItemWidth = "200"
+  minItemWidth = "300",
+  maxItemWidth
 }: GridStyleProps) => {
   return {
     container: css`
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(${minItemWidth}px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(${minItemWidth}px, ${maxItemWidth ? maxItemWidth + "px" : "1fr"}));
       gap: 30px;
     `,
     item: css`

--- a/packages/components/src/components/Tag/Tag.style.ts
+++ b/packages/components/src/components/Tag/Tag.style.ts
@@ -20,7 +20,7 @@ export let makeStyles = ({
       vertical-align: middle;
     `,
     icon: css`
-      & > *:nth-child(1) {
+      & > path:nth-of-type(1) {
         color: inherit;
         flex-shrink: 0;
       }

--- a/packages/components/src/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/packages/components/src/components/VideoPlayer/VideoPlayer.style.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/core";
-import { spacing, typography, colors, breakpoints } from "../../theme";
+import { breakpoints } from "../../theme";
 
-export type VideoStyleProps = {
+export type VideoPlayerStyleProps = {
   width?: string | number;
   height?: string | number;
   responsive?: boolean;
@@ -13,7 +13,7 @@ export let makeStyles = ({
   height = "100%",
   responsive = true,
   ratio = "16:9",
-}: VideoStyleProps) => {
+}: VideoPlayerStyleProps) => {
   let ratioPerc = ratio
     .split(":")
     .map(x => Number(x))

--- a/packages/components/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/components/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import ReactPlayer from "react-player";
-import { VideoStyleProps, makeStyles } from "./Video.style";
+import { VideoPlayerStyleProps, makeStyles } from "./VideoPlayer.style";
 
-export type VideoProps = {
+export type VideoPlayerProps = {
   src?: string;
   playing?: boolean;
   poster?: string;
@@ -21,9 +21,9 @@ export type VideoProps = {
   onError?(error: any): void;
   onDuration?(duration: number): void;
   onProgress?(state: { played: number; loaded: number }): void;
-} & VideoStyleProps;
+} & VideoPlayerStyleProps;
 
-export default function Video({
+export default function VideoPlayer({
   src,
   poster,
   playing,
@@ -44,7 +44,7 @@ export default function Video({
   volume = 0.7,
   controls = true,
   ...styleProps
-}: VideoProps) {
+}: VideoPlayerProps) {
   let { playerStyles, containerStyles } = makeStyles(styleProps);
   return (
     <div css={containerStyles}>

--- a/packages/components/src/components/VideoPlayer/index.tsx
+++ b/packages/components/src/components/VideoPlayer/index.tsx
@@ -1,3 +1,1 @@
-import Video from "./Video";
-
-export default Video;
+export { default } from "./VideoPlayer"

--- a/packages/components/src/components/VideoPreview/VideoPreview.styles.tsx
+++ b/packages/components/src/components/VideoPreview/VideoPreview.styles.tsx
@@ -39,12 +39,9 @@ export let makeStyles = ({ showChannel = false }: VideoPreviewStyleProps) => {
       font-size: ${typography.sizes.small};
     `,
     channel: css`
-      text-decoration: none;
-      & > h3 {
-        margin: 5px 0 0;
-        font-size: ${typography.sizes.xsmall};
-        color: ${colors.grey.darker};
-      }
+      margin: 5px 0 0;
+      font-size: ${typography.sizes.xsmall};
+      color: ${colors.grey.darker};
     `
   }
 }

--- a/packages/components/src/components/VideoPreview/VideoPreview.tsx
+++ b/packages/components/src/components/VideoPreview/VideoPreview.tsx
@@ -38,7 +38,7 @@ export default function VideoPreview({
         <div css={styles.textContainer}>
           <h3 css={styles.title} onClick={event => { event.stopPropagation(); onClick() }}>{title}</h3>
           {showChannel && (
-            <h3 onClick={event => { event.stopPropagation(); onChannelClick() }}>{channel}</h3>
+            <h3 css={styles.channel} onClick={event => { event.stopPropagation(); onChannelClick() }}>{channel}</h3>
           )}
         </div>
       </div>

--- a/packages/components/src/components/VideoPreview/VideoPreview.tsx
+++ b/packages/components/src/components/VideoPreview/VideoPreview.tsx
@@ -4,49 +4,41 @@ import { makeStyles, VideoPreviewStyleProps } from "./VideoPreview.styles"
 import Avatar from "./../Avatar"
 
 type VideoPreviewProps = {
-  url: string
   title: string
   channel?: string
-  channelUrl?: string
   channelImg?: string
   showChannel?: boolean
   poster?: string
+  onClick?: any
+  onChannelClick?: any
 } & VideoPreviewStyleProps
 
 export default function VideoPreview({
-  url,
   title,
   channel,
-  channelUrl,
   channelImg,
   showChannel = false,
   poster,
+  onClick,
+  onChannelClick,
   ...styleProps
 }: VideoPreviewProps) {
   let styles = makeStyles({ showChannel, ...styleProps })
   return (
-    <div css={styles.container}>
+    <div css={styles.container} onClick={onClick}>
       <div css={styles.coverContainer}>
-        <a css={styles.link} href={url}>
-          <img css={styles.cover} src={poster} />
-        </a>
+        <img css={styles.cover} src={poster} onClick={event => { event.stopPropagation(); onClick() }} />
       </div>
       <div css={styles.infoContainer}>
         {showChannel && (
-          <a css={styles.link} href={url}>
-            <div css={styles.avatar}>
-              <Avatar size="small" img={channelImg} />
-            </div>
-          </a>
+          <div css={styles.avatar} onClick={event => { event.stopPropagation(); onChannelClick() }}>
+            <Avatar size="small" img={channelImg} />
+          </div>
         )}
         <div css={styles.textContainer}>
-          <a css={styles.link} href={url}>
-            <h3 css={styles.title}>{title}</h3>
-          </a>
+          <h3 css={styles.title} onClick={event => { event.stopPropagation(); onClick() }}>{title}</h3>
           {showChannel && (
-            <a css={styles.channel} href={channelUrl}>
-              <h3>{channel}</h3>
-            </a>
+            <h3 onClick={event => { event.stopPropagation(); onChannelClick() }}>{channel}</h3>
           )}
         </div>
       </div>


### PR DESCRIPTION
Some components were using `<a>` tags for the navigation. These elements, although they redirect the app to the right path, they shouldn't be used on a React component since they will trigger a full page refresh.

The links were replaced by event callbacks and navigation is done programmatically.
There was also a situation on the VideoPreview component where a link inside a link was needed and doing programmatically was the only solution given that rendering a link inside a link is not good practice.

Some styles were also fixed.