### PR TITLE
fix infinite loop when double click on progress bar

### DIFF
--- a/src/views/VideoView/VideoView.tsx
+++ b/src/views/VideoView/VideoView.tsx
@@ -102,13 +102,6 @@ const VideoView: React.FC = () => {
     }
   }, [video?.id, handleTimeUpdate, updateWatchedVideos])
 
-  const handlePlay = useCallback(() => {
-    setPlaying(true)
-  }, [])
-  const handlePause = useCallback(() => {
-    setPlaying(false)
-  }, [])
-
   if (error) {
     throw error
   }
@@ -129,8 +122,6 @@ const VideoView: React.FC = () => {
               posterUrl={video.thumbnailUrl}
               onEnd={handleVideoEnd}
               onTimeUpdated={handleTimeUpdate}
-              onPlay={handlePlay}
-              onPause={handlePause}
               startTime={startTimestamp}
             />
           ) : (


### PR DESCRIPTION
closes #314
These two properties doing nothing except for this bug as I figured out.
how to reproduce: double click on the progress bar
![Peek 2021-03-06 23-30](https://user-images.githubusercontent.com/6043510/110220242-3a872000-7ed5-11eb-8b56-1b150df94ede.gif)
