### PR TITLE
Add dynamic page titles

### DIFF
--- a/src/views/VideosView/VideosView.tsx
+++ b/src/views/VideosView/VideosView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 
 import { ErrorBoundary } from '@sentry/react'
 import { useInView } from 'react-intersection-observer'
@@ -28,6 +28,10 @@ const VideosView: React.FC = () => {
     error: featuredVideosError,
     refetch: refetchFeaturedVideos,
   } = useFeaturedVideos({}, { notifyOnNetworkStatusChange: true })
+
+  useEffect(() => {
+    document.title = !featuredVideos ? 'Videos' : `Videos (${featuredVideos?.length})`
+  }, [featuredVideos])
 
   const topicsRef = useRef<HTMLHeadingElement>(null)
   const { ref: targetRef, inView } = useInView({


### PR DESCRIPTION
Addressing issue #510 

### Details
- Adding `useState` to update the page title
- Draft implementation for 'VideosView' w/video count (including 0)
- Defaults to just say "Videos" if/while `featuredVideos` is undefined

### Thoughts
- What other pages should receive this treatment?
- Any other/alternate desired copy?
- Since draft PR, currently there is no logic to revert the title back to "Joystream"