### PR TITLE
Fix wrongly returned id in createOrUpdateVideo method

### DIFF
--- a/src/joystream-lib/api.ts
+++ b/src/joystream-lib/api.ts
@@ -340,7 +340,7 @@ export class JoystreamJs {
     const { data: events, block } = await this.sendExtrinsic(tx, cb)
 
     const contentEvents = events.filter((event) => event.section === 'content')
-    const videoId = contentEvents[0].data[1]
+    const videoId = contentEvents[0].data[2]
     return {
       data: new BN(videoId as never).toString(),
       block,


### PR DESCRIPTION
It turns out that I was returning `ChannelId` instead of `VideoId`. Thanks @mikkio-j  for pointing this out to me.