### PR TITLE
Fix issue with missing assets when editing video

### DIFF
--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -133,6 +133,9 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
   })
 
   useEffect(() => {
+    if (isEdit) {
+      return
+    }
     // reset multifileselect when sheetState is closed
     if (sheetState === 'closed') {
       setValue('assets', {
@@ -140,7 +143,7 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
         thumbnail: null,
       })
     }
-  }, [sheetState, setValue])
+  }, [sheetState, setValue, isEdit])
 
   // we pass the functions explicitly so the debounced function doesn't need to change when those functions change
   const debouncedDraftSave = useRef(


### PR DESCRIPTION
There was a bug with the missing thumbnail and video when a user was trying to edit the video. It looked like this: 
![thumbnail bug](https://user-images.githubusercontent.com/51168865/118010181-13265680-b34f-11eb-97c3-919ab6bbd9ef.gif)

This PR should fix the problem