### PR TITLE
Add tooltips to player controls

### DIFF
--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -183,6 +183,9 @@ export const CurrentTime = styled(Text)`
 `
 
 export const ScreenControls = styled.div`
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 0.5em;
   margin-left: auto;
   display: flex;
 
@@ -382,4 +385,16 @@ export const BigPlayButton = styled(ControlButton)`
     width: ${sizes(10)} !important;
     height: ${sizes(10)} !important;
   }
+`
+
+export const ControlTooltip = styled(Text)`
+  font-size: 0.875em;
+  background: ${colors.transparentBlack[54]};
+  backdrop-filter: blur(${sizes(8)});
+  display: flex;
+  align-items: center;
+  padding: 0.5em;
+  flex: none;
+  order: 1;
+  flex-grow: 0;
 `

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -83,16 +83,6 @@ export const ControlButton = styled.button<ControlButtonProps>`
     height: 1.5em;
   }
 
-  :hover {
-    background-color: ${colors.transparentPrimary[18]};
-    backdrop-filter: blur(${sizes(8)});
-    transition: none !important;
-  }
-
-  :active {
-    background-color: ${colors.transparentPrimary[10]};
-  }
-
   ::before {
     ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
     ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
@@ -112,7 +102,21 @@ export const ControlButton = styled.button<ControlButtonProps>`
     transition: opacity ${transitions.timings.player} ease-in !important;
   }
 
-  ${({ showTooltipOnlyOnFocus }) => !showTooltipOnlyOnFocus && ':hover,'}
+  :hover {
+    background-color: ${colors.transparentPrimary[18]};
+    backdrop-filter: blur(${sizes(8)});
+    transition: none !important;
+
+    ::before {
+      transition: none !important;
+      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
+    }
+  }
+
+  :active {
+    background-color: ${colors.transparentPrimary[10]};
+  }
+
   :focus {
     ::before {
       /* turn off transition on mouse enter, but turn on on mouse leave */
@@ -130,7 +134,7 @@ export const ControlButton = styled.button<ControlButtonProps>`
   :focus:not(:focus-visible):hover {
     ::before {
       transition: none !important;
-      opacity: 1;
+      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
     }
   }
 

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -246,7 +246,6 @@ export const ScreenControls = styled.div`
   grid-template-columns: auto auto;
   gap: 0.5em;
   margin-left: auto;
-  display: flex;
 
   ${ControlButton}:last-of-type {
     margin-right: 0;

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -15,6 +15,12 @@ type CustomControlsProps = {
   isEnded?: boolean
 }
 
+type ControlButtonProps = {
+  tooltipText?: string
+  tooltipPosition?: 'left' | 'right'
+  showTooltipOnlyOnFocus?: boolean
+}
+
 const focusStyles = css`
   :focus {
     /* Provide a fallback style for browsers
@@ -58,7 +64,7 @@ export const CustomControls = styled.div<CustomControlsProps>`
   transition: transform 200ms ${transitions.easing}, opacity 200ms ${transitions.easing};
 `
 
-export const ControlButton = styled.button`
+export const ControlButton = styled.button<ControlButtonProps>`
   margin-right: 0.5em;
   display: flex !important;
   cursor: pointer;
@@ -68,7 +74,8 @@ export const ControlButton = styled.button`
   align-items: center;
   justify-content: center;
   padding: 0.5em;
-  transition: background-color ${transitions.timings.player} ${transitions.easing} !important;
+  position: relative;
+  transition: opacity ${transitions.timings.player} ease-in !important;
 
   & > svg {
     filter: drop-shadow(0 1px 2px ${colors.transparentBlack[32]});
@@ -79,10 +86,58 @@ export const ControlButton = styled.button`
   :hover {
     background-color: ${colors.transparentPrimary[18]};
     backdrop-filter: blur(${sizes(8)});
+    transition: none !important;
   }
 
   :active {
     background-color: ${colors.transparentPrimary[10]};
+  }
+
+  ::before {
+    ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
+    ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
+
+    opacity: 0;
+    pointer-events: none;
+    content: ${({ tooltipText }) => tooltipText && `'${tooltipText}'`};
+    position: absolute;
+    font-size: 0.875em;
+    bottom: calc(3.5em - 1px);
+    background: ${colors.transparentBlack[54]};
+    backdrop-filter: blur(${sizes(8)});
+    display: flex;
+    align-items: center;
+    padding: 0.5em;
+    white-space: nowrap;
+    transition: opacity ${transitions.timings.player} ease-in !important;
+  }
+
+  ${({ showTooltipOnlyOnFocus }) => !showTooltipOnlyOnFocus && ':hover,'}
+  :focus {
+    ::before {
+      /* turn off transition on mouse enter, but turn on on mouse leave */
+      transition: none !important;
+      opacity: 1;
+    }
+  }
+
+  :focus-visible {
+    ::before {
+      opacity: 1;
+    }
+  }
+
+  :focus:not(:focus-visible):hover {
+    ::before {
+      transition: none !important;
+      opacity: 1;
+    }
+  }
+
+  :focus:not(:focus-visible):not(:hover) {
+    ::before {
+      opacity: 0;
+    }
   }
 
   ${focusStyles}
@@ -385,16 +440,4 @@ export const BigPlayButton = styled(ControlButton)`
     width: ${sizes(10)} !important;
     height: ${sizes(10)} !important;
   }
-`
-
-export const ControlTooltip = styled(Text)`
-  font-size: 0.875em;
-  background: ${colors.transparentBlack[54]};
-  backdrop-filter: blur(${sizes(8)});
-  display: flex;
-  align-items: center;
-  padding: 0.5em;
-  flex: none;
-  order: 1;
-  flex-grow: 0;
 `

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -75,7 +75,7 @@ export const ControlButton = styled.button<ControlButtonProps>`
   justify-content: center;
   padding: 0.5em;
   position: relative;
-  transition: opacity ${transitions.timings.player} ease-in !important;
+  transition: background ${transitions.timings.player} ease-in !important;
 
   & > svg {
     filter: drop-shadow(0 1px 2px ${colors.transparentBlack[32]});

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -477,7 +477,7 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
   )
 }
 
-type Placement = 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end' | 'top'
+type Placement = 'top-start' | 'top-end' | 'top'
 
 type VideoControlTooltipProps = {
   placement: Placement

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -1,4 +1,3 @@
-import Tippy from '@tippyjs/react/headless'
 import { debounce } from 'lodash'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
@@ -15,7 +14,6 @@ import {
   SvgPlayerSoundHalf,
   SvgPlayerSoundOn,
 } from '@/shared/icons'
-import { transitions } from '@/shared/theme'
 import { Logger } from '@/utils/logger'
 import { formatDurationShort } from '@/utils/time'
 
@@ -429,11 +427,17 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
           <>
             <ControlsOverlay isFullScreen={isFullScreen}>
               <CustomControls isFullScreen={isFullScreen} isEnded={playerState === 'ended'}>
-                <ControlButton onClick={handlePlayPause}>
+                <ControlButton
+                  onClick={handlePlayPause}
+                  tooltipText={isPlaying ? 'Pause (k)' : 'Play (k)'}
+                  tooltipPosition="left"
+                >
                   {playerState === 'ended' ? <SvgPlayerRestart /> : isPlaying ? <SvgPlayerPause /> : <SvgPlayerPlay />}
                 </ControlButton>
                 <VolumeControl>
-                  <VolumeButton onClick={handleMute}>{renderVolumeButton()}</VolumeButton>
+                  <VolumeButton onClick={handleMute} showTooltipOnlyOnFocus tooltipText="Volume">
+                    {renderVolumeButton()}
+                  </VolumeButton>
                   <VolumeSliderContainer>
                     <VolumeSlider
                       step={0.01}
@@ -452,11 +456,15 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
                 </CurrentTimeWrapper>
                 <ScreenControls>
                   {isPiPSupported && (
-                    <ControlButton onClick={handlePictureInPicture}>
+                    <ControlButton onClick={handlePictureInPicture} tooltipText="Picture-in-picture">
                       {isPiPEnabled ? <SvgPlayerPipDisable /> : <SvgPlayerPip />}
                     </ControlButton>
                   )}
-                  <ControlButton onClick={handleFullScreen}>
+                  <ControlButton
+                    onClick={handleFullScreen}
+                    tooltipPosition="right"
+                    tooltipText={isFullScreen ? 'Exit full screen (f)' : 'Full screen (f)'}
+                  >
                     {isFullScreen ? <SvgPlayerSmallScreen /> : <SvgPlayerFullScreen />}
                   </ControlButton>
                 </ScreenControls>
@@ -474,45 +482,6 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
       </div>
       {!isInBackground && <ControlsIndicator player={player} />}
     </Container>
-  )
-}
-
-type Placement = 'top-start' | 'top-end' | 'top'
-
-type VideoControlTooltipProps = {
-  placement: Placement
-  text: string
-  onClick?: () => void
-  className?: string
-}
-
-const VideoControlWithTooltip: React.FC<VideoControlTooltipProps> = ({
-  placement,
-  children,
-  onClick,
-  text,
-  className,
-}) => {
-  const [isVisible, setIsVisible] = useState(false)
-  return (
-    <span className={className}>
-      <Tippy
-        interactive={true}
-        offset={[0, 8]}
-        onMount={() => setIsVisible(true)}
-        onHide={() => setIsVisible(false)}
-        placement={placement}
-        render={(attrs) => (
-          <CSSTransition in={isVisible} timeout={200} classNames={transitions.names.fade}>
-            <ControlTooltip variant="caption" {...attrs}>
-              {text}
-            </ControlTooltip>
-          </CSSTransition>
-        )}
-      >
-        <ControlButton onClick={onClick}>{children}</ControlButton>
-      </Tippy>
-    </span>
   )
 }
 

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -1,3 +1,4 @@
+import Tippy from '@tippyjs/react/headless'
 import { debounce } from 'lodash'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
@@ -14,6 +15,7 @@ import {
   SvgPlayerSoundHalf,
   SvgPlayerSoundOn,
 } from '@/shared/icons'
+import { transitions } from '@/shared/theme'
 import { Logger } from '@/utils/logger'
 import { formatDurationShort } from '@/utils/time'
 
@@ -472,6 +474,45 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
       </div>
       {!isInBackground && <ControlsIndicator player={player} />}
     </Container>
+  )
+}
+
+type Placement = 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end' | 'top'
+
+type VideoControlTooltipProps = {
+  placement: Placement
+  text: string
+  onClick?: () => void
+  className?: string
+}
+
+const VideoControlWithTooltip: React.FC<VideoControlTooltipProps> = ({
+  placement,
+  children,
+  onClick,
+  text,
+  className,
+}) => {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <span className={className}>
+      <Tippy
+        interactive={true}
+        offset={[0, 8]}
+        onMount={() => setIsVisible(true)}
+        onHide={() => setIsVisible(false)}
+        placement={placement}
+        render={(attrs) => (
+          <CSSTransition in={isVisible} timeout={200} classNames={transitions.names.fade}>
+            <ControlTooltip variant="caption" {...attrs}>
+              {text}
+            </ControlTooltip>
+          </CSSTransition>
+        )}
+      >
+        <ControlButton onClick={onClick}>{children}</ControlButton>
+      </Tippy>
+    </span>
   )
 }
 


### PR DESCRIPTION
Fix #937 

Figma: https://www.figma.com/file/TGUpBXgXf9ceMvHbRB5BIx/Joystream-Atlas?node-id=9977%3A263879
https://www.figma.com/file/TGUpBXgXf9ceMvHbRB5BIx/Joystream-Atlas?node-id=9164%3A0

I will tackle the timeline tooltip in another PR