### PR TITLE
Test image downsizing

### DIFF
--- a/src/components/Dialogs/ImageCropDialog/ImageCropDialog.tsx
+++ b/src/components/Dialogs/ImageCropDialog/ImageCropDialog.tsx
@@ -17,20 +17,9 @@ import {
 } from './ImageCropDialog.style'
 import { SvgGlyphPan, SvgGlyphZoomIn, SvgGlyphZoomOut } from '@/shared/icons'
 
-type OriginalImgSize = {
-  width?: number
-  height?: number
-  fileSize?: number
-}
-
 export type ImageCropDialogProps = {
   imageType: CropperImageType
-  onConfirm: (
-    croppedBlob: Blob,
-    croppedUrl: string,
-    imageCropData: ImageCropData,
-    originalImgSize?: OriginalImgSize
-  ) => void
+  onConfirm: (croppedBlob: Blob, croppedUrl: string, imageCropData: ImageCropData) => void
 } & Pick<ActionDialogProps, 'onExitClick'>
 
 export type ImageCropDialogImperativeHandle = {
@@ -44,7 +33,6 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
   const [showDialog, setShowDialog] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null)
-  const [originalFileSize, setOriginalFileSize] = useState<number>()
   const [editedImageHref, setEditedImageHref] = useState<string | null>(null)
   const { currentZoom, zoomRange, zoomStep, handleZoomChange, cropImage } = useCropper({ imageEl, imageType })
 
@@ -84,7 +72,6 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
     }
     const selectedFile = files[0]
     const fileUrl = URL.createObjectURL(selectedFile)
-    setOriginalFileSize(selectedFile.size)
     setEditedImageHref(fileUrl)
     setShowDialog(true)
   }
@@ -92,12 +79,7 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
   const handleConfirmClick = async () => {
     const [blob, url, imageCropData] = await cropImage()
     resetDialog()
-    const originalImageSize = {
-      height: imageEl?.naturalHeight,
-      width: imageEl?.naturalWidth,
-      fileSize: originalFileSize,
-    }
-    onConfirm(blob, url, imageCropData, originalImageSize)
+    onConfirm(blob, url, imageCropData)
   }
 
   const zoomControlNode = (

--- a/src/components/Dialogs/ImageCropDialog/ImageCropDialog.tsx
+++ b/src/components/Dialogs/ImageCropDialog/ImageCropDialog.tsx
@@ -17,9 +17,20 @@ import {
 } from './ImageCropDialog.style'
 import { SvgGlyphPan, SvgGlyphZoomIn, SvgGlyphZoomOut } from '@/shared/icons'
 
+type OriginalImgSize = {
+  width?: number
+  height?: number
+  fileSize?: number
+}
+
 export type ImageCropDialogProps = {
   imageType: CropperImageType
-  onConfirm: (croppedBlob: Blob, croppedUrl: string, imageCropData: ImageCropData) => void
+  onConfirm: (
+    croppedBlob: Blob,
+    croppedUrl: string,
+    imageCropData: ImageCropData,
+    originalImgSize?: OriginalImgSize
+  ) => void
 } & Pick<ActionDialogProps, 'onExitClick'>
 
 export type ImageCropDialogImperativeHandle = {
@@ -33,6 +44,7 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
   const [showDialog, setShowDialog] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null)
+  const [originalFileSize, setOriginalFileSize] = useState<number>()
   const [editedImageHref, setEditedImageHref] = useState<string | null>(null)
   const { currentZoom, zoomRange, zoomStep, handleZoomChange, cropImage } = useCropper({ imageEl, imageType })
 
@@ -72,6 +84,7 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
     }
     const selectedFile = files[0]
     const fileUrl = URL.createObjectURL(selectedFile)
+    setOriginalFileSize(selectedFile.size)
     setEditedImageHref(fileUrl)
     setShowDialog(true)
   }
@@ -79,7 +92,12 @@ const ImageCropDialogComponent: React.ForwardRefRenderFunction<
   const handleConfirmClick = async () => {
     const [blob, url, imageCropData] = await cropImage()
     resetDialog()
-    onConfirm(blob, url, imageCropData)
+    const originalImageSize = {
+      height: imageEl?.naturalHeight,
+      width: imageEl?.naturalWidth,
+      fileSize: originalFileSize,
+    }
+    onConfirm(blob, url, imageCropData, originalImageSize)
   }
 
   const zoomControlNode = (

--- a/src/components/Dialogs/ImageCropDialog/cropper.ts
+++ b/src/components/Dialogs/ImageCropDialog/cropper.ts
@@ -145,14 +145,18 @@ export const useCropper = ({ imageEl, imageType }: UseCropperOpts) => {
         return
       }
       const imageCropData = cropper.getCropBoxData()
-      cropper.getCroppedCanvas(CANVAS_OPTS_PER_TYPE[imageType]).toBlob((blob) => {
-        if (!blob) {
-          console.error('Empty blob from cropped canvas', { blob })
-          return
-        }
-        const url = URL.createObjectURL(blob)
-        resolve([blob, url, imageCropData])
-      })
+      cropper.getCroppedCanvas(CANVAS_OPTS_PER_TYPE[imageType]).toBlob(
+        (blob) => {
+          if (!blob) {
+            console.error('Empty blob from cropped canvas', { blob })
+            return
+          }
+          const url = URL.createObjectURL(blob)
+          resolve([blob, url, imageCropData])
+        },
+        'image/jpeg',
+        0.7
+      )
     })
   }
 

--- a/src/components/Dialogs/ImageCropDialog/cropper.ts
+++ b/src/components/Dialogs/ImageCropDialog/cropper.ts
@@ -145,18 +145,14 @@ export const useCropper = ({ imageEl, imageType }: UseCropperOpts) => {
         return
       }
       const imageCropData = cropper.getCropBoxData()
-      cropper.getCroppedCanvas(CANVAS_OPTS_PER_TYPE[imageType]).toBlob(
-        (blob) => {
-          if (!blob) {
-            console.error('Empty blob from cropped canvas', { blob })
-            return
-          }
-          const url = URL.createObjectURL(blob)
-          resolve([blob, url, imageCropData])
-        },
-        'image/jpeg',
-        0.7
-      )
+      cropper.getCroppedCanvas(CANVAS_OPTS_PER_TYPE[imageType]).toBlob((blob) => {
+        if (!blob) {
+          console.error('Empty blob from cropped canvas', { blob })
+          return
+        }
+        const url = URL.createObjectURL(blob)
+        resolve([blob, url, imageCropData])
+      }, 'image/jpeg')
     })
   }
 

--- a/src/views/playground/PlaygroundLayout.tsx
+++ b/src/views/playground/PlaygroundLayout.tsx
@@ -6,6 +6,7 @@ import { DraftsProvider, UploadingFilesDataProvider, ActiveUserProvider, Connect
 import { Route, Routes } from 'react-router'
 import {
   FileHashing,
+  ImageDownsizing,
   PlaygroundConnectionState,
   PlaygroundDrafts,
   PlaygroundMemberChannel,
@@ -22,6 +23,7 @@ const playgroundRoutes = [
   { path: 'member-active-channel', element: <PlaygroundMemberChannel />, name: 'Active user/member/channel' },
   { path: 'file-hashing', element: <FileHashing />, name: 'File hashing' },
   { path: 'connection-state', element: <PlaygroundConnectionState />, name: 'Connection state' },
+  { path: 'image-downsizing', element: <ImageDownsizing />, name: 'Image downsizing' },
 ]
 
 export const PlaygroundLayout = () => {

--- a/src/views/playground/Playgrounds/ImageDownsizing.tsx
+++ b/src/views/playground/Playgrounds/ImageDownsizing.tsx
@@ -54,12 +54,6 @@ const StyledImg = styled.img`
   display: block;
 `
 
-type OriginalImgSize = {
-  height?: number
-  width?: number
-  fileSize?: number
-}
-
 const ImageDownsizing = () => {
   const avatarDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
   const coverDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
@@ -72,7 +66,6 @@ const ImageDownsizing = () => {
     height: 0,
     fileSize: 0,
   })
-  const [originalAvatarSizes, setOriginalAvatarSizes] = useState<OriginalImgSize | undefined>()
 
   useEffect(() => {
     if (!avatarImgRef.current) {
@@ -94,7 +87,6 @@ const ImageDownsizing = () => {
     height: 0,
     fileSize: 0,
   })
-  const [originalCoverSizes, setOriginalCoverSizes] = useState<OriginalImgSize | undefined>()
 
   useEffect(() => {
     if (!coverImgRef.current) {
@@ -110,32 +102,20 @@ const ImageDownsizing = () => {
     })
   }, [coverSizes])
 
-  const handleConfirmAvatar = (
-    croppedBlob: Blob,
-    croppedUrl: string,
-    imageCropData: Cropper.CropBoxData,
-    originalImgSize?: OriginalImgSize
-  ) => {
+  const handleConfirmAvatar = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
     setAvatarUrl(croppedUrl)
     setAvatarSizes({
       ...avatarSizes,
       fileSize: croppedBlob.size,
     })
-    setOriginalAvatarSizes(originalImgSize)
   }
 
-  const handleConfirmCover = (
-    croppedBlob: Blob,
-    croppedUrl: string,
-    imageCropData: Cropper.CropBoxData,
-    originalImgSize?: OriginalImgSize
-  ) => {
+  const handleConfirmCover = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
     setCoverUrl(croppedUrl)
     setCoverSizes({
       ...coverSizes,
       fileSize: croppedBlob.size,
     })
-    setOriginalCoverSizes(originalImgSize)
   }
 
   return (
@@ -170,10 +150,6 @@ const ImageDownsizing = () => {
         <>
           <StyledImg src={avatarUrl} ref={avatarImgRef} />
           <p>
-            Original image size: {originalAvatarSizes?.width || 0} X {originalAvatarSizes?.height || 0}
-          </p>
-          <p>Original image filesize: {formatBytes(originalAvatarSizes?.fileSize || 0)}</p>
-          <p>
             Cropped image size: {avatarSizes.width || 0} X {avatarSizes.height}
           </p>
           <p>Cropped image filesize: {formatBytes(avatarSizes.fileSize)}</p>
@@ -184,10 +160,6 @@ const ImageDownsizing = () => {
       {coverUrl && (
         <>
           <StyledImg src={coverUrl} ref={coverImgRef} />
-          <p>
-            Original image size: {originalCoverSizes?.width || 0} X {originalCoverSizes?.height || 0}
-          </p>
-          <p>Original image filesize: {formatBytes(originalCoverSizes?.fileSize || 0)}</p>
           <p>
             Cropped image size: {coverSizes.width || 0} X {coverSizes.height}
           </p>

--- a/src/views/playground/Playgrounds/ImageDownsizing.tsx
+++ b/src/views/playground/Playgrounds/ImageDownsizing.tsx
@@ -1,0 +1,116 @@
+import { ImageCropDialog, ImageCropDialogImperativeHandle } from '@/components'
+import { Button, Text } from '@/shared/components'
+import { css } from '@emotion/react'
+import styled from '@emotion/styled'
+import React, { useRef, useState } from 'react'
+
+const LARGE_FILE_IMAGES = [
+  {
+    url:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/In_the_Conservatory.jpg/8192px-In_the_Conservatory.jpg',
+    size: '~ 25mb',
+  },
+  {
+    url: 'https://effigis.com/wp-content/uploads/2015/02/Airbus_Pleiades_50cm_8bit_RGB_Yogyakarta.jpg',
+    size: '~ 50mb',
+  },
+  {
+    url:
+      'https://upload.wikimedia.org/wikipedia/en/f/f3/Franti%C5%A1ek_Kupka_-_Katedr%C3%A1la_-_Google_Art_Project.jpg',
+    size: '~ 95mb',
+  },
+  {
+    url:
+      'https://upload.wikimedia.org/wikipedia/commons/6/60/James_McNeill_Whistler_-_La_Princesse_du_pays_de_la_porcelaine_-_Google_Art_Project.jpg',
+    size: '~ 200mb',
+  },
+]
+
+const LARGE_WIDTH_HEIGHT_IMAGES = [
+  {
+    url: 'https://alexandre.alapetite.fr/doc-alex/large-image/8192.png',
+    size: '8192×8192 pixels',
+  },
+  {
+    url: 'https://alexandre.alapetite.fr/doc-alex/large-image/16383.png',
+    size: '16383×16383 pixels',
+  },
+]
+
+const StyledLink = styled.a`
+  text-decoration: none;
+  color: white;
+  :hover {
+    opacity: 0.8;
+  }
+`
+
+const StyledButton = styled(Button)`
+  margin-top: 50px;
+  display: block;
+`
+const StyledImg = styled.img`
+  margin-top: 30px;
+  display: block;
+`
+
+const ImageDownsizing = () => {
+  const avatarDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
+  const coverDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
+
+  const [avatarUrl, setAvatarUrl] = useState('')
+  const [coverUrl, setCoverUrl] = useState('')
+
+  const handleConfirmAvatar = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
+    setAvatarUrl(croppedUrl)
+  }
+
+  const handleConfirmCover = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
+    setCoverUrl(croppedUrl)
+  }
+  return (
+    <div>
+      <Text variant="h3">Large images in terms of file size</Text>
+      <ul>
+        {LARGE_FILE_IMAGES.map((image, idx) => (
+          <li key={idx}>
+            <StyledLink href={image.url}>
+              Image {idx}, size: {image.size}
+            </StyledLink>
+          </li>
+        ))}
+      </ul>
+      <StyledLink href="https://commons.wikimedia.org/wiki/Commons:Very_high-resolution_file_downloads">
+        More
+      </StyledLink>
+      <Text variant="h3">Large images in terms of width and height</Text>
+      <ul>
+        {LARGE_WIDTH_HEIGHT_IMAGES.map((image, idx) => (
+          <li key={idx}>
+            <StyledLink href={image.url}>
+              Image {idx}, size: {image.size}
+            </StyledLink>
+          </li>
+        ))}
+      </ul>
+      <StyledLink href="https://alexandre.alapetite.fr/doc-alex/large-image/index.en.html">More</StyledLink>
+      <StyledButton onClick={() => avatarDialogRef.current?.open()}>Upload avatar image</StyledButton>
+      <ImageCropDialog imageType="avatar" onConfirm={handleConfirmAvatar} ref={avatarDialogRef} />
+      {avatarUrl && (
+        <>
+          <StyledImg src={avatarUrl} />
+        </>
+      )}
+
+      <StyledButton onClick={() => coverDialogRef.current?.open()}>Upload cover image</StyledButton>
+      <ImageCropDialog imageType="cover" onConfirm={handleConfirmCover} ref={coverDialogRef} />
+      {coverUrl && (
+        <>
+          <StyledImg src={coverUrl} />
+        </>
+      )}
+    </div>
+  )
+}
+
+export default ImageDownsizing

--- a/src/views/playground/Playgrounds/ImageDownsizing.tsx
+++ b/src/views/playground/Playgrounds/ImageDownsizing.tsx
@@ -2,7 +2,7 @@ import { ImageCropDialog, ImageCropDialogImperativeHandle } from '@/components'
 import { Button, Text } from '@/shared/components'
 import { formatBytes } from '@/utils/size'
 import styled from '@emotion/styled'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 const LARGE_FILE_IMAGES = [
   {
@@ -147,9 +147,8 @@ const ImageDownsizing = () => {
             Original image size: {originalAvatarSizes?.width} X {originalAvatarSizes?.height}
           </p>
           <p>Original image filesize: {formatBytes(originalAvatarSizes?.fileSize || 0)}</p>
-          <p>
-            Cropped image size: {avatarSizes.width} X {avatarSizes.height}
-          </p>
+          {/* constant, they are always the same - defined by CANVAS_OPTS_PER_TYPE in cropper.ts  */}
+          <p>Cropped image size: 256 X 256</p>
           <p>Cropped image filesize: {formatBytes(avatarSizes.fileSize)}</p>
         </>
       )}
@@ -162,9 +161,8 @@ const ImageDownsizing = () => {
             Original image size: {originalCoverSizes?.width} X {originalCoverSizes?.height}
           </p>
           <p>Original image filesize: {formatBytes(originalCoverSizes?.fileSize || 0)}</p>
-          <p>
-            Cropped image size: {coverSizes.width} X {coverSizes.height}
-          </p>
+          {/* constant, they are always the same - defined by CANVAS_OPTS_PER_TYPE in cropper.ts  */}
+          <p>Cropped image size: 1920 X 480 </p>
           <p>Cropped image filesize: {formatBytes(coverSizes.fileSize)} </p>
         </>
       )}

--- a/src/views/playground/Playgrounds/ImageDownsizing.tsx
+++ b/src/views/playground/Playgrounds/ImageDownsizing.tsx
@@ -1,6 +1,6 @@
 import { ImageCropDialog, ImageCropDialogImperativeHandle } from '@/components'
 import { Button, Text } from '@/shared/components'
-import { css } from '@emotion/react'
+import { formatBytes } from '@/utils/size'
 import styled from '@emotion/styled'
 import React, { useRef, useState } from 'react'
 
@@ -54,20 +54,64 @@ const StyledImg = styled.img`
   display: block;
 `
 
+type OriginalImgSize = {
+  height?: number
+  width?: number
+  fileSize?: number
+}
+
 const ImageDownsizing = () => {
   const avatarDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
   const coverDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
 
   const [avatarUrl, setAvatarUrl] = useState('')
+  const [avatarSizes, setAvatarSizes] = useState({
+    width: 0,
+    height: 0,
+    fileSize: 0,
+  })
+  const [originalAvatarSizes, setOriginalAvatarSizes] = useState<OriginalImgSize | undefined>()
+
   const [coverUrl, setCoverUrl] = useState('')
+  const [coverSizes, setCoverSizes] = useState({
+    width: 0,
+    height: 0,
+    fileSize: 0,
+  })
+  const [originalCoverSizes, setOriginalCoverSizes] = useState<OriginalImgSize | undefined>()
 
-  const handleConfirmAvatar = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
+  const handleConfirmAvatar = (
+    croppedBlob: Blob,
+    croppedUrl: string,
+    imageCropData: Cropper.CropBoxData,
+    originalImgSize?: OriginalImgSize
+  ) => {
+    const { width, height } = imageCropData
     setAvatarUrl(croppedUrl)
+    setAvatarSizes({
+      width,
+      height,
+      fileSize: croppedBlob.size,
+    })
+    setOriginalAvatarSizes(originalImgSize)
   }
 
-  const handleConfirmCover = (croppedBlob: Blob, croppedUrl: string, imageCropData: Cropper.CropBoxData) => {
+  const handleConfirmCover = (
+    croppedBlob: Blob,
+    croppedUrl: string,
+    imageCropData: Cropper.CropBoxData,
+    originalImgSize?: OriginalImgSize
+  ) => {
     setCoverUrl(croppedUrl)
+    const { width, height } = imageCropData
+    setCoverSizes({
+      width,
+      height,
+      fileSize: croppedBlob.size,
+    })
+    setOriginalCoverSizes(originalImgSize)
   }
+
   return (
     <div>
       <Text variant="h3">Large images in terms of file size</Text>
@@ -99,14 +143,29 @@ const ImageDownsizing = () => {
       {avatarUrl && (
         <>
           <StyledImg src={avatarUrl} />
+          <p>
+            Original image size: {originalAvatarSizes?.width} X {originalAvatarSizes?.height}
+          </p>
+          <p>Original image filesize: {formatBytes(originalAvatarSizes?.fileSize || 0)}</p>
+          <p>
+            Cropped image size: {avatarSizes.width} X {avatarSizes.height}
+          </p>
+          <p>Cropped image filesize: {formatBytes(avatarSizes.fileSize)}</p>
         </>
       )}
-
       <StyledButton onClick={() => coverDialogRef.current?.open()}>Upload cover image</StyledButton>
       <ImageCropDialog imageType="cover" onConfirm={handleConfirmCover} ref={coverDialogRef} />
       {coverUrl && (
         <>
           <StyledImg src={coverUrl} />
+          <p>
+            Original image size: {originalCoverSizes?.width} X {originalCoverSizes?.height}
+          </p>
+          <p>Original image filesize: {formatBytes(originalCoverSizes?.fileSize || 0)}</p>
+          <p>
+            Cropped image size: {coverSizes.width} X {coverSizes.height}
+          </p>
+          <p>Cropped image filesize: {formatBytes(coverSizes.fileSize)} </p>
         </>
       )}
     </div>

--- a/src/views/playground/Playgrounds/ImageDownsizing.tsx
+++ b/src/views/playground/Playgrounds/ImageDownsizing.tsx
@@ -2,7 +2,7 @@ import { ImageCropDialog, ImageCropDialogImperativeHandle } from '@/components'
 import { Button, Text } from '@/shared/components'
 import { formatBytes } from '@/utils/size'
 import styled from '@emotion/styled'
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 const LARGE_FILE_IMAGES = [
   {

--- a/src/views/playground/Playgrounds/index.ts
+++ b/src/views/playground/Playgrounds/index.ts
@@ -5,3 +5,4 @@ export { default as PlaygroundUploadingFilesData } from './PlaygroundUploadingFi
 export { default as PlaygroundMemberChannel } from './PlaygroundMemberChannel'
 export { default as FileHashing } from './FileHashing'
 export { default as PlaygroundConnectionState } from './PlaygroundConnectionState'
+export { default as ImageDownsizing } from './ImageDownsizing'


### PR DESCRIPTION
Fix #468

Some images do not work. For example: [~100mb](https://upload.wikimedia.org/wikipedia/en/f/f3/Franti%C5%A1ek_Kupka_-_Katedr%C3%A1la_-_Google_Art_Project.jpg) , [~300mb](https://upload.wikimedia.org/wikipedia/commons/7/76/Vincent_van_Gogh_-_De_slaapkamer_-_Google_Art_Project.jpg)
On firefox, if you try using image cropping after you click confirm, you will see nothing. On chrome, the cropper dialog will not display the image at all and it will break if you touch zoom controls.
Also worth noticing - for some reason, if you open these images on chrome, you will see a small square 16px on 16px(or something). 
Not sure if I should open an issue for that. I think these images are just broken somehow. 
