### PR TITLE
Fix Progress Bug In VideoPreview

### DIFF
--- a/src/shared/components/VideoPreview/VideoPreview.tsx
+++ b/src/shared/components/VideoPreview/VideoPreview.tsx
@@ -98,7 +98,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const coverNode = (
     <>
       <CoverImage src={posterURL} ref={imgRef} alt={`${title} by ${channelName} thumbnail`} />
-      {duration && <CoverDurationOverlay>{formatDurationShort(duration)}</CoverDurationOverlay>}
+      {!!duration && <CoverDurationOverlay>{formatDurationShort(duration)}</CoverDurationOverlay>}
       {!!progress && (
         <ProgressOverlay>
           <ProgressBar style={{ width: `${progress}%` }} />


### PR DESCRIPTION
Fixes a minor bug where VideoPreview would render `"0"` instead of nothing when `duration` is `0`.