### PR TITLE
fix typechecking

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-scripts": "4.0.1",
     "react-transition-group": "^4.4.1",
     "ts-loader": "^6.2.1",
-    "typescript": "^3.8.3",
+    "typescript": "^4.2.3",
     "use-resize-observer": "^7.0.0",
     "video.js": "^7.8.3",
     "webpack-merge": "^5.7.3"

--- a/src/api/hooks/coverVideo.ts
+++ b/src/api/hooks/coverVideo.ts
@@ -1,8 +1,7 @@
 import { CoverVideo, AllChannelFieldsFragment } from '@/api/queries'
 import { MockVideo } from '@/mocking/data/mockVideos'
 
-import { mockCoverVideo, mockCoverVideoInfo, mockCoverVideoMedia } from '@/mocking/data/mockCoverVideo'
-import { coverMockChannel } from '@/mocking/data/mockChannels'
+import { mockCoverVideo } from '@/mocking/data/mockCoverVideo'
 
 type UseCoverVideo = () => {
   data: {
@@ -15,22 +14,7 @@ type UseCoverVideo = () => {
 
 const useCoverVideo: UseCoverVideo = () => {
   return {
-    data: {
-      __typename: 'CoverVideo',
-      coverDescription: mockCoverVideoInfo.coverDescription,
-      coverCutMediaMetadata: mockCoverVideoInfo.coverCutMediaMetadata,
-      video: {
-        ...mockCoverVideo,
-        createdAt: new Date(),
-        category: {
-          __typename: 'VideoCategory',
-          id: 'random_category',
-        },
-        duration: mockCoverVideoMedia.duration,
-        mediaMetadata: mockCoverVideoMedia,
-        channel: coverMockChannel,
-      },
-    },
+    data: mockCoverVideo,
   }
 }
 

--- a/src/api/queries/__generated__/channels.generated.tsx
+++ b/src/api/queries/__generated__/channels.generated.tsx
@@ -16,10 +16,13 @@ export type BasicChannelFieldsFragment = {
 
 export type AllChannelFieldsFragment = {
   __typename?: 'Channel'
-  coverPhotoUrl?: Types.Maybe<string>
-  coverPhotoAvailability: Types.AssetAvailability
+  description?: Types.Maybe<string>
   follows?: Types.Maybe<number>
   isPublic?: Types.Maybe<boolean>
+  isCensored: boolean
+  coverPhotoUrl?: Types.Maybe<string>
+  coverPhotoAvailability: Types.AssetAvailability
+  language?: Types.Maybe<{ __typename?: 'Language'; name: string }>
   coverPhotoDataObject?: Types.Maybe<{ __typename?: 'DataObject' } & DataObjectFieldsFragment>
 } & BasicChannelFieldsFragment
 
@@ -38,15 +41,7 @@ export type GetChannelQueryVariables = Types.Exact<{
 
 export type GetChannelQuery = {
   __typename?: 'Query'
-  channel?: Types.Maybe<
-    {
-      __typename?: 'Channel'
-      description?: Types.Maybe<string>
-      isPublic?: Types.Maybe<boolean>
-      isCensored: boolean
-      language?: Types.Maybe<{ __typename?: 'Language'; name: string }>
-    } & AllChannelFieldsFragment
-  >
+  channel?: Types.Maybe<{ __typename?: 'Channel' } & AllChannelFieldsFragment>
 }
 
 export type GetVideoCountQueryVariables = Types.Exact<{
@@ -129,13 +124,18 @@ export const BasicChannelFieldsFragmentDoc = gql`
 export const AllChannelFieldsFragmentDoc = gql`
   fragment AllChannelFields on Channel {
     ...BasicChannelFields
+    description
+    follows
+    isPublic
+    isCensored
+    language {
+      name
+    }
     coverPhotoUrl
     coverPhotoAvailability
     coverPhotoDataObject {
       ...DataObjectFields
     }
-    follows
-    isPublic
   }
   ${BasicChannelFieldsFragmentDoc}
   ${DataObjectFieldsFragmentDoc}
@@ -182,12 +182,6 @@ export const GetChannelDocument = gql`
   query GetChannel($where: ChannelWhereUniqueInput!) {
     channel(where: $where) {
       ...AllChannelFields
-      description
-      isPublic
-      isCensored
-      language {
-        name
-      }
     }
   }
   ${AllChannelFieldsFragmentDoc}

--- a/src/api/queries/channels.graphql
+++ b/src/api/queries/channels.graphql
@@ -2,6 +2,7 @@ fragment BasicChannelFields on Channel {
   id
   title
   createdAt
+
   avatarPhotoUrl
   avatarPhotoAvailability
   avatarPhotoDataObject {
@@ -11,13 +12,19 @@ fragment BasicChannelFields on Channel {
 
 fragment AllChannelFields on Channel {
   ...BasicChannelFields
+  description
+  follows
+  isPublic
+  isCensored
+  language {
+    name
+  }
+
   coverPhotoUrl
   coverPhotoAvailability
   coverPhotoDataObject {
     ...DataObjectFields
   }
-  follows
-  isPublic
 }
 
 query GetBasicChannel($where: ChannelWhereUniqueInput!) {
@@ -29,12 +36,6 @@ query GetBasicChannel($where: ChannelWhereUniqueInput!) {
 query GetChannel($where: ChannelWhereUniqueInput!) {
   channel(where: $where) {
     ...AllChannelFields
-    description
-    isPublic
-    isCensored
-    language {
-      name
-    }
   }
 }
 

--- a/src/components/Dialogs/MessageDialog/MessageDialog.tsx
+++ b/src/components/Dialogs/MessageDialog/MessageDialog.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
-import ActionDialog from '../ActionDialog/ActionDialog'
-import { TransactionDialogProps } from '../TransactionDialog/TransactionDialog'
+import ActionDialog, { ActionDialogProps } from '../ActionDialog/ActionDialog'
 import { StyledIcon, StyledTitleText, StyledDescriptionText } from './MessageDialog.style'
 import { IconType } from '@/shared/components/Icon'
 
 export type MessageDialogProps = {
   variant?: 'success' | 'warning' | 'error' | 'info'
-} & TransactionDialogProps
+  title?: string
+  description?: string
+} & ActionDialogProps
 
 const MessageDialog: React.FC<MessageDialogProps> = ({
   title,

--- a/src/components/Dialogs/TransactionDialog/TransactionDialog.tsx
+++ b/src/components/Dialogs/TransactionDialog/TransactionDialog.tsx
@@ -3,7 +3,9 @@ import ActionDialog, { ActionDialogProps } from '../ActionDialog/ActionDialog'
 import { TextContainer, StyledTransactionIllustration, Spinner } from './TransactionDialog.style'
 import { StyledTitleText, StyledDescriptionText } from '../MessageDialog/MessageDialog.style'
 
-const TransactionDialog: React.FC<ActionDialogProps> = ({ ...actionDialogProps }) => {
+export type TransactionDialogProps = ActionDialogProps
+
+const TransactionDialog: React.FC<TransactionDialogProps> = ({ ...actionDialogProps }) => {
   return (
     <ActionDialog {...actionDialogProps} secondaryButtonText="Cancel" exitButton={false}>
       <StyledTransactionIllustration />

--- a/src/components/Topbar/StudioTopbar/StudioTopbar.tsx
+++ b/src/components/Topbar/StudioTopbar/StudioTopbar.tsx
@@ -167,7 +167,7 @@ const ChannelInfo = React.forwardRef<HTMLDivElement, ChannelInfoProps>(
       <ChannelInfoContainer onClick={onClick} isActive={active} ref={ref}>
         <StyledAvatar size="medium" imageUrl={channel?.avatarPhotoUrl} />
         <TextContainer>
-          <Text>{channel ? channel.handle : 'New Channel'}</Text>
+          <Text>{channel ? channel.title : 'New Channel'}</Text>
           <Text>{memberName}</Text>
         </TextContainer>
         {active && <Icon name="check" />}
@@ -193,7 +193,7 @@ const NavDrawer = React.forwardRef<HTMLDivElement, NavDrawerProps>(
                 key={channel.id}
                 channel={channel}
                 memberName={memberName}
-                active={channel.handle === currentChannel?.handle}
+                active={channel.title === currentChannel?.title}
                 onClick={() => onCurrentChannelChange(channel.id)}
               />
             ))}

--- a/src/joystream-lib/api.ts
+++ b/src/joystream-lib/api.ts
@@ -277,6 +277,6 @@ export class JoystreamJs {
 
     const contentEvents = events.filter((event) => event.section === 'content')
     const channelId = contentEvents[0].data[1]
-    return new BN(channelId as never).toNumber().toString()
+    return new BN(channelId as never).toString()
   }
 }

--- a/src/joystream-lib/api.ts
+++ b/src/joystream-lib/api.ts
@@ -277,6 +277,6 @@ export class JoystreamJs {
 
     const contentEvents = events.filter((event) => event.section === 'content')
     const channelId = contentEvents[0].data[1]
-    return new BN(channelId as never).toNumber()
+    return new BN(channelId as never).toNumber().toString()
   }
 }

--- a/src/joystream-lib/types.ts
+++ b/src/joystream-lib/types.ts
@@ -5,8 +5,8 @@ export type Account = {
   id: AccountId
   name: string
 }
-export type MemberId = number
-export type ChannelId = number
+export type MemberId = string
+export type ChannelId = string
 
 export type AssetMetadata = {
   size: number

--- a/src/mocking/accessors/pagination.ts
+++ b/src/mocking/accessors/pagination.ts
@@ -19,8 +19,8 @@ export type CursorPaginatedDataArgs = {
 }
 
 type OffsetLimitPaginatedDataArgs = {
-  offset?: number
-  limit?: number
+  offset?: number | null
+  limit?: number | null
 }
 
 const indexToCursor = (idx: number): string => btoa(idx.toString())
@@ -59,7 +59,9 @@ export const createOffsetLimitPaginationAccessor = <TData extends GenericData>(d
 ): TData[] => {
   const filteredData = filterAndSortGenericData<TData>(data, variables)
 
-  const { limit = 50, offset = 0 } = variables
+  const { limit: rawLimit, offset: rawOffset } = variables
+  const limit = rawLimit ?? 50
+  const offset = rawOffset ?? 0
 
   return filteredData.slice(offset, offset + limit)
 }

--- a/src/mocking/data/mockChannels.ts
+++ b/src/mocking/data/mockChannels.ts
@@ -26,6 +26,8 @@ export const coverMockChannel: MockChannel = {
   avatarPhotoUrl: rawCoverVideo.channel.avatarPhotoUrl,
   avatarPhotoAvailability: AssetAvailability.Accepted,
   coverPhotoAvailability: AssetAvailability.Invalid,
+  isPublic: true,
+  isCensored: false,
 }
 
 const mockChannels: MockChannel[] = [...regularMockChannels, coverMockChannel]

--- a/src/mocking/data/mockCoverVideo.ts
+++ b/src/mocking/data/mockCoverVideo.ts
@@ -1,41 +1,43 @@
 import rawCoverVideo from './raw/coverVideo.json'
 import mockCategories from './mockCategories'
-import { MockVideo } from '@/mocking/data/mockVideos'
 import { coverMockChannel } from '@/mocking/data/mockChannels'
 import { MockLicense } from '@/mocking/data/mockLicenses'
 import { AssetAvailability, CoverVideo } from '@/api/queries'
-import { MockVideoMedia } from './mockVideosMedia'
 
 export const mockCoverVideoLicense: MockLicense = {
   __typename: 'License',
   ...rawCoverVideo.license,
 }
-export const mockCoverVideoMedia: Omit<MockVideoMedia, 'location'> = {
-  ...rawCoverVideo.videoMedia,
+
+type MockCoverVideo = CoverVideo & {
+  __typename: 'CoverVideo'
 }
 
-export const mockCoverVideo: MockVideo = {
-  ...rawCoverVideo.video,
-  __typename: 'Video',
-  createdAt: new Date(rawCoverVideo.video.createdAt),
-  channel: coverMockChannel,
-  license: mockCoverVideoLicense,
-  mediaMetadata: mockCoverVideoMedia,
-  mediaAvailability: AssetAvailability.Accepted,
-  mediaUrl: rawCoverVideo.cover.coverCutMediaMetadata.location.url,
-  thumbnailUrl: rawCoverVideo.video.thumbnailUrl,
-  thumbnailAvailability: AssetAvailability.Accepted,
-  duration: rawCoverVideo.videoMedia.duration,
-  category: mockCategories[mockCategories.length - 1],
-}
-
-export type CoverInfo = Omit<CoverVideo, 'video' | '__typename' | 'id'>
-
-export const mockCoverVideoInfo: CoverInfo = {
-  ...rawCoverVideo.cover,
+export const mockCoverVideo: MockCoverVideo = {
+  __typename: 'CoverVideo',
+  id: 'fake-cover-video-id',
+  video: {
+    ...rawCoverVideo.video,
+    createdAt: new Date(rawCoverVideo.video.createdAt),
+    channel: {
+      ...coverMockChannel,
+      videos: [],
+    },
+    license: mockCoverVideoLicense,
+    mediaMetadata: rawCoverVideo.videoMediaMetadata,
+    mediaAvailability: AssetAvailability.Accepted,
+    mediaUrl: rawCoverVideo.cover.coverCutMediaMetadata.location.url,
+    thumbnailUrl: rawCoverVideo.video.thumbnailUrl,
+    thumbnailAvailability: AssetAvailability.Accepted,
+    duration: rawCoverVideo.videoMediaMetadata.duration,
+    category: mockCategories[mockCategories.length - 1],
+    isCensored: false,
+    isFeatured: false,
+  },
   coverCutMediaMetadata: {
     __typename: 'VideoMediaMetadata',
     ...rawCoverVideo.cover.coverCutMediaMetadata,
   },
   coverCutMediaAvailability: AssetAvailability.Accepted,
+  coverDescription: rawCoverVideo.cover.coverDescription,
 }

--- a/src/mocking/data/mockVideos.ts
+++ b/src/mocking/data/mockVideos.ts
@@ -38,8 +38,8 @@ const coverMockVideo: MockVideo = {
   mediaUrl: rawCoverVideo.video.mediaUrl,
   thumbnailUrl: rawCoverVideo.video.thumbnailUrl,
   thumbnailAvailability: AssetAvailability.Accepted,
-  mediaMetadata: rawCoverVideo.videoMedia,
-  duration: rawCoverVideo.videoMedia.duration,
+  mediaMetadata: rawCoverVideo.videoMediaMetadata,
+  duration: rawCoverVideo.videoMediaMetadata.duration,
   category: mockCategories[0],
   isPublic: true,
 }

--- a/src/mocking/data/mockVideosMedia.ts
+++ b/src/mocking/data/mockVideosMedia.ts
@@ -1,7 +1,7 @@
 import rawVideosMedia from './raw/videosMedia.json'
-import { VideoMediaFieldsFragment } from '@/api/queries'
 
-export type MockVideoMedia = VideoMediaFieldsFragment & {
+export type MockVideoMedia = {
+  id: string
   duration: number
   location: {
     url: string

--- a/src/mocking/data/raw/coverVideo.json
+++ b/src/mocking/data/raw/coverVideo.json
@@ -8,7 +8,7 @@
     "thumbnailUrl": "https://eu-central-1.linodeobjects.com/atlas-assets/cover-video/thumbnail.jpg",
     "mediaUrl": "https://eu-central-1.linodeobjects.com/atlas-assets/cover-video/video.webm"
   },
-  "videoMedia": {
+  "videoMediaMetadata": {
     "id": "4551c421-8edd-4d3b-8357-9fe825742775",
     "codec": "H264_mpeg4",
     "pixelWidth": 2560,

--- a/src/shared/components/CategoryPicker/CategoryPicker.tsx
+++ b/src/shared/components/CategoryPicker/CategoryPicker.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Container, StyledToggleButton, StyledPlaceholder } from './CategoryPicker.style'
-import { CategoryFieldsFragment } from '@/api/queries'
+import { VideoCategoryFieldsFragment } from '@/api/queries'
 
 type CategoryPickerProps = {
-  categories?: CategoryFieldsFragment[]
+  categories?: VideoCategoryFieldsFragment[]
   selectedCategoryId: string | null
   loading?: boolean
   onChange: (categoryId: string | null) => void

--- a/src/views/playground/Playgrounds/PlaygroundMemberChannel.tsx
+++ b/src/views/playground/Playgrounds/PlaygroundMemberChannel.tsx
@@ -78,7 +78,7 @@ const PlaygroundMemberChannel = () => {
                 value={channel.id}
                 selectedValue={selectedChannel?.id}
                 onClick={handleActiveChannelChange}
-                label={channel.handle}
+                label={channel.title || 'Unknown'}
               />
             ))}
       </div>

--- a/src/views/playground/Playgrounds/PlaygroundUploadingFilesData.tsx
+++ b/src/views/playground/Playgrounds/PlaygroundUploadingFilesData.tsx
@@ -23,7 +23,7 @@ export const PlaygroundUploadingFilesData = () => {
       hash: `${blob.size}${blob.type}`,
       storageProvider: 'storage',
       type: 'avatar',
-      cropData,
+      imageCropData: cropData,
       size: blob.size,
       parentObject: {
         type: 'channel',
@@ -62,22 +62,22 @@ export const PlaygroundUploadingFilesData = () => {
             }
           }
         }}
-      ></input>
+      />
       <Text>{error?.message}</Text>
       <h2>Uploading files data:</h2>
       {uploadingFilesData.length > 0 ? (
-        uploadingFilesData.map(({ id, hash, storageProvider, type, status, cropData }) => (
+        uploadingFilesData.map(({ id, hash, storageProvider, type, status, imageCropData }) => (
           <StyledDataContainer key={id}>
             <StyledButton aria-label="close dialog" onClick={() => removeUploadingFileData(id)} icon="close" />
             <p>ID: {id}</p>
             <p>Hash: {hash}</p>
             <p>Storage Provider: {storageProvider}</p>
             <p>Type: {type}</p>
-            {cropData && (
+            {imageCropData && (
               <>
                 <p>Crop data:</p>
-                <p>left:{cropData.left}</p>
-                <p>top:{cropData.top}</p> <p>width:{cropData.width}</p> <p>height:{cropData.height}</p>
+                <p>left:{imageCropData.left}</p>
+                <p>top:{imageCropData.top}</p> <p>width:{imageCropData.width}</p> <p>height:{imageCropData.height}</p>
               </>
             )}
             <p>status: {status}</p>

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -87,7 +87,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
       ...getValues(),
       avatar: { blob: null, url: avatarPhotoUrl },
       cover: { blob: null, url: coverPhotoUrl },
-      channelName: title,
+      channelName: title || '',
       description: description || '',
       isPublic,
       selectedLanguage: foundLanguage || languages[0],

--- a/yarn.lock
+++ b/yarn.lock
@@ -18642,10 +18642,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 ua-parser-js@^0.7.18:
   version "0.7.22"


### PR DESCRIPTION
Fixes #409 

Turns our `tsc` was failing because of version mismatch - we were using `@3` and some libraries required `>4`. I have no idea why it failed silently though as if everything was all right instead of reporting some error. Really weird