### PR TITLE
Scroll to errors

### DIFF
--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -14,6 +14,7 @@ export type SelectProps<T = string> = {
   value?: T | null
   items: SelectItem<T>[]
   placeholder?: string
+  containerRef?: Ref<HTMLDivElement>
 } & InputBaseProps
 
 // don't use React.FC so we can use a generic type on a component
@@ -25,9 +26,9 @@ const Select = <T,>({
   value,
   disabled,
   onChange,
-  customRef,
+  containerRef,
   ...inputBaseProps
-}: SelectProps<T> & { customRef?: Ref<HTMLDivElement> }) => {
+}: SelectProps<T>) => {
   const itemsValues = items.map((item) => item.value)
 
   const handleItemSelect = (changes: UseSelectStateChange<T>) => {
@@ -48,7 +49,7 @@ const Select = <T,>({
 
   return (
     <InputBase error={error} disabled={disabled} {...inputBaseProps} isSelect={true}>
-      <SelectWrapper ref={customRef}>
+      <SelectWrapper ref={containerRef}>
         <label {...getLabelProps()} tabIndex={disabled ? -1 : 0}>
           {label && <StyledLabelText>{label}</StyledLabelText>}
         </label>

--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Ref } from 'react'
 import InputBase, { InputBaseProps } from '../InputBase'
 import { SelectButton, SelectMenu, SelectOption, SelectWrapper, StyledLabelText } from './Select.style'
 import { useSelect, UseSelectStateChange } from 'downshift'
@@ -25,8 +25,9 @@ const Select = <T,>({
   value,
   disabled,
   onChange,
+  customRef,
   ...inputBaseProps
-}: SelectProps<T>) => {
+}: SelectProps<T> & { customRef?: Ref<HTMLDivElement> }) => {
   const itemsValues = items.map((item) => item.value)
 
   const handleItemSelect = (changes: UseSelectStateChange<T>) => {
@@ -47,7 +48,7 @@ const Select = <T,>({
 
   return (
     <InputBase error={error} disabled={disabled} {...inputBaseProps} isSelect={true}>
-      <SelectWrapper>
+      <SelectWrapper ref={customRef}>
         <label {...getLabelProps()} tabIndex={disabled ? -1 : 0}>
           {label && <StyledLabelText>{label}</StyledLabelText>}
         </label>

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -144,6 +144,8 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
       700
     )
   )
+  const categorySelectRef = useRef<HTMLDivElement>(null)
+  const isExplicitInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (tabDataLoading || !tabData || !selectedVideoTab) {
@@ -329,8 +331,15 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="category"
               control={control}
               rules={requiredValidation('Video category')}
+              onFocus={() => {
+                categorySelectRef.current?.scrollIntoView({
+                  behavior: 'smooth',
+                  block: 'start',
+                })
+              }}
               render={({ value, onChange }) => (
                 <Select
+                  customRef={categorySelectRef}
                   value={value ?? null}
                   items={categoriesSelectItems}
                   onChange={(value) => {
@@ -370,9 +379,16 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => value !== null,
               }}
+              onFocus={() => {
+                isExplicitInputRef.current?.scrollIntoView({
+                  behavior: 'smooth',
+                  block: 'start',
+                })
+              }}
               render={({ value, onChange }) => (
                 <StyledRadioContainer>
                   <RadioButton
+                    ref={isExplicitInputRef}
                     value="false"
                     label="All audiences"
                     onChange={() => {

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -339,7 +339,7 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               }}
               render={({ value, onChange }) => (
                 <Select
-                  customRef={categorySelectRef}
+                  containerRef={categorySelectRef}
                   value={value ?? null}
                   items={categoriesSelectItems}
                   onChange={(value) => {

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -241,6 +241,13 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
     }
   }
 
+  const handleFieldFocus = (ref: React.RefObject<HTMLElement>) => {
+    ref.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    })
+  }
+
   const categoriesSelectItems: SelectItem[] =
     categories?.map((c) => ({
       name: c.name || 'Unknown category',
@@ -331,12 +338,7 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="category"
               control={control}
               rules={requiredValidation('Video category')}
-              onFocus={() => {
-                categorySelectRef.current?.scrollIntoView({
-                  behavior: 'smooth',
-                  block: 'start',
-                })
-              }}
+              onFocus={() => handleFieldFocus(categorySelectRef)}
               render={({ value, onChange }) => (
                 <Select
                   containerRef={categorySelectRef}
@@ -379,12 +381,7 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => value !== null,
               }}
-              onFocus={() => {
-                isExplicitInputRef.current?.scrollIntoView({
-                  behavior: 'smooth',
-                  block: 'start',
-                })
-              }}
+              onFocus={() => handleFieldFocus(isExplicitInputRef)}
               render={({ value, onChange }) => (
                 <StyledRadioContainer>
                   <RadioButton


### PR DESCRIPTION
Fix: #560 

Came up with this solution to scroll into the errored required fields as react-use-form wasn't doing it by default for some reason.