### PR TITLE
Category picker enhancement

### DIFF
--- a/src/shared/components/CategoryPicker/CategoryPicker.style.ts
+++ b/src/shared/components/CategoryPicker/CategoryPicker.style.ts
@@ -4,8 +4,20 @@ import ToggleButton from '../ToggleButton'
 import { sizes, colors } from '@/shared/theme'
 
 export const Container = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  display: -webkit-box;
+  white-space: nowrap;
+  overflow: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  > * {
+    &:first-child {
+      margin-left: var(--global-horizontal-padding);
+    }
+    &:last-child {
+      margin-right: var(--global-horizontal-padding);
+    }
+  }
 `
 
 export const StyledPlaceholder = styled(Placeholder)`

--- a/src/shared/components/CategoryPicker/CategoryPicker.style.ts
+++ b/src/shared/components/CategoryPicker/CategoryPicker.style.ts
@@ -4,7 +4,7 @@ import ToggleButton from '../ToggleButton'
 import { sizes, colors } from '@/shared/theme'
 
 export const Container = styled.div`
-  display: -webkit-box;
+  display: block;
   white-space: nowrap;
   overflow: scroll;
   > * {
@@ -18,6 +18,7 @@ export const Container = styled.div`
 `
 
 export const StyledPlaceholder = styled(Placeholder)`
+  display: inline-block;
   margin: 0 ${sizes(3)} ${sizes(3)} 0;
 `
 

--- a/src/shared/components/CategoryPicker/CategoryPicker.style.ts
+++ b/src/shared/components/CategoryPicker/CategoryPicker.style.ts
@@ -22,5 +22,5 @@ export const StyledPlaceholder = styled(Placeholder)`
 `
 
 export const StyledToggleButton = styled(ToggleButton)`
-  margin: 0 ${sizes(3)} ${sizes(3)} 0;
+  margin-right: ${sizes(3)};
 `

--- a/src/shared/components/CategoryPicker/CategoryPicker.style.ts
+++ b/src/shared/components/CategoryPicker/CategoryPicker.style.ts
@@ -7,9 +7,6 @@ export const Container = styled.div`
   display: -webkit-box;
   white-space: nowrap;
   overflow: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
   > * {
     &:first-child {
       margin-left: var(--global-horizontal-padding);

--- a/src/shared/components/Placeholder/Placeholder.tsx
+++ b/src/shared/components/Placeholder/Placeholder.tsx
@@ -22,6 +22,7 @@ const pulse = keyframes`
 `
 
 const Placeholder = styled.div<PlaceholderProps>`
+  display: 'inline-flex';
   width: ${({ width = '100%' }) => getPropValue(width)};
   height: ${({ height = '100%' }) => getPropValue(height)};
   margin-bottom: ${({ bottomSpace = 0 }) => getPropValue(bottomSpace)};

--- a/src/shared/components/Placeholder/Placeholder.tsx
+++ b/src/shared/components/Placeholder/Placeholder.tsx
@@ -22,7 +22,6 @@ const pulse = keyframes`
 `
 
 const Placeholder = styled.div<PlaceholderProps>`
-  display: 'inline-flex';
   width: ${({ width = '100%' }) => getPropValue(width)};
   height: ${({ height = '100%' }) => getPropValue(height)};
   margin-bottom: ${({ bottomSpace = 0 }) => getPropValue(bottomSpace)};

--- a/src/views/BrowseView/BrowseView.style.ts
+++ b/src/views/BrowseView/BrowseView.style.ts
@@ -22,7 +22,7 @@ export const StyledCategoryPicker = styled(CategoryPicker)<IsAtTop>`
   }
   /*Offset Category Picker by Navbar Height */
   top: ${NAVBAR_HEIGHT}px;
-  padding: ${sizes(5)} 0 ${sizes(2)};
+  padding: ${sizes(5)} 0 ${sizes(5)};
   margin: 0 calc(-1 * var(--global-horizontal-padding));
   background-color: ${colors.black};
   border-bottom: 1px solid ${(props) => (props.isAtTop ? colors.black : colors.gray[800])};

--- a/src/views/BrowseView/BrowseView.style.ts
+++ b/src/views/BrowseView/BrowseView.style.ts
@@ -16,6 +16,10 @@ export const Header = styled(Text)`
 export const StyledCategoryPicker = styled(CategoryPicker)<IsAtTop>`
   z-index: ${zIndex.overlay};
   position: sticky;
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    display: none;
+  }
   /*Offset Category Picker by Navbar Height */
   top: ${NAVBAR_HEIGHT}px;
   padding: ${sizes(5)} 0 ${sizes(2)};

--- a/src/views/BrowseView/BrowseView.style.ts
+++ b/src/views/BrowseView/BrowseView.style.ts
@@ -18,7 +18,7 @@ export const StyledCategoryPicker = styled(CategoryPicker)<IsAtTop>`
   position: sticky;
   /*Offset Category Picker by Navbar Height */
   top: ${NAVBAR_HEIGHT}px;
-  padding: ${sizes(5)} var(--global-horizontal-padding) ${sizes(2)};
+  padding: ${sizes(5)} 0 ${sizes(2)};
   margin: 0 calc(-1 * var(--global-horizontal-padding));
   background-color: ${colors.black};
   border-bottom: 1px solid ${(props) => (props.isAtTop ? colors.black : colors.gray[800])};


### PR DESCRIPTION
The previous category picker was getting **too** much **height** as a sticky container, making it unusable on **smaller** screens!

Screenshot from [_Browse_](https://play.joystream.org/browse) endpoint:

![image](https://user-images.githubusercontent.com/35824204/103267323-8e055b00-49c6-11eb-8240-961c32dbeaf8.png)


I'm suggesting an enhancement to the category picker by making it horizontally **scrollable** shown as below:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/35824204/103268904-acb92100-49c9-11eb-85b1-b68dd08f0373.gif)

