### PR TITLE
Add feeder.sh in-app feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "date-fns": "^2.15.0",
     "downshift": "^6.1.0",
     "emotion-normalize": "~11.0.0",
+    "feeder-react-feedback": "^0.0.6",
     "glider-js": "^1.7.3",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",

--- a/src/MainLayout.tsx
+++ b/src/MainLayout.tsx
@@ -1,4 +1,6 @@
 import loadable from '@loadable/component'
+import Feedback from 'feeder-react-feedback'
+import 'feeder-react-feedback/dist/feeder-react-feedback.css'
 import React, { useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
@@ -42,6 +44,7 @@ export const MainLayout: React.FC = () => {
 
   return (
     <>
+      <Feedback projectId="60d97fe1f85c5e0004270d70" />;
       <GlobalStyle additionalStyles={[routingTransitions]} />
       <BrowserRouter>
         <Routes>

--- a/src/types/feeder-react-feedback.d.ts
+++ b/src/types/feeder-react-feedback.d.ts
@@ -1,0 +1,1 @@
+declare module 'feeder-react-feedback'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10686,6 +10686,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+feeder-react-feedback@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/feeder-react-feedback/-/feeder-react-feedback-0.0.6.tgz#78a2044da24da217f5fa760cdbf841474ebb8546"
+  integrity sha512-BdilgLncuOdoFFC0Da3wYMIYODSxZaH3vUS4662QUTzKOGrGrc63yDywRFw2x4b30Kie3kwD4z3rXcaTznq7Mg==
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"


### PR DESCRIPTION
I'm adding this module:
https://feeder.sh/

#879
It enables user feedback, we have to create an account and change the projectId to one of yours. Right now I have a own account and made projectId, but its not a blockchain solution. (Preview is also on the website)

Was not sure about the .css file. Without .d.ts type file, it would give an error.

Was also not sure if I would implement in App.tsx or Mainlayout, just chose MainLayout for now.

It's kind of hard to see, because the background is black too, but works well.

Picture:
![image](https://user-images.githubusercontent.com/25594670/123612392-c87b7380-d802-11eb-813e-676ab84f7a73.png)

Received feedback on feeder.sh:
![image](https://user-images.githubusercontent.com/25594670/123612543-f1036d80-d802-11eb-8611-83d3bc2dd14e.png)