### PR TITLE
Improve media queries restrictions and enhance usage developer comfort

### DIFF
--- a/src/components/BackgroundPattern.tsx
+++ b/src/components/BackgroundPattern.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from '@emotion/styled'
 
 import { ReactComponent as BackgroundPatternSVG } from '@/assets/bg-pattern.svg'
-import { breakpoints, zIndex, transitions } from '@/shared/theme'
+import { zIndex, transitions, media } from '@/shared/theme'
 
 const PATTERN_OFFSET = {
   SMALL: '-150px',
@@ -26,12 +26,13 @@ const StyledBackgroundPattern = styled(BackgroundPatternSVG)`
   position: absolute;
   transform: scale(1.3);
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     display: block;
     top: 73px;
     right: ${PATTERN_OFFSET.SMALL};
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     right: ${PATTERN_OFFSET.MEDIUM};
   }
 `

--- a/src/components/CoverVideo/CoverVideo.style.ts
+++ b/src/components/CoverVideo/CoverVideo.style.ts
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled'
 import { darken, fluidRange } from 'polished'
-
 import { Button, IconButton, Placeholder, Text } from '@/shared/components'
-import { breakpoints, colors, sizes } from '@/shared/theme'
+import { breakpoints, colors, sizes, media } from '@/shared/theme'
 import { css, keyframes } from '@emotion/react'
 import ChannelLink from '../ChannelLink'
 
@@ -23,19 +22,23 @@ export const Container = styled.section`
 
   // because of the fixed aspect ratio, as the viewport width grows, the media will occupy more height as well
   // so that the media doesn't take too big of a portion of the space, we let the content overlap the media via a negative margin
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.SMALL}px;
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.MEDIUM}px;
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.LARGE}px;
   }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.XLARGE}px;
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.XXLARGE}px;
   }
 `
@@ -84,7 +87,7 @@ export const HorizontalGradientOverlay = styled.div`
   display: none;
   background: linear-gradient(90deg, rgba(0, 0, 0, 0.8) 11.76%, rgba(0, 0, 0, 0) 100%);
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     display: block;
   }
 `
@@ -95,7 +98,8 @@ export const VerticalGradientOverlay = styled.div`
   // as the content overlaps the media more and more as the viewport width grows, we need to hide some part of the media with a gradient
   // this helps with keeping a consistent background behind a page content - we don't want the media to peek out in the content spacing
   background: linear-gradient(0deg, black 0%, rgba(0, 0, 0, 0) ${GRADIENT_HEIGHT / 2}px);
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     background: linear-gradient(
       0deg,
       black 0%,
@@ -103,7 +107,8 @@ export const VerticalGradientOverlay = styled.div`
       rgba(0, 0, 0, 0) ${CONTENT_OVERLAP_MAP.SMALL - GRADIENT_OVERLAP + GRADIENT_HEIGHT}px
     );
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     background: linear-gradient(
       0deg,
       black 0%,
@@ -111,7 +116,8 @@ export const VerticalGradientOverlay = styled.div`
       rgba(0, 0, 0, 0) ${CONTENT_OVERLAP_MAP.MEDIUM - GRADIENT_OVERLAP + GRADIENT_HEIGHT}px
     );
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     background: linear-gradient(
       0deg,
       black 0%,
@@ -119,7 +125,8 @@ export const VerticalGradientOverlay = styled.div`
       rgba(0, 0, 0, 0) ${CONTENT_OVERLAP_MAP.LARGE - GRADIENT_OVERLAP + GRADIENT_HEIGHT}px
     );
   }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     background: linear-gradient(
       0deg,
       black 0%,
@@ -127,7 +134,8 @@ export const VerticalGradientOverlay = styled.div`
       rgba(0, 0, 0, 0) ${CONTENT_OVERLAP_MAP.XLARGE - GRADIENT_OVERLAP + GRADIENT_HEIGHT}px
     );
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     background: linear-gradient(
       0deg,
       black 0%,
@@ -142,26 +150,26 @@ export const InfoContainer = styled.div<{ isLoading: boolean }>`
   margin-top: -${sizes(8)};
   padding-bottom: ${sizes(12)};
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     position: absolute;
     margin: 0;
     padding-bottom: 0;
     bottom: ${CONTENT_OVERLAP_MAP.SMALL + INFO_BOTTOM_MARGIN / 4}px;
   }
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     bottom: ${CONTENT_OVERLAP_MAP.MEDIUM + INFO_BOTTOM_MARGIN / 2}px;
   }
 
-  @media screen and (min-width: ${breakpoints.large}) {
+  ${media.large} {
     bottom: ${CONTENT_OVERLAP_MAP.LARGE + INFO_BOTTOM_MARGIN}px;
   }
 
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+  ${media.xlarge} {
     bottom: ${CONTENT_OVERLAP_MAP.XLARGE + INFO_BOTTOM_MARGIN}px;
   }
 
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+  ${media.xxlarge} {
     bottom: ${CONTENT_OVERLAP_MAP.XXLARGE + INFO_BOTTOM_MARGIN}px;
   }
 `
@@ -175,7 +183,8 @@ export const TitleContainer = styled.div`
     text-decoration: none;
   }
   margin-bottom: ${sizes(8)};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-bottom: ${sizes(10)};
   }
 
@@ -194,14 +203,16 @@ export const Title = styled(Text)`
 
   display: inline-block;
   margin-bottom: ${sizes(4)};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-bottom: ${sizes(5)};
   }
 `
 
 export const TitlePlaceholder = styled(Placeholder)`
   margin-bottom: ${sizes(4)};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-bottom: ${sizes(5)};
   }
 `

--- a/src/components/Dialogs/ActionDialog/ActionDialog.style.ts
+++ b/src/components/Dialogs/ActionDialog/ActionDialog.style.ts
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled'
 import { css } from '@emotion/react'
-import { breakpoints, sizes, colors, typography } from '@/shared/theme'
+import { media, sizes, colors, typography } from '@/shared/theme'
 import { Button } from '@/shared/components'
-
-const BREAKPOINT = breakpoints.small
 
 type ButtonProps = {
   error?: boolean
@@ -18,7 +16,7 @@ export const ButtonsContainer = styled.div`
     margin-top: ${sizes(2)};
   }
 
-  @media screen and (min-width: ${BREAKPOINT}) {
+  ${media.small} {
     flex-direction: row-reverse;
     margin-left: auto;
 
@@ -39,7 +37,7 @@ export const ActionsContainer = styled.div`
 
   padding-top: ${sizes(6)};
 
-  @media screen and (min-width: ${BREAKPOINT}) {
+  ${media.small} {
     flex-direction: row;
     align-items: center;
   }
@@ -49,7 +47,7 @@ export const AdditionalActionsContainer = styled.div`
   width: 100%;
   margin-bottom: ${sizes(6)};
 
-  @media screen and (min-width: ${BREAKPOINT}) {
+  ${media.small} {
     margin-bottom: 0;
     margin-right: ${sizes(6)};
   }

--- a/src/components/Dialogs/BaseDialog/BaseDialog.style.ts
+++ b/src/components/Dialogs/BaseDialog/BaseDialog.style.ts
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled'
 import { IconButton } from '@/shared/components'
-import { colors, sizes, breakpoints } from '@/shared/theme'
+import { colors, sizes, media } from '@/shared/theme'
 
 export const StyledContainer = styled.div`
   --dialog-padding: ${sizes(4)};
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     --dialog-padding: ${sizes(6)};
   }
+
   position: relative;
   width: 90%;
   max-width: 440px;
@@ -18,7 +19,7 @@ export const StyledContainer = styled.div`
   padding: var(--dialog-padding);
   box-shadow: 0 8px 8px rgba(0, 0, 0, 0.12), 0 24px 40px rgba(0, 0, 0, 0.16);
 
-  @media screen and (min-height: 800px) {
+  ${media.medium} {
     margin: ${sizes(32)} auto;
   }
 `

--- a/src/components/Dialogs/Multistepper/Multistepper.style.ts
+++ b/src/components/Dialogs/Multistepper/Multistepper.style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import BaseDialog from '../BaseDialog'
 import { Text } from '@/shared/components'
-import { colors, sizes, breakpoints, typography } from '@/shared/theme'
+import { colors, sizes, media, typography } from '@/shared/theme'
 
 type CircleProps = {
   isFilled?: boolean
@@ -26,7 +26,8 @@ export const StyledHeader = styled.div`
   padding-bottom: var(--dialog-padding);
   hr {
     display: none;
-    @media screen and (min-width: ${breakpoints.small}) {
+
+    ${media.small} {
       display: inline;
       width: 16px;
       height: 1px;
@@ -40,7 +41,8 @@ export const StyledHeader = styled.div`
 
 export const StyledStepsInfoContainer = styled.div`
   display: grid;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     grid-template-columns: 1fr 1fr 1fr;
     grid-row-gap: ${sizes(4)};
   }
@@ -49,7 +51,8 @@ export const StyledStepInfo = styled.div<StyledStepInfoProps>`
   display: ${({ isActive }) => (isActive ? 'flex' : 'none')};
   align-items: center;
   margin-right: ${sizes(2)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
   }
 `
@@ -72,7 +75,8 @@ export const StyledStepInfoText = styled(Text)<StyledStepInfoProps>`
   font-weight: ${typography.weights.semibold};
   line-height: 16px;
   margin-left: ${sizes(2)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     max-width: 120px;
     font-size: ${sizes(3)};
   }

--- a/src/components/Dialogs/TransactionDialog/TransactionDialog.style.ts
+++ b/src/components/Dialogs/TransactionDialog/TransactionDialog.style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { sizes, breakpoints } from '@/shared/theme'
+import { sizes, media } from '@/shared/theme'
 import { ReactComponent as TransactionIllustration } from '@/assets/transaction-illustration.svg'
 import Spinner from '@/shared/components/Spinner'
 
@@ -12,7 +12,8 @@ export const StyledTransactionIllustration = styled(TransactionIllustration)`
   position: absolute;
   top: 0;
   left: -50px;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     left: 0;
   }
 `

--- a/src/components/Sidenav/SidenavBase.style.ts
+++ b/src/components/Sidenav/SidenavBase.style.ts
@@ -1,6 +1,6 @@
 import { ReactComponent as UnstyledFullLogo } from '@/assets/full-logo.svg'
 import { Text } from '@/shared/components'
-import { breakpoints, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
+import { colors, sizes, transitions, typography, zIndex, media } from '@/shared/theme'
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { Link, LinkProps } from 'react-router-dom'
@@ -48,7 +48,8 @@ export const LogoLink = styled(Link)`
   margin-top: 24px;
   margin-left: 80px;
   text-decoration: none;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-left: 86px;
   }
 `
@@ -92,7 +93,8 @@ export const SidebarNavItem = styled.li<ExpandableElementProps>`
   &[data-badge]:after {
     left: ${sizes(10)};
     top: ${sizes(3)};
-    @media screen and (min-width: ${breakpoints.medium}) {
+
+    ${media.medium} {
       transform: translateY(${({ expanded }) => (expanded ? 0 : -8)}px);
       transition: transform ${transitions.timings.regular} ${transitions.easing};
     }
@@ -116,7 +118,7 @@ export const SidebarNavLink = styled(Link, { shouldForwardProp: isPropValid })<S
     background-color: ${({ isStudio }) => (isStudio ? colors.transparentWhite[32] : colors.transparentBlack[54])};
   }
   > svg {
-    @media screen and (min-width: ${breakpoints.medium}) {
+    ${media.medium} {
       transform: translateY(${({ expanded }) => (expanded ? 0 : -8)}px);
       transition: transform ${transitions.timings.regular} ${transitions.easing};
     }
@@ -132,7 +134,7 @@ export const SidebarNavLink = styled(Link, { shouldForwardProp: isPropValid })<S
     background-color: ${({ isStudio }) => (isStudio ? colors.transparentWhite[6] : colors.transparentBlack[24])};
   }
   :after {
-    @media screen and (min-width: ${breakpoints.medium}) {
+    ${media.medium} {
       content: ${({ content }) => `'${content}'`};
       position: absolute;
       font-size: 12px;

--- a/src/components/Topbar/StudioTopbar/StudioTopbar.style.tsx
+++ b/src/components/Topbar/StudioTopbar/StudioTopbar.style.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Link } from 'react-router-dom'
-import { breakpoints, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
+import { media, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
 import { Avatar, Text, Placeholder } from '@/shared/components'
 import TopbarBase from '../TopbarBase'
 import { TOP_NAVBAR_HEIGHT } from '../TopbarBase.style'
@@ -11,7 +11,7 @@ type CommonStudioTopbarProps = {
 }
 
 export const StyledTopbarBase = styled(TopbarBase)`
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     display: flex;
     justify-content: space-between;
   }
@@ -61,7 +61,8 @@ export const StudioTopbarContainer = styled.div`
     }
     ${TextContainer} {
       display: none;
-      @media screen and (min-width: ${breakpoints.medium}) {
+
+      ${media.medium} {
         display: flex;
       }
     }
@@ -138,7 +139,8 @@ export const DrawerContainer = styled.div<CommonStudioTopbarProps>`
   background-color: ${colors.gray[800]};
   transition: transform ${transitions.timings.regular} ${transitions.easing};
   z-index: ${zIndex.nearOverlay};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     width: 328px;
   }
   ${ChannelInfoContainer} {
@@ -149,7 +151,7 @@ export const DrawerContainer = styled.div<CommonStudioTopbarProps>`
     margin-left: 0;
   }
   ${TextContainer} {
-    @media screen and (min-width: ${breakpoints.medium}) {
+    ${media.medium} {
       width: 200px;
     }
   }

--- a/src/components/Topbar/TopbarBase.style.tsx
+++ b/src/components/Topbar/TopbarBase.style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { Text } from '@/shared/components'
 import { StyledSearchbar } from '@/components/Topbar/ViewerTopbar/ViewerTopbar.style'
-import { breakpoints, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
+import { colors, sizes, transitions, typography, zIndex, media } from '@/shared/theme'
 import { ReactComponent as UnstyledShortLogo } from '@/assets/logo.svg'
 import { ReactComponent as UnstyledFullLogoDefault } from '@/assets/full-logo.svg'
 import { Link } from 'react-router-dom'
@@ -36,7 +36,7 @@ export const Header = styled.header<TopNavbarStyleProps>`
 
   padding: ${sizes(3)} calc(var(--scrollbar-gap-width) + ${sizes(3)}) ${sizes(3)} ${sizes(3)};
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     z-index: ${zIndex.header};
     display: grid;
     grid-template-columns: 1fr 2fr 1fr;
@@ -55,12 +55,11 @@ export const LogoLink = styled(Link)`
   margin-right: ${sizes(1)};
   text-decoration: none;
   color: ${colors.gray[300]};
-  @media screen and (min-width: ${breakpoints.medium}) {
-    margin-right: ${sizes(5)};
-  }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     padding: 0;
     margin-left: 2px;
+    margin-right: ${sizes(5)};
   }
 `
 
@@ -68,7 +67,8 @@ export const StudioText = styled(Text)`
   display: none;
   font-family: ${typography.fonts.headers};
   margin-left: 6px;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: block;
   }
 `
@@ -76,7 +76,8 @@ export const StudioText = styled(Text)`
 export const ShortLogo = styled(UnstyledShortLogo)`
   display: block;
   height: ${sizes(8)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: none;
   }
 `
@@ -84,7 +85,8 @@ export const ShortLogo = styled(UnstyledShortLogo)`
 export const FullLogo = styled(UnstyledFullLogoDefault)<LogoContainerProps>`
   display: none;
   height: ${sizes(8)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: ${({ variant }) => (variant === 'default' ? 'block' : 'flex')};
   }
 `
@@ -94,11 +96,13 @@ export const LogoContainer = styled.div<LogoContainerProps>`
   margin-top: ${({ variant }) => (variant === 'default' ? sizes(1) : '0')};
   display: ${({ variant }) => (variant === 'default' ? 'none' : 'flex')};
   align-items: center;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
     margin: 0 ${sizes(3)} 0 ${sizes(12)};
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-left: 0;
   }
 `

--- a/src/components/Topbar/ViewerTopbar/ViewerTopbar.style.tsx
+++ b/src/components/Topbar/ViewerTopbar/ViewerTopbar.style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 import { Searchbar } from '@/shared/components'
-import { breakpoints, sizes, transitions } from '@/shared/theme'
+import { sizes, transitions, media } from '@/shared/theme'
 
 export const SearchbarContainer = styled.div`
   max-width: 1156px;
@@ -11,7 +11,7 @@ export const SearchbarContainer = styled.div`
   align-items: center;
   margin-left: ${sizes(14)};
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     margin: 0;
   }
 `
@@ -20,7 +20,8 @@ export const StyledSearchbar = styled(Searchbar)`
   transition: max-width ${transitions.timings.regular} ${transitions.easing};
   will-change: max-width;
   height: 42px;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     height: initial;
   }
 `

--- a/src/shared/components/ActionBar/ActionBar.style.ts
+++ b/src/shared/components/ActionBar/ActionBar.style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { colors, sizes, typography, breakpoints, transitions } from '@/shared/theme'
+import { colors, sizes, typography, transitions, media } from '@/shared/theme'
 import { Text, Tooltip } from '@/shared/components'
 import { StudioContainer } from '@/components'
 
@@ -16,7 +16,8 @@ export const StyledActionBarContainer = styled.div<ActionBarContainerProps>`
   background-color: ${colors.gray[900]};
   padding: ${sizes(3)} ${sizes(4)};
   border-top: 1px solid ${colors.gray[700]};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     flex-direction: row;
     justify-content: space-between;
     padding: ${sizes(4)} ${sizes(8)};
@@ -36,10 +37,12 @@ export const StyledInfoContainer = styled.div`
   width: 100%;
   flex-direction: row;
   align-items: center;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     align-items: center;
     width: 100%;
   }
@@ -51,7 +54,8 @@ export const StyledPrimaryText = styled(Text)`
   font-size: ${typography.sizes.h5};
   font-weight: ${typography.weights.bold};
   text-align: right;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-right: ${sizes(4)};
   }
 `
@@ -62,7 +66,8 @@ export const StyledSecondaryText = styled(Text)`
   line-height: 20px;
   max-width: 280px;
   display: none;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     display: block;
   }
 `
@@ -86,7 +91,8 @@ export const StyledTooltip = styled(Tooltip)`
     height: 100%;
     align-items: center;
   }
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: block;
   }
 `

--- a/src/shared/components/Avatar/Avatar.style.tsx
+++ b/src/shared/components/Avatar/Avatar.style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { css, SerializedStyles } from '@emotion/react'
 import { TransitionGroup } from 'react-transition-group'
-import { breakpoints, colors, transitions, typography } from '@/shared/theme'
+import { breakpoints, colors, transitions, typography, media } from '@/shared/theme'
 import Placeholder from '../Placeholder'
 import { ReactComponent as Silhouette } from '@/assets/avatar-silhouette.svg'
 
@@ -25,7 +25,8 @@ const coverAvatarCss = css`
   width: 64px;
   min-width: 64px;
   height: 64px;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     width: 88px;
     min-width: 88px;
     height: 88px;

--- a/src/shared/components/ChannelCover/ChannelCover.style.ts
+++ b/src/shared/components/ChannelCover/ChannelCover.style.ts
@@ -1,4 +1,4 @@
-import { breakpoints, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
+import { media, colors, sizes, transitions, typography, zIndex } from '@/shared/theme'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import Text from '../Text'
@@ -47,7 +47,8 @@ export const CoverImage = styled.div<CoverImageProps>`
   // as the content overlaps the media more and more as the viewport width grows, we need to hide some part of the media with a gradient
   // this helps with keeping a consistent background behind a page content - we don't want the media to peek out in the content spacing
   background-image: linear-gradient(0deg, black 0%, rgba(0, 0, 0, 0) ${GRADIENT_HEIGHT / 4}px), url(${({ src }) => src});
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     background-image: linear-gradient(
         0deg,
         black 0%,
@@ -56,7 +57,8 @@ export const CoverImage = styled.div<CoverImageProps>`
       ),
       url(${({ src }) => src});
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     background-image: linear-gradient(
         0deg,
         black 0%,
@@ -65,7 +67,8 @@ export const CoverImage = styled.div<CoverImageProps>`
       ),
       url(${({ src }) => src});
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     background-image: linear-gradient(
         0deg,
         black 0%,
@@ -74,7 +77,8 @@ export const CoverImage = styled.div<CoverImageProps>`
       ),
       url(${({ src }) => src});
   }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     background-image: linear-gradient(
         0deg,
         black 0%,
@@ -83,7 +87,8 @@ export const CoverImage = styled.div<CoverImageProps>`
       ),
       url(${({ src }) => src});
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     background-image: linear-gradient(
         0deg,
         black 0%,
@@ -99,19 +104,23 @@ export const CoverWrapper = styled.div`
   // because of the fixed aspect ratio, as the viewport width grows, the media will occupy more height as well
   // so that the media doesn't take too big of a portion of the space, we let the content overlap the media via a negative margin
   margin-bottom: -${CONTENT_OVERLAP_MAP.BASE}px;
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.SMALL}px;
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.MEDIUM}px;
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.LARGE}px;
   }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.XLARGE}px;
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     margin-bottom: -${CONTENT_OVERLAP_MAP.XXLARGE}px;
   }
 `
@@ -122,10 +131,9 @@ export const EditableControls = styled.div`
   position: absolute;
   display: flex;
   justify-content: center;
-
   transition: opacity ${transitions.timings.loading} ${transitions.easing};
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     background-color: ${colors.transparentBlack[54]};
     opacity: 0;
     :hover {
@@ -133,7 +141,7 @@ export const EditableControls = styled.div`
     }
   }
 
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+  ${media.xlarge} {
     height: 70%;
   }
 `
@@ -148,7 +156,8 @@ export const RemoveCoverDesktopButton = styled(Button)`
   ${removeButtonStyles};
 
   display: none;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
   }
 `
@@ -158,7 +167,7 @@ export const RemoveCoverMobileButton = styled(IconButton)`
 
   background-color: ${colors.gray[800]};
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     display: none;
   }
 `
@@ -172,7 +181,7 @@ export const EditCoverDesktopOverlay = styled.div`
   color: ${colors.gray[200]};
   display: none;
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     display: flex;
     cursor: pointer;
   }
@@ -185,7 +194,7 @@ export const EditCoverMobileButton = styled(IconButton)`
 
   background-color: ${colors.gray[800]};
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     display: none;
   }
 `

--- a/src/shared/components/FileSelect/FileDrop.style.ts
+++ b/src/shared/components/FileSelect/FileDrop.style.ts
@@ -1,4 +1,4 @@
-import { breakpoints, colors, sizes, transitions } from '@/shared/theme'
+import { colors, sizes, transitions, media } from '@/shared/theme'
 import styled from '@emotion/styled'
 import Text from '../Text'
 import { darken } from 'polished'
@@ -51,7 +51,7 @@ export const DragAndDropArea = styled.div<DragAndDropAreaProps>`
     border: 1px dashed ${colors.blue[500]};
   }
 
-  @media screen and (min-width: 450px) {
+  ${media.compact} {
     padding-top: 56.25%;
   }
 `
@@ -68,7 +68,7 @@ export const InnerContainer = styled.div`
   max-width: 280px;
   height: 100%;
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     max-width: 350px;
   }
 `
@@ -109,7 +109,8 @@ export const Thumbnail = styled.img`
   object-fit: contain;
   cursor: pointer;
   display: block;
-  @media screen and (min-width: 450px) {
+
+  ${media.compact} {
     object-fit: initial;
   }
 `
@@ -124,14 +125,16 @@ export const DismissButton = styled(IconButton)`
 
 export const Title = styled(Text)`
   margin-top: ${sizes(2)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-top: ${sizes(4)};
   }
 `
 
 export const Paragraph = styled(Text)`
   margin-top: ${sizes(4)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-top: ${sizes(8)};
   }
 `
@@ -141,14 +144,16 @@ export const ButtonsGroup = styled.div`
   align-items: center;
   justify-content: center;
   margin-top: ${sizes(4)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-top: ${sizes(8)};
   }
 `
 
 export const DragDropText = styled(Text)`
   display: none;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: initial;
     margin-right: ${sizes(5)};
     color: ${colors.gray[300]};

--- a/src/shared/components/FileStep/FileStep.style.ts
+++ b/src/shared/components/FileStep/FileStep.style.ts
@@ -1,4 +1,4 @@
-import { breakpoints, colors, sizes, transitions, typography } from '@/shared/theme'
+import { media, colors, sizes, transitions, typography } from '@/shared/theme'
 import styled from '@emotion/styled'
 import CircularProgressbar from '../CircularProgressbar'
 import Text from '../Text'
@@ -72,7 +72,8 @@ export const FileName = styled(Text)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     width: 200px;
   }
 `

--- a/src/shared/components/GlobalStyle/GlobalStyle.tsx
+++ b/src/shared/components/GlobalStyle/GlobalStyle.tsx
@@ -1,7 +1,7 @@
 import { css, Global, SerializedStyles } from '@emotion/react'
 import emotionNormalize from 'emotion-normalize'
 import React from 'react'
-import { breakpoints, colors, sizes, typography } from '../../theme'
+import { media, colors, sizes, typography } from '../../theme'
 import { transitionStyles } from './transitionStyles'
 
 const globalStyles = css`
@@ -41,7 +41,7 @@ const globalStyles = css`
     --global-horizontal-padding: ${sizes(4)};
     --sidenav-collapsed-width: 0;
 
-    @media screen and (min-width: ${breakpoints.medium}) {
+    ${media.medium} {
       --global-horizontal-padding: ${sizes(8)};
       --sidenav-collapsed-width: 72px;
     }

--- a/src/shared/components/HamburgerButton/HamburgerButton.style.ts
+++ b/src/shared/components/HamburgerButton/HamburgerButton.style.ts
@@ -1,7 +1,7 @@
 // based on https://github.com/jonsuh/hamburgers licensed under MIT
 
 import styled from '@emotion/styled'
-import { breakpoints, colors, sizes, zIndex } from '../../theme'
+import { colors, sizes, zIndex, media } from '../../theme'
 
 type HamburgerInnerProps = {
   active: boolean
@@ -30,7 +30,8 @@ export const Hamburger = styled.button`
   &:active {
     background-color: rgba(0, 0, 0, 0.4);
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     top: 16px;
     height: ${sizes(12)};
     width: ${sizes(12)};

--- a/src/shared/components/HeaderTextField/HeaderTextField.style.tsx
+++ b/src/shared/components/HeaderTextField/HeaderTextField.style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { fluidRange } from 'polished'
 import { Text } from '@/shared/components'
-import { colors, sizes, typography, breakpoints } from '@/shared/theme'
+import { colors, sizes, typography, media } from '@/shared/theme'
 
 type HelperTextProps = {
   error?: boolean
@@ -20,10 +20,11 @@ export const Container = styled.div`
 
 export const StyledInput = styled.input<StyledInputProps>`
   --input-max-width: 60vw;
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     --input-max-width: 400px;
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     --input-max-width: 600px;
   }
   line-height: 1;

--- a/src/shared/components/MultiFileSelect/MultiFileSelect.style.ts
+++ b/src/shared/components/MultiFileSelect/MultiFileSelect.style.ts
@@ -1,4 +1,4 @@
-import { breakpoints, colors, sizes } from '@/shared/theme'
+import { colors, sizes, media } from '@/shared/theme'
 import styled from '@emotion/styled'
 
 export const MultiFileSelectContainer = styled.div`
@@ -9,7 +9,8 @@ export const MultiFileSelectContainer = styled.div`
 export const StepsContainer = styled.div`
   width: 100%;
   margin-top: ${sizes(5)};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-top: ${sizes(10)};
     display: flex;
     justify-content: space-between;
@@ -27,7 +28,8 @@ export const StepDivider = styled.div`
   svg {
     transform: rotate(90deg);
   }
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     width: ${sizes(12)};
     height: initial;
     svg {

--- a/src/shared/components/Pagination/Pagination.style.tsx
+++ b/src/shared/components/Pagination/Pagination.style.tsx
@@ -1,4 +1,4 @@
-import { breakpoints, colors, sizes, transitions, typography } from '@/shared/theme'
+import { colors, sizes, transitions, typography, media } from '@/shared/theme'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import IconButton from '../IconButton'
@@ -12,14 +12,15 @@ export const PaginationWrapper = styled.div`
   display: flex;
   max-width: 400px;
   justify-content: space-between;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     max-width: unset;
     justify-content: unset;
   }
 `
 
 export const ChevronButton = styled(IconButton)`
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     &:first-of-type {
       margin-right: ${sizes(8)};
     }
@@ -31,7 +32,8 @@ export const ChevronButton = styled(IconButton)`
 
 export const ThreeDotsWrapper = styled.div`
   display: none;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     width: ${sizes(12)};
     height: ${sizes(12)};
     color: ${colors.gray[300]};
@@ -74,8 +76,10 @@ export const PaginationButton = styled.button<PaginationButtonProps>`
   :active {
     ${buttonActiveState}
   }
+
   ${({ isActive }) => isActive && buttonActiveState};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
   }
 `

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import { css } from '@emotion/react'
-import { breakpoints, colors, sizes, transitions, typography, zIndex } from '../../theme'
+import { breakpoints, colors, sizes, transitions, typography, zIndex, media } from '../../theme'
 
 type ContainerProps = {
   isInBackground?: boolean
@@ -46,7 +46,7 @@ export const Container = styled.div<ContainerProps>`
     align-items: center;
     height: ${sizes(16)} !important;
 
-    @media screen and (min-width: ${breakpoints.small}) {
+    ${media.small} {
       padding: 5px ${sizes(8)} 0;
       background-color: rgba(0, 0, 0, 0.3);
     }
@@ -91,7 +91,8 @@ export const Container = styled.div<ContainerProps>`
 
     .vjs-picture-in-picture-control {
       display: none;
-      @media screen and (min-width: ${breakpoints.small}) {
+
+      ${media.small} {
         display: block;
         margin-left: auto;
       }
@@ -120,7 +121,7 @@ export const Container = styled.div<ContainerProps>`
       width: 100%;
       bottom: -2px;
 
-      @media screen and (min-width: ${breakpoints.small}) {
+      ${media.small} {
         top: 0;
         left: ${sizes(8)};
         width: calc(100% - 2 * ${sizes(8)});
@@ -145,7 +146,8 @@ export const Container = styled.div<ContainerProps>`
             background: ${colors.blue[500]};
             border-radius: 100%;
             border: 2px solid ${colors.white};
-            @media screen and (min-width: ${breakpoints.small}) {
+
+            ${media.small} {
               display: none;
             }
           }

--- a/src/shared/components/VideoPreviewBase/VideoPreviewBase.styles.tsx
+++ b/src/shared/components/VideoPreviewBase/VideoPreviewBase.styles.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { fluidRange, transparentize } from 'polished'
 import styled from '@emotion/styled'
 import { css } from '@emotion/react'
-import { breakpoints, colors, sizes, transitions, typography } from '@/shared/theme'
+import { colors, sizes, transitions, typography, media } from '@/shared/theme'
 import Placeholder from '../Placeholder'
 import Avatar from '../Avatar'
 import Text from '../Text'
@@ -61,7 +61,7 @@ export const CoverContainer = styled.div<ClickableProps>`
 `
 
 const mainContainerCss = css`
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     flex-direction: row;
   }
 `
@@ -81,7 +81,7 @@ export const Container = styled.article<MainProps>`
 `
 
 const mainInfoContainerCss = css`
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     margin: ${sizes(8)} 0 0 ${sizes(6)};
   }
 `

--- a/src/shared/theme/breakpoints.ts
+++ b/src/shared/theme/breakpoints.ts
@@ -1,8 +1,13 @@
-export default {
+const breakpoints: {
+  [key: string]: string
+} = {
   base: '320px',
+  compact: '450px',
   small: '600px',
   medium: '1024px',
   large: '1440px',
   xlarge: '1920px',
   xxlarge: '2560px',
 }
+
+export default breakpoints

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -2,7 +2,8 @@ import typography from './typography'
 import colors from './colors'
 import { sizes, zIndex } from './sizes'
 import breakpoints from './breakpoints'
+import media from './media'
 import transitions from './transitions'
 
-export { typography, breakpoints, sizes, zIndex, colors, transitions }
-export default { typography, breakpoints, sizes, colors, transitions }
+export { typography, breakpoints, sizes, zIndex, colors, transitions, media }
+export default { typography, breakpoints, sizes, colors, transitions, media }

--- a/src/shared/theme/media.ts
+++ b/src/shared/theme/media.ts
@@ -1,0 +1,17 @@
+import breakpoints from './breakpoints'
+
+function buildQuery(br: string) {
+  return `@media screen and (min-width: ${br})`
+}
+
+const media = {
+  base: buildQuery(breakpoints.base),
+  compact: buildQuery(breakpoints.compact),
+  small: buildQuery(breakpoints.small),
+  medium: buildQuery(breakpoints.medium),
+  large: buildQuery(breakpoints.large),
+  xlarge: buildQuery(breakpoints.xlarge),
+  xxlarge: buildQuery(breakpoints.xxlarge),
+}
+
+export default media

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.style.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.style.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { sizes, breakpoints } from '@/shared/theme'
+import { sizes, breakpoints, media } from '@/shared/theme'
 import { Avatar } from '@/shared/components'
 import { Header, TitleSection } from '@/views/viewer/ChannelView/ChannelView.style'
 
@@ -25,7 +25,8 @@ export const InnerFormContainer = styled.div`
   width: 100%;
   margin-top: 50px;
   padding-bottom: 100px;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     padding-bottom: 200px;
   }
 `
@@ -36,7 +37,8 @@ export const StyledAvatar = styled(Avatar)`
   flex-shrink: 0;
   width: 80px;
   height: 80px;
-  @media (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     width: 136px;
     height: 136px;
   }

--- a/src/views/studio/CreateMemberView/CreateMemberView.style.ts
+++ b/src/views/studio/CreateMemberView/CreateMemberView.style.ts
@@ -1,6 +1,6 @@
 import { StudioContainer } from '@/components'
 import { Button, Text } from '@/shared/components'
-import { breakpoints, colors, sizes } from '@/shared/theme'
+import { media, colors, sizes } from '@/shared/theme'
 import styled from '@emotion/styled'
 
 export const Header = styled.header`
@@ -11,7 +11,8 @@ export const Header = styled.header`
 export const Hero = styled(Text)`
   font-size: 54px;
   word-break: break-word;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     font-size: 72px;
   }
 `
@@ -36,7 +37,7 @@ export const Form = styled.form`
   max-width: 580px;
   height: initial;
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     left: 0;
     height: calc(100vh - 300px);
     width: 100%;

--- a/src/views/studio/MyUploadsView/AssetLine/AssetLine.style.tsx
+++ b/src/views/studio/MyUploadsView/AssetLine/AssetLine.style.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Text } from '@/shared/components'
-import { colors, sizes, breakpoints } from '@/shared/theme'
+import { colors, sizes, media } from '@/shared/theme'
 
 type FileLineProps = {
   isLast?: boolean
@@ -10,7 +10,8 @@ export const FileLineContainer = styled.div<FileLineProps>`
   display: flex;
   align-items: center;
   margin: ${sizes(6)} 0;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin: ${sizes(2)} 0;
   }
 `
@@ -29,11 +30,13 @@ export const FileLinePoint = styled.div`
     height: 32px;
     transform: translateY(calc(50% - 1px));
   }
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: block;
     margin-left: ${sizes(4)};
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-left: ${sizes(13)};
   }
 `
@@ -46,11 +49,13 @@ export const FileLineLastPoint = styled.div`
   border-left: 2px solid ${colors.gray[500]};
   border-bottom: 2px solid ${colors.gray[500]};
   transform: translateY(calc(-50% + 1px));
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: block;
     margin-left: ${sizes(4)};
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     margin-left: ${sizes(13)};
   }
 `
@@ -64,7 +69,8 @@ export const StatusMessage = styled(Text)`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     max-width: ${sizes(42)};
   }
 `
@@ -92,7 +98,8 @@ export const FileInfoContainer = styled.div`
     display: flex;
     align-items: center;
   }
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-left: ${sizes(6)};
     grid-template-columns: repeat(3, 1fr);
   }

--- a/src/views/studio/MyUploadsView/AssetsGroupUploadBar/AssetsGroupUploadBar.style.tsx
+++ b/src/views/studio/MyUploadsView/AssetsGroupUploadBar/AssetsGroupUploadBar.style.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { colors, sizes, zIndex, breakpoints, transitions } from '@/shared/theme'
+import { colors, sizes, zIndex, media, transitions } from '@/shared/theme'
 import { keyframes } from '@emotion/react'
 import { ExpandButton } from '@/shared/components'
 
@@ -70,7 +70,8 @@ export const Thumbnail = styled.div`
   width: ${sizes(18)};
   height: ${sizes(12)};
   background-color: ${colors.gray[700]};
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: flex;
   }
 `

--- a/src/views/studio/MyUploadsView/PlaceholderItems.tsx
+++ b/src/views/studio/MyUploadsView/PlaceholderItems.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from '@emotion/styled'
-import { breakpoints, colors } from '@/shared/theme'
+import { colors, media } from '@/shared/theme'
 import { Placeholder } from '@/shared/components'
 import {
   Container,
@@ -29,7 +29,8 @@ const Placeholders = () => {
 
 const StyledPlaceholderThumbnail = styled(Placeholder)`
   display: none;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     display: block;
   }
 `

--- a/src/views/studio/MyVideosView/EmptyVideosView.tsx
+++ b/src/views/studio/MyVideosView/EmptyVideosView.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { ReactComponent as WellIllustration } from '@/assets/well-blue.svg'
 import { ReactComponent as EmptyIllustration } from '@/assets/empty-videos-illustration.svg'
 import { Button, Text } from '@/shared/components'
-import { sizes, colors, breakpoints } from '@/shared/theme'
+import { sizes, colors, media } from '@/shared/theme'
 import { SvgGlyphAddVideo } from '@/shared/icons'
 
 // for when there is absolutely no videos available
@@ -35,17 +35,17 @@ const StyledWEmptyIllustration = styled(EmptyIllustration)`
   max-height: 50vh;
   max-width: 75vw;
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     max-width: initial;
     grid-row-start: initial;
     max-height: 60vh;
   }
-  @media screen and (min-width: ${breakpoints.large}) {
-  }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     max-height: 70vh;
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     transform: scale(1.2);
   }
 `
@@ -54,9 +54,7 @@ const ContainerView = styled.div`
   display: grid;
   padding: 0 0 ${sizes(10)} 0;
 
-  @media screen and (min-width: ${breakpoints.medium}) {
-  }
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     grid-template-columns: auto 1fr;
     margin: ${sizes(20)} auto 0;
   }
@@ -66,9 +64,9 @@ const InnerContainerView = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-
   align-items: center;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     align-items: initial;
   }
 `
@@ -80,7 +78,7 @@ const MessageView = styled.div`
   margin-top: ${sizes(8)};
   margin-bottom: ${sizes(8)};
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     text-align: left;
     margin-top: ${sizes(12)};
   }

--- a/src/views/studio/SelectMembershipView/SelectMembershipView.style.ts
+++ b/src/views/studio/SelectMembershipView/SelectMembershipView.style.ts
@@ -1,6 +1,6 @@
 import { StudioContainer } from '@/components'
 import { Text } from '@/shared/components'
-import { breakpoints, colors, sizes } from '@/shared/theme'
+import { colors, sizes, media } from '@/shared/theme'
 import styled from '@emotion/styled'
 
 export const Header = styled.header`
@@ -11,7 +11,8 @@ export const Header = styled.header`
 export const Hero = styled(Text)`
   font-size: 54px;
   word-break: break-word;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     font-size: 72px;
   }
 `
@@ -32,7 +33,8 @@ export const MemberChannelGrid = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     max-width: 600px;
   }
 `

--- a/src/views/studio/SignInView/SignInView.style.ts
+++ b/src/views/studio/SignInView/SignInView.style.ts
@@ -1,5 +1,5 @@
 import { Button, Text } from '@/shared/components'
-import { breakpoints, colors, sizes, zIndex } from '@/shared/theme'
+import { media, colors, sizes, zIndex } from '@/shared/theme'
 import styled from '@emotion/styled'
 import { ReactComponent as BackgroundPatternSVG } from '@/assets/bg-pattern.svg'
 import tileImg from '@/assets/tile-example.png'
@@ -12,7 +12,8 @@ export const StyledBackgroundPattern = styled(BackgroundPatternSVG)`
   z-index: ${zIndex.background};
   max-width: 100%;
   transform: translateX(0);
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     left: 50%;
     transform: translateX(-50%);
   }
@@ -57,7 +58,8 @@ export const VideoImgBg = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
   background-position: top right;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     left: 0;
     height: 350px;
   }
@@ -74,7 +76,8 @@ export const TileImgBg = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
   background-position: top left;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     right: 70px;
     top: 190px;
     left: initial;
@@ -94,10 +97,12 @@ export const Overlay = styled.div`
   width: 100vw;
   height: 150%;
   overflow: hidden;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     width: 100%;
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     background: radial-gradient(100% 200% at 0% 100%, black 0%, rgba(0, 0, 0, 0) 100%);
     width: 70%;
     left: 20%;

--- a/src/views/viewer/ChannelView/ChannelView.style.tsx
+++ b/src/views/viewer/ChannelView/ChannelView.style.tsx
@@ -1,5 +1,5 @@
 import { CONTENT_OVERLAP_MAP, Placeholder, Text } from '@/shared/components'
-import { breakpoints, sizes, colors, typography } from '@/shared/theme'
+import { breakpoints, sizes, colors, typography, media } from '@/shared/theme'
 import { fluidRange } from 'polished'
 import styled from '@emotion/styled'
 import { ChannelLink } from '@/components'
@@ -8,7 +8,7 @@ export const Header = styled.section`
   position: relative;
   padding-bottom: 50px;
 
-  @media screen and (min-width: ${breakpoints.medium}) {
+  ${media.medium} {
     padding-bottom: 0;
   }
 `
@@ -26,30 +26,36 @@ export const TitleSection = styled.div`
   align-items: start;
   width: 100%;
   margin-top: -64px;
-  @media screen and (min-width: ${breakpoints.small}) {
+
+  ${media.small} {
     margin-top: -100px;
     flex-direction: row;
     align-items: center;
   }
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     position: absolute;
     margin-top: 0;
     bottom: ${CONTENT_OVERLAP_MAP.MEDIUM + INFO_BOTTOM_MARGIN}px;
   }
-  @media screen and (min-width: ${breakpoints.large}) {
+
+  ${media.large} {
     bottom: ${CONTENT_OVERLAP_MAP.LARGE + INFO_BOTTOM_MARGIN}px;
   }
-  @media screen and (min-width: ${breakpoints.xlarge}) {
+
+  ${media.xlarge} {
     bottom: ${CONTENT_OVERLAP_MAP.XLARGE + INFO_BOTTOM_MARGIN}px;
   }
-  @media screen and (min-width: ${breakpoints.xxlarge}) {
+
+  ${media.xxlarge} {
     bottom: ${CONTENT_OVERLAP_MAP.XXLARGE + INFO_BOTTOM_MARGIN}px;
   }
 `
 export const TitleContainer = styled.div`
   max-width: 100%;
   overflow: hidden;
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     max-width: 60%;
   }
   z-index: 2;
@@ -93,7 +99,8 @@ export const StyledChannelLink = styled(ChannelLink)`
 export const TitlePlaceholder = styled(Placeholder)`
   width: 300px;
   height: ${SM_TITLE_HEIGHT};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     height: ${TITLE_HEIGHT};
   }
 `
@@ -102,7 +109,8 @@ export const SubTitlePlaceholder = styled(Placeholder)`
   width: 140px;
   margin-top: ${sizes(2)};
   height: ${SM_SUBTITLE_HEIGHT};
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     height: ${SUBTITLE_HEIGHT};
   }
 `
@@ -111,7 +119,7 @@ export const StyledButtonContainer = styled.div`
   z-index: 2;
   background-color: ${colors.transparentBlack[54]};
 
-  @media screen and (min-width: ${breakpoints.small}) {
+  ${media.small} {
     margin-top: 0;
     margin-left: auto;
     align-self: center;

--- a/src/views/viewer/SearchOverlayView/RecentSearches/previews/previews.style.ts
+++ b/src/views/viewer/SearchOverlayView/RecentSearches/previews/previews.style.ts
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 import styled from '@emotion/styled'
 import { css } from '@emotion/react'
 import { Avatar, Placeholder, Text } from '@/shared/components'
-import { breakpoints, colors, sizes } from '@/shared/theme'
+import { colors, sizes, media } from '@/shared/theme'
 
 const previewSubtextCss = css`
   margin-top: ${sizes(1)};
@@ -43,7 +43,7 @@ export const PreviewContainer = styled(Link)`
   > * + * {
     margin-left: ${sizes(3)};
 
-    @media screen and (min-width: ${breakpoints.small}) {
+    ${media.small} {
       margin-left: ${sizes(6)};
     }
   }

--- a/src/views/viewer/VideoView/VideoView.style.tsx
+++ b/src/views/viewer/VideoView/VideoView.style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { ViewWrapper } from '@/components'
 import { Placeholder, Text } from '@/shared/components'
-import { sizes, colors, typography, breakpoints } from '@/shared/theme'
+import { sizes, colors, typography, breakpoints, media } from '@/shared/theme'
 import { fluidRange } from 'polished'
 
 export const StyledViewWrapper = styled(ViewWrapper)`
@@ -12,7 +12,8 @@ export const StyledViewWrapper = styled(ViewWrapper)`
 export const PlayerContainer = styled.div`
   width: 100%;
   height: calc(100vw * 0.5625);
-  @media screen and (min-width: ${breakpoints.medium}) {
+
+  ${media.medium} {
     height: 70vh;
   }
 `
@@ -59,7 +60,8 @@ export const DescriptionContainer = styled.div`
   p {
     font-size: ${typography.sizes.body2};
     margin: ${sizes(4)} 0 0;
-    @media screen and (min-width: ${breakpoints.small}) {
+
+    ${media.small} {
       font-size: 1rem;
       color: ${colors.gray[300]};
       line-height: 175%;


### PR DESCRIPTION
I would like to suggest using the following approach with media queries.

Using this approach helps to preserve consistency across the codebase since it's necessary to introduce some minor changes to the media setup to start using a new breakpoint additionally all breakpoints are 'min' ones therefore app styling integrity is less prone to human error.

Also, it's generally easier to style using such queries since it's more concise and requires less effort to achieve the same goal.
![image](https://user-images.githubusercontent.com/32495390/114316999-4e422980-9b06-11eb-96e3-bd4adf2fedbe.png)
