### PR TITLE
react-hook-form v7 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-docgen-typescript-loader": "^3.7.1",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.3.1",
-    "react-hook-form": "^6.15.3",
+    "react-hook-form": "^7.8.1",
     "react-intersection-observer": "^8.31.0",
     "react-number-format": "^4.4.4",
     "react-player": "^2.2.0",

--- a/src/shared/components/Datepicker/Datepicker.tsx
+++ b/src/shared/components/Datepicker/Datepicker.tsx
@@ -8,7 +8,7 @@ const DATE_FORMAT = 'dd/MM/yyyy'
 
 export type DatepickerProps = {
   name?: string
-  value?: Date
+  value?: Date | null
   required?: boolean
   error?: boolean
   disabled?: boolean

--- a/src/utils/formValidationOptions.ts
+++ b/src/utils/formValidationOptions.ts
@@ -1,15 +1,5 @@
+import { RegisterOptions, Validate } from 'react-hook-form'
 import { isValid } from 'date-fns'
-import { ValidationRule, Message, Validate } from 'react-hook-form'
-
-type RegisterOptions = Partial<{
-  required: Message | ValidationRule<boolean>
-  min: ValidationRule<number | string>
-  max: ValidationRule<number | string>
-  maxLength: ValidationRule<number | string>
-  minLength: ValidationRule<number | string>
-  pattern: ValidationRule<RegExp>
-  validate: Validate | Record<string, Validate>
-}>
 
 type TextValidationArgs = {
   name: string
@@ -18,7 +8,7 @@ type TextValidationArgs = {
   required?: boolean
   pattern?: RegExp
   patternMessage?: string
-  validate?: Validate
+  validate?: Validate<string>
 }
 
 export const textFieldValidation = ({
@@ -61,7 +51,7 @@ export const requiredValidation: (name: string) => RegisterOptions = (name) => (
 })
 
 // Validates DD/MM/YYYY formatted dates
-export const pastDateValidation = (date: Date, required = false) => {
+export const pastDateValidation = (date: Date | null, required = false) => {
   if (!date) return !required
 
   if (!isValid(date)) return false

--- a/src/utils/formValidationOptions.ts
+++ b/src/utils/formValidationOptions.ts
@@ -1,5 +1,5 @@
-import { RegisterOptions, Validate } from 'react-hook-form'
 import { isValid } from 'date-fns'
+import { RegisterOptions, Validate } from 'react-hook-form'
 
 type TextValidationArgs = {
   name: string

--- a/src/views/playground/Playgrounds/PlaygroundValidationForm.tsx
+++ b/src/views/playground/Playgrounds/PlaygroundValidationForm.tsx
@@ -33,7 +33,15 @@ type Inputs = {
 }
 
 const PlaygroundValidationForm = () => {
-  const { register, handleSubmit, control, setValue, reset, clearErrors, errors } = useForm<Inputs>({
+  const {
+    register,
+    handleSubmit,
+    control,
+    setValue,
+    reset,
+    clearErrors,
+    formState: { errors },
+  } = useForm<Inputs>({
     shouldFocusError: false,
     defaultValues: {
       title: '',
@@ -55,8 +63,7 @@ const PlaygroundValidationForm = () => {
     <>
       <form onSubmit={onSubmit}>
         <HeaderTextField
-          name="header"
-          ref={register(textFieldValidation({ name: 'Channel name', minLength: 3, maxLength: 20 }))}
+          {...register('header', textFieldValidation({ name: 'Channel name', minLength: 3, maxLength: 20 }))}
           value="Lorem ipsum"
           error={!!errors.header}
           helperText={errors.header?.message}
@@ -64,9 +71,8 @@ const PlaygroundValidationForm = () => {
 
         <FormField title="Title" description="Lorem ipsum dolor sit amet">
           <TextField
-            name="title"
             label="Title"
-            ref={register(textFieldValidation({ name: 'Title', minLength: 3, maxLength: 20 }))}
+            {...register('title', textFieldValidation({ name: 'Title', minLength: 3, maxLength: 20 }))}
             error={!!errors.title}
             helperText={errors.title?.message}
           />
@@ -76,8 +82,8 @@ const PlaygroundValidationForm = () => {
           <Controller
             name="selectedVideoVisibility"
             control={control}
-            rules={{ validate: (data) => data === true || data === false }}
-            render={({ value, onChange }) => (
+            rules={{ validate: (data) => data !== null }}
+            render={({ field: { value, onChange } }) => (
               <Select
                 items={items}
                 onChange={onChange}
@@ -91,13 +97,17 @@ const PlaygroundValidationForm = () => {
         <FormField title="Marketing" description="Lorem ipsum dolor sit amet.">
           <StyledCheckboxContainer>
             <Controller
-              as={Checkbox}
               name="check"
               rules={{ required: true }}
-              error={!!errors.check}
               control={control}
-              value={false}
-              label="My video features a paid promotion material"
+              render={({ field: { value, onChange } }) => (
+                <Checkbox
+                  value={value}
+                  error={!!errors.check}
+                  label="My video features a paid promotion material"
+                  onChange={onChange}
+                />
+              )}
             />
           </StyledCheckboxContainer>
         </FormField>
@@ -122,7 +132,7 @@ const PlaygroundValidationForm = () => {
             name="radioGroup"
             control={control}
             rules={{ required: true }}
-            render={(props) => (
+            render={({ field: { value } }) => (
               <StyledRadioContainer>
                 <RadioButton
                   value="all"
@@ -131,7 +141,7 @@ const PlaygroundValidationForm = () => {
                     clearErrors('radioGroup')
                     setValue('radioGroup', e.currentTarget.value)
                   }}
-                  selectedValue={props.value}
+                  selectedValue={value}
                   error={!!errors.radioGroup}
                 />
                 <RadioButton
@@ -141,7 +151,7 @@ const PlaygroundValidationForm = () => {
                     clearErrors('radioGroup')
                     setValue('radioGroup', e.currentTarget.value)
                   }}
-                  selectedValue={props.value}
+                  selectedValue={value}
                   error={!!errors.radioGroup}
                 />
               </StyledRadioContainer>
@@ -151,8 +161,7 @@ const PlaygroundValidationForm = () => {
 
         <FormField title="Description">
           <TextArea
-            name="textarea"
-            ref={register(textFieldValidation({ name: 'Description', minLength: 3, maxLength: 20 }))}
+            {...register('textarea', textFieldValidation({ name: 'Description', minLength: 3, maxLength: 20 }))}
             maxLength={20}
             error={!!errors.textarea}
             helperText={errors.textarea?.message}

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -96,10 +96,9 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
     register,
     handleSubmit: createSubmitHandler,
     control,
-    formState: { isDirty, dirtyFields },
+    formState: { isDirty, dirtyFields, errors },
     watch,
     reset,
-    errors,
   } = useForm<Inputs>({
     defaultValues: {
       avatar: { url: null, blob: null, assetDimensions: null, imageCropData: null },
@@ -356,7 +355,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
         <Controller
           name="cover"
           control={control}
-          render={({ value, onChange }) => (
+          render={({ field: { value, onChange } }) => (
             <>
               <ChannelCover
                 coverPhotoUrl={loading ? null : value.url}
@@ -387,7 +386,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
           <Controller
             name="avatar"
             control={control}
-            render={({ value, onChange }) => (
+            render={({ field: { value, onChange } }) => (
               <>
                 <StyledAvatar
                   imageUrl={value.url}
@@ -421,7 +420,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
                   name="title"
                   control={control}
                   rules={textFieldValidation({ name: 'Channel name', minLength: 3, maxLength: 40, required: true })}
-                  render={({ value, onChange }) => (
+                  render={({ field: { value, onChange } }) => (
                     <Tooltip text="Click to edit channel title">
                       <StyledHeaderTextField
                         ref={titleRef}
@@ -454,15 +453,13 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
           <FormField title="Description">
             <Tooltip text="Click to edit channel description">
               <TextArea
-                name="description"
                 placeholder="Description of your channel to share with your audience"
                 rows={8}
-                ref={(ref) => {
-                  if (ref) {
-                    register(ref, textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 }))
-                    descriptionRef.current = ref
-                  }
-                }}
+                {...register(
+                  'description',
+                  textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 })
+                )}
+                ref={descriptionRef}
                 maxLength={1000}
                 error={!!errors.description}
                 helperText={errors.description?.message}
@@ -474,7 +471,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
               name="language"
               control={control}
               rules={requiredValidation('Language')}
-              render={({ value, onChange }) => (
+              render={({ field: { value, onChange } }) => (
                 <Select
                   items={languages}
                   disabled={loading}
@@ -494,7 +491,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
             <Controller
               name="isPublic"
               control={control}
-              render={({ value, onChange }) => (
+              render={({ field: { value, onChange } }) => (
                 <Select
                   items={PUBLIC_SELECT_ITEMS}
                   disabled={loading}

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -98,6 +98,7 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
     control,
     formState: { isDirty, dirtyFields, errors },
     watch,
+    setFocus,
     reset,
   } = useForm<Inputs>({
     defaultValues: {
@@ -109,9 +110,6 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
       isPublic: true,
     },
   })
-
-  const titleRef = useRef<HTMLInputElement | null>(null)
-  const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
 
   const { sheetState, anyVideoTabsCachedAssets, setSheetState } = useEditVideoSheet()
   const { openWarningDialog } = useDisplayDataLostWarning()
@@ -327,12 +325,12 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
     {
       title: 'Add channel title',
       completed: !!dirtyFields.title,
-      onClick: () => titleRef.current?.focus(),
+      onClick: () => setFocus('title'),
     },
     {
       title: 'Add description',
       completed: !!dirtyFields.description,
-      onClick: () => descriptionRef.current?.focus(),
+      onClick: () => setFocus('description'),
     },
     {
       title: 'Add avatar image',
@@ -420,10 +418,10 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
                   name="title"
                   control={control}
                   rules={textFieldValidation({ name: 'Channel name', minLength: 3, maxLength: 40, required: true })}
-                  render={({ field: { value, onChange } }) => (
+                  render={({ field: { ref, value, onChange } }) => (
                     <Tooltip text="Click to edit channel title">
                       <StyledHeaderTextField
-                        ref={titleRef}
+                        ref={ref}
                         placeholder="Channel title"
                         value={value}
                         onChange={(e) => {
@@ -452,22 +450,16 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
         <InnerFormContainer>
           <FormField title="Description">
             <Tooltip text="Click to edit channel description">
-              <Controller
-                name="description"
-                control={control}
-                rules={textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 })}
-                render={({ field: { value, onChange } }) => (
-                  <TextArea
-                    placeholder="Description of your channel to share with your audience"
-                    rows={8}
-                    ref={descriptionRef}
-                    value={value}
-                    onChange={onChange}
-                    maxLength={1000}
-                    error={!!errors.description}
-                    helperText={errors.description?.message}
-                  />
+              <TextArea
+                placeholder="Description of your channel to share with your audience"
+                rows={8}
+                {...register(
+                  'description',
+                  textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 })
                 )}
+                maxLength={1000}
+                error={!!errors.description}
+                helperText={errors.description?.message}
               />
             </Tooltip>
           </FormField>

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -452,17 +452,22 @@ const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChanne
         <InnerFormContainer>
           <FormField title="Description">
             <Tooltip text="Click to edit channel description">
-              <TextArea
-                placeholder="Description of your channel to share with your audience"
-                rows={8}
-                {...register(
-                  'description',
-                  textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 })
+              <Controller
+                name="description"
+                control={control}
+                rules={textFieldValidation({ name: 'Description', minLength: 3, maxLength: 1000 })}
+                render={({ field: { value, onChange } }) => (
+                  <TextArea
+                    placeholder="Description of your channel to share with your audience"
+                    rows={8}
+                    ref={descriptionRef}
+                    value={value}
+                    onChange={onChange}
+                    maxLength={1000}
+                    error={!!errors.description}
+                    helperText={errors.description?.message}
+                  />
                 )}
-                ref={descriptionRef}
-                maxLength={1000}
-                error={!!errors.description}
-                helperText={errors.description?.message}
               />
             </Tooltip>
           </FormField>

--- a/src/views/studio/CreateMemberView/CreateMemberView.tsx
+++ b/src/views/studio/CreateMemberView/CreateMemberView.tsx
@@ -38,7 +38,11 @@ const CreateMemberView = () => {
   const { nodeConnectionStatus } = useConnectionStatus()
 
   const navigate = useNavigate()
-  const { register, handleSubmit, errors } = useForm<Inputs>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Inputs>({
     shouldFocusError: false,
     defaultValues: {
       handle: '',
@@ -148,11 +152,10 @@ const CreateMemberView = () => {
       <Form onSubmit={handleCreateMember}>
         <StyledAvatar size="view" imageUrl={errors.avatar ? undefined : avatarImageUrl} />
         <StyledTextField
-          name="avatar"
-          onChange={(e) => debouncedHandleAvatarChange.current(e.target.value)}
           label="Avatar URL"
           placeholder="https://example.com/avatar.jpeg"
-          ref={register(
+          {...register(
+            'avatar',
             textFieldValidation({
               name: 'Avatar URL',
               pattern: URL_PATTERN,
@@ -162,14 +165,15 @@ const CreateMemberView = () => {
               validate: debouncedAvatarValidation.current,
             })
           )}
+          onChange={(e) => debouncedHandleAvatarChange.current(e.target.value)}
           error={!!errors.avatar}
           helperText={errors.avatar?.message}
         />
         <StyledTextField
-          name="handle"
           placeholder="johnnysmith"
           label="Member handle"
-          ref={register(
+          {...register(
+            'handle',
             textFieldValidation({
               name: 'Member handle',
               maxLength: 40,
@@ -186,11 +190,10 @@ const CreateMemberView = () => {
           }
         />
         <TextArea
-          name="about"
           label="About"
           placeholder="Anything you'd like to share about yourself with the Joystream community"
           maxLength={1000}
-          ref={register(textFieldValidation({ name: 'About', maxLength: 1000 }))}
+          {...register('about', textFieldValidation({ name: 'About', maxLength: 1000 }))}
           error={!!errors.about}
           helperText={errors.about?.message}
         />

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -270,16 +270,33 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
     }
   )
 
-  watch((data) => {
-    if (!Object.keys(dirtyFields).length) {
-      return
+  useEffect(() => {
+    const subscription = watch((data) => {
+      if (!Object.keys(dirtyFields).length) {
+        return
+      }
+      if (!selectedVideoTab?.isDraft) {
+        debouncedSetSelectedVideoTabCachedDirtyFormData.current(
+          data,
+          dirtyFields,
+          setSelectedVideoTabCachedDirtyFormData
+        )
+      } else {
+        debouncedDraftSave.current(selectedVideoTab, data, addDraft, updateDraft, updateSelectedVideoTab)
+      }
+    })
+    return () => {
+      subscription.unsubscribe()
     }
-    if (!selectedVideoTab?.isDraft) {
-      debouncedSetSelectedVideoTabCachedDirtyFormData.current(data, dirtyFields, setSelectedVideoTabCachedDirtyFormData)
-    } else {
-      debouncedDraftSave.current(selectedVideoTab, data, addDraft, updateDraft, updateSelectedVideoTab)
-    }
-  })
+  }, [
+    addDraft,
+    dirtyFields,
+    selectedVideoTab,
+    setSelectedVideoTabCachedDirtyFormData,
+    updateDraft,
+    updateSelectedVideoTab,
+    watch,
+  ])
 
   const handleVideoFileChange = async (video: VideoInputFile | null) => {
     const updatedAssets = {

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -373,12 +373,11 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => value !== null,
               }}
-              render={({ field: { value, onChange } }) => (
+              render={({ field }) => (
                 <Select
-                  value={value}
+                  {...field}
                   items={visibilityOptions}
-                  onChange={onChange}
-                  error={!!errors.isPublic && !value}
+                  error={!!errors.isPublic && !field.value}
                   helperText={errors.isPublic ? 'Video visibility must be selected' : ''}
                 />
               )}
@@ -389,12 +388,11 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="language"
               control={control}
               rules={requiredValidation('Video language')}
-              render={({ field: { value, onChange } }) => (
+              render={({ field }) => (
                 <Select
-                  value={value ?? null}
+                  {...field}
                   items={languages}
-                  onChange={onChange}
-                  error={!!errors.language && !value}
+                  error={!!errors.language && !field.value}
                   helperText={errors.language?.message}
                 />
               )}
@@ -405,15 +403,14 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="category"
               control={control}
               rules={requiredValidation('Video category')}
-              render={({ field: { value, onChange }, fieldState: { invalid } }) => {
+              render={({ field, fieldState: { invalid } }) => {
                 if (invalid) handleFieldFocus(categorySelectRef)
                 return (
                   <Select
+                    {...field}
                     containerRef={categorySelectRef}
-                    value={value ?? null}
                     items={categoriesSelectItems}
-                    onChange={onChange}
-                    error={!!errors.category && !value}
+                    error={!!errors.category && !field.value}
                     helperText={errors.category?.message}
                   />
                 )
@@ -425,16 +422,15 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="licenseCode"
               control={control}
               rules={requiredValidation('License')}
-              render={({ field: { value, onChange }, fieldState: { invalid } }) => {
+              render={({ field, fieldState: { invalid } }) => {
                 if (invalid) handleFieldFocus(licenseSelectRef)
                 return (
                   <Select
+                    {...field}
                     containerRef={licenseSelectRef}
-                    value={value ?? null}
                     items={knownLicensesOptions}
                     placeholder="Choose license type"
-                    onChange={onChange}
-                    error={!!errors.licenseCode && !value}
+                    error={!!errors.licenseCode && !field.value}
                     helperText={errors.licenseCode?.message}
                   />
                 )
@@ -530,10 +526,9 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => pastDateValidation(value),
               }}
-              render={({ field: { value, onChange } }) => (
+              render={({ field }) => (
                 <Datepicker
-                  value={value}
-                  onChange={onChange}
+                  {...field}
                   error={!!errors.publishedBeforeJoystream}
                   helperText={errors.publishedBeforeJoystream ? 'Please provide a valid date.' : ''}
                 />

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -373,11 +373,12 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => value !== null,
               }}
-              render={({ field }) => (
+              render={({ field: { value, onChange } }) => (
                 <Select
-                  {...field}
+                  value={value}
                   items={visibilityOptions}
-                  error={!!errors.isPublic && !field.value}
+                  onChange={onChange}
+                  error={!!errors.isPublic && !value}
                   helperText={errors.isPublic ? 'Video visibility must be selected' : ''}
                 />
               )}
@@ -388,11 +389,12 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="language"
               control={control}
               rules={requiredValidation('Video language')}
-              render={({ field }) => (
+              render={({ field: { value, onChange } }) => (
                 <Select
-                  {...field}
+                  value={value}
                   items={languages}
-                  error={!!errors.language && !field.value}
+                  onChange={onChange}
+                  error={!!errors.language && !value}
                   helperText={errors.language?.message}
                 />
               )}
@@ -403,14 +405,15 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="category"
               control={control}
               rules={requiredValidation('Video category')}
-              render={({ field, fieldState: { invalid } }) => {
+              render={({ field: { value, onChange }, fieldState: { invalid } }) => {
                 if (invalid) handleFieldFocus(categorySelectRef)
                 return (
                   <Select
-                    {...field}
                     containerRef={categorySelectRef}
+                    value={value}
                     items={categoriesSelectItems}
-                    error={!!errors.category && !field.value}
+                    onChange={onChange}
+                    error={!!errors.category && !value}
                     helperText={errors.category?.message}
                   />
                 )
@@ -422,15 +425,16 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               name="licenseCode"
               control={control}
               rules={requiredValidation('License')}
-              render={({ field, fieldState: { invalid } }) => {
+              render={({ field: { value, onChange }, fieldState: { invalid } }) => {
                 if (invalid) handleFieldFocus(licenseSelectRef)
                 return (
                   <Select
-                    {...field}
                     containerRef={licenseSelectRef}
+                    value={value}
                     items={knownLicensesOptions}
                     placeholder="Choose license type"
-                    error={!!errors.licenseCode && !field.value}
+                    onChange={onChange}
+                    error={!!errors.licenseCode && !value}
                     helperText={errors.licenseCode?.message}
                   />
                 )
@@ -526,9 +530,10 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               rules={{
                 validate: (value) => pastDateValidation(value),
               }}
-              render={({ field }) => (
+              render={({ field: { value, onChange } }) => (
                 <Datepicker
-                  {...field}
+                  value={value}
+                  onChange={onChange}
                   error={!!errors.publishedBeforeJoystream}
                   helperText={errors.publishedBeforeJoystream ? 'Please provide a valid date.' : ''}
                 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -17380,10 +17380,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^6.15.3:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.3.tgz#ab4ccad9cde42a121fdfb828d9aff0d3d008441f"
-  integrity sha512-593jDlfP66NlMUOW5aNlCTzFWcFAOIyeFIGQtDreVLZ6n2o5D0DBIv/F+6mGZY0kCZs7yArs/YcgZBFLm1IXbg==
+react-hook-form@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.8.1.tgz#291609c50778bf8bc94e5d4c586e9ee5c6dd512f"
+  integrity sha512-pwWxd4UfwsKVh/W2YE2Hnu7KBY4KTCZq3QO1PMISzP31AZ5Kmv6ji085QVIHVWVSLT4oX6IhmZ2bWJ2oBIwobQ==
 
 react-hotkeys@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Issue: #428 

~~For using `watch` instead of form change handler - I decided not to do that. React-hook-form documentation warns about performance issues. I did experience stuttering in video sheet when using `watch((data) => {})`. Instead handler is now being triggered by `FormWrapper` change, no need to put it on each field~~