### PR TITLE
hide unknown interrupted videos and followed channels

### DIFF
--- a/src/components/ChannelLink/ChannelLink.tsx
+++ b/src/components/ChannelLink/ChannelLink.tsx
@@ -15,6 +15,7 @@ type ChannelLinkProps = {
   overrideChannel?: BasicChannelFieldsFragment
   avatarSize?: AvatarSize
   className?: string
+  onNotFound?: () => void
 }
 
 const ChannelLink: React.FC<ChannelLinkProps> = ({
@@ -24,9 +25,15 @@ const ChannelLink: React.FC<ChannelLinkProps> = ({
   noLink,
   overrideChannel,
   avatarSize = 'default',
+  onNotFound,
   className,
 }) => {
-  const { channel } = useBasicChannel(id || '', { fetchPolicy: 'cache-first', skip: !id })
+  const { channel } = useBasicChannel(id || '', {
+    fetchPolicy: 'cache-first',
+    skip: !id,
+    onCompleted: (data) => !data && onNotFound?.(),
+    onError: (error) => console.error('Failed to fetch channel', error),
+  })
   const { getAssetUrl } = useAsset()
 
   const displayedChannel = overrideChannel || channel

--- a/src/components/ChannelLink/ChannelLink.tsx
+++ b/src/components/ChannelLink/ChannelLink.tsx
@@ -29,7 +29,6 @@ const ChannelLink: React.FC<ChannelLinkProps> = ({
   className,
 }) => {
   const { channel } = useBasicChannel(id || '', {
-    fetchPolicy: 'cache-first',
     skip: !id,
     onCompleted: (data) => !data && onNotFound?.(),
     onError: (error) => console.error('Failed to fetch channel', error),

--- a/src/components/InterruptedVideosGallery.tsx
+++ b/src/components/InterruptedVideosGallery.tsx
@@ -25,7 +25,7 @@ const InterruptedVideosGallery: React.FC<RouteComponentProps> = () => {
   }
 
   const onVideoNotFound = (id: string) => {
-    console.warn(`interrupted video not found, removing id: ${id}`)
+    console.warn(`Interrupted video not found, removing id: ${id}`)
     updateWatchedVideos('REMOVED', id)
   }
 

--- a/src/components/InterruptedVideosGallery.tsx
+++ b/src/components/InterruptedVideosGallery.tsx
@@ -24,6 +24,11 @@ const InterruptedVideosGallery: React.FC<RouteComponentProps> = () => {
     updateWatchedVideos('REMOVED', id)
   }
 
+  const onVideoNotFound = (id: string) => {
+    console.warn(`interrupted video not found, removing id: ${id}`)
+    updateWatchedVideos('REMOVED', id)
+  }
+
   return (
     <VideoGallery
       title="Continue watching"
@@ -31,6 +36,7 @@ const InterruptedVideosGallery: React.FC<RouteComponentProps> = () => {
       loading={false}
       removeButton
       onRemoveButtonClick={onRemoveButtonClick}
+      onVideoNotFound={onVideoNotFound}
     />
   )
 }

--- a/src/components/Sidenav/ViewerSidenav/FollowedChannels.tsx
+++ b/src/components/Sidenav/ViewerSidenav/FollowedChannels.tsx
@@ -20,9 +20,15 @@ type FollowedChannelsProps = {
   followedChannels: FollowedChannel[]
   expanded: boolean
   onClick: () => void
+  onChannelNotFound?: (id: string) => void
 }
 
-const FollowedChannels: React.FC<FollowedChannelsProps> = ({ followedChannels, expanded, onClick }) => {
+const FollowedChannels: React.FC<FollowedChannelsProps> = ({
+  followedChannels,
+  expanded,
+  onClick,
+  onChannelNotFound,
+}) => {
   const [isShowingMore, setIsShowingMore] = useState(false)
 
   const numberOfChannels = followedChannels.length
@@ -41,7 +47,7 @@ const FollowedChannels: React.FC<FollowedChannelsProps> = ({ followedChannels, e
           <ChannelsList>
             {channels.map(({ id }) => (
               <ChannelsItem key={id} onClick={onClick}>
-                <StyledChannelLink id={id} />
+                <StyledChannelLink id={id} onNotFound={() => onChannelNotFound?.(id)} />
               </ChannelsItem>
             ))}
           </ChannelsList>

--- a/src/components/Sidenav/ViewerSidenav/ViewerSidenav.tsx
+++ b/src/components/Sidenav/ViewerSidenav/ViewerSidenav.tsx
@@ -32,7 +32,7 @@ export const ViewerSidenav: React.FC = () => {
   } = usePersonalData()
 
   const handleChannelNotFound = (id: string) => {
-    console.warn(`followed channel not found, removing id: ${id}`)
+    console.warn(`Followed channel not found, removing id: ${id}`)
     updateChannelFollowing(id, false)
   }
 

--- a/src/components/Sidenav/ViewerSidenav/ViewerSidenav.tsx
+++ b/src/components/Sidenav/ViewerSidenav/ViewerSidenav.tsx
@@ -28,7 +28,13 @@ export const ViewerSidenav: React.FC = () => {
   const [expanded, setExpanded] = useState(false)
   const {
     state: { followedChannels },
+    updateChannelFollowing,
   } = usePersonalData()
+
+  const handleChannelNotFound = (id: string) => {
+    console.warn(`followed channel not found, removing id: ${id}`)
+    updateChannelFollowing(id, false)
+  }
 
   return (
     <SidenavBase
@@ -36,7 +42,12 @@ export const ViewerSidenav: React.FC = () => {
       toggleSideNav={setExpanded}
       items={viewerSidenavItems}
       additionalContent={
-        <FollowedChannels onClick={() => setExpanded(false)} followedChannels={followedChannels} expanded={expanded} />
+        <FollowedChannels
+          onClick={() => setExpanded(false)}
+          onChannelNotFound={handleChannelNotFound}
+          followedChannels={followedChannels}
+          expanded={expanded}
+        />
       }
       buttonsContent={
         <>

--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -25,6 +25,7 @@ type VideoGalleryProps = {
   loading?: boolean
   removeButton?: boolean
   onRemoveButtonClick?: (id: string) => void
+  onVideoNotFound?: (id: string) => void
   onVideoClick?: (id: string) => void
 }
 
@@ -51,6 +52,7 @@ const VideoGallery: React.FC<VideoGalleryProps> = ({
   onVideoClick,
   removeButton,
   onRemoveButtonClick,
+  onVideoNotFound,
 }) => {
   const [coverHeight, setCoverHeight] = useState<number>()
   const onCoverResize = useCallback((_, imgHeight) => {
@@ -75,6 +77,7 @@ const VideoGallery: React.FC<VideoGalleryProps> = ({
   }))
   const createClickHandler = (id?: string) => () => id && onVideoClick && onVideoClick(id)
   const createRemoveButtonClickHandler = (id?: string) => () => id && onRemoveButtonClick && onRemoveButtonClick(id)
+  const createNotFoundHandler = (id?: string) => () => id && onVideoNotFound && onVideoNotFound(id)
   return (
     <Gallery
       title={title}
@@ -92,6 +95,7 @@ const VideoGallery: React.FC<VideoGalleryProps> = ({
           removeButton={video ? removeButton : false}
           onCoverResize={onCoverResize}
           onClick={createClickHandler(video.id)}
+          onNotFound={createNotFoundHandler(video.id)}
           onRemoveButtonClick={createRemoveButtonClickHandler(video.id)}
         />
       ))}


### PR DESCRIPTION
Resolve #686

If we fail to fetch an interrupted video or followed channel, we delete it from the respective list