### PR TITLE
remove forwardRef from ActionBar

### DIFF
--- a/src/shared/components/ActionBar/ActionBar.tsx
+++ b/src/shared/components/ActionBar/ActionBar.tsx
@@ -31,55 +31,52 @@ export type ActionBarProps = {
   onCancelClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-const ActionBar = React.forwardRef<HTMLDivElement, ActionBarProps>(
-  ({
-    primaryText,
-    secondaryText,
-    primaryButtonText,
-    secondaryButtonText,
-    detailsText,
-    tooltipText,
-    detailsTextIcon,
-    secondaryButtonIcon,
-    className,
-    disabled,
-    onConfirmClick,
-    onCancelClick,
-  }) => {
-    return (
-      <StyledActionBarContainer className={className}>
-        <StyledInnerContainer>
-          <StyledInfoContainer>
-            <StyledPrimaryText>{primaryText}</StyledPrimaryText>
-            <StyledSecondaryText>{secondaryText}</StyledSecondaryText>
-          </StyledInfoContainer>
-          <StyledButtonsContainer>
-            {detailsText && tooltipText && (
-              <Tooltip text={tooltipText} placement="top-end" offsetX={-6}>
-                <DetailsContainer>
-                  <Text variant="body2" secondary>
-                    {detailsText}
-                  </Text>
-                  <DetailsIconWrapper>{detailsTextIcon || <SvgGlyphInfo />}</DetailsIconWrapper>
-                </DetailsContainer>
-              </Tooltip>
-            )}
-            {secondaryButtonText && !detailsText && (
-              <Button icon={secondaryButtonIcon} onClick={onCancelClick} variant="secondary" size="large">
-                {secondaryButtonText}
-              </Button>
-            )}
-            {primaryButtonText && (
-              <Button disabled={disabled} onClick={onConfirmClick} size="large" type="submit">
-                {primaryButtonText}
-              </Button>
-            )}
-          </StyledButtonsContainer>
-        </StyledInnerContainer>
-      </StyledActionBarContainer>
-    )
-  }
-)
-ActionBar.displayName = 'ActionBar'
+const ActionBar: React.FC<ActionBarProps> = ({
+  primaryText,
+  secondaryText,
+  primaryButtonText,
+  secondaryButtonText,
+  detailsText,
+  tooltipText,
+  detailsTextIcon,
+  secondaryButtonIcon,
+  className,
+  disabled,
+  onConfirmClick,
+  onCancelClick,
+}) => {
+  return (
+    <StyledActionBarContainer className={className}>
+      <StyledInnerContainer>
+        <StyledInfoContainer>
+          <StyledPrimaryText>{primaryText}</StyledPrimaryText>
+          <StyledSecondaryText>{secondaryText}</StyledSecondaryText>
+        </StyledInfoContainer>
+        <StyledButtonsContainer>
+          {detailsText && tooltipText && (
+            <Tooltip text={tooltipText} placement="top-end" offsetX={-6}>
+              <DetailsContainer>
+                <Text variant="body2" secondary>
+                  {detailsText}
+                </Text>
+                <DetailsIconWrapper>{detailsTextIcon || <SvgGlyphInfo />}</DetailsIconWrapper>
+              </DetailsContainer>
+            </Tooltip>
+          )}
+          {secondaryButtonText && !detailsText && (
+            <Button icon={secondaryButtonIcon} onClick={onCancelClick} variant="secondary" size="large">
+              {secondaryButtonText}
+            </Button>
+          )}
+          {primaryButtonText && (
+            <Button disabled={disabled} onClick={onConfirmClick} size="large" type="submit">
+              {primaryButtonText}
+            </Button>
+          )}
+        </StyledButtonsContainer>
+      </StyledInnerContainer>
+    </StyledActionBarContainer>
+  )
+}
 
 export default ActionBar


### PR DESCRIPTION
#779 introduced error
![image](https://user-images.githubusercontent.com/51168865/122088467-07262c80-ce06-11eb-9604-7b6a11d357ff.png)
I think we don't actually need this `forwardRef` here( we don't pass `ref` anywhere), so I think we could just get rid of it.