### PR TITLE
Tooltip fixes

### DIFF
--- a/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
+++ b/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
@@ -89,7 +89,7 @@ export const ControlButton = styled.button<ControlButtonProps>`
     }
   }
 
-  ${focusStyles}
+  ${focusStyles};
 `
 
 type ControlButtonTooltipProps = {
@@ -103,7 +103,7 @@ export const ControlButtonTooltip = styled.div<ControlButtonTooltipProps>`
   opacity: 0;
   pointer-events: none;
   position: absolute;
-  bottom: calc(3em);
+  bottom: 3em;
   background: ${colors.transparentBlack[54]};
   backdrop-filter: blur(${sizes(8)});
   display: flex;

--- a/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
+++ b/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 
 import { colors, sizes, transitions } from '@/shared/theme'
@@ -9,24 +8,6 @@ type ControlButtonProps = {
   showTooltipOnlyOnFocus?: boolean
   disableFocus?: boolean
 }
-
-const focusStyles = css`
-  :focus {
-    /* Provide a fallback style for browsers
-     that don't support :focus-visible e.g safari */
-    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
-  }
-
-  /* https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible */
-
-  :focus-visible {
-    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
-  }
-
-  :focus:not(:focus-visible) {
-    box-shadow: unset;
-  }
-`
 
 export const ControlButton = styled.button<ControlButtonProps>`
   margin-right: 0.5em;
@@ -47,13 +28,21 @@ export const ControlButton = styled.button<ControlButtonProps>`
     height: 1.5em;
   }
 
+  :hover,
+  :focus,
+  :focus-visible {
+    /* turn off transition on mouse enter, but turn on on mouse leave */
+    transition: none !important;
+    ${() => ControlButtonTooltip} {
+      transition: none !important;
+    }
+  }
+
   :hover {
     background-color: ${colors.transparentPrimary[18]};
     backdrop-filter: blur(${sizes(8)});
-    transition: none !important;
 
     ${() => ControlButtonTooltip} {
-      transition: none !important;
       opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
     }
   }
@@ -63,22 +52,33 @@ export const ControlButton = styled.button<ControlButtonProps>`
   }
 
   :focus {
+    /* Provide a fallback style for browsers
+    that don't support :focus-visible e.g safari */
+    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
     ${() => ControlButtonTooltip} {
-      /* turn off transition on mouse enter, but turn on on mouse leave */
-      transition: none !important;
       opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
     }
   }
 
   :focus-visible {
+    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
     ${() => ControlButtonTooltip} {
       opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
     }
   }
 
+  :focus:not(:focus-visible) {
+    box-shadow: unset;
+  }
+
+  :hover:focus {
+    ${() => ControlButtonTooltip} {
+      opacity: 1;
+    }
+  }
+
   :focus:not(:focus-visible):hover {
     ${() => ControlButtonTooltip} {
-      transition: none !important;
       opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
     }
   }
@@ -88,8 +88,6 @@ export const ControlButton = styled.button<ControlButtonProps>`
       opacity: 0;
     }
   }
-
-  ${focusStyles};
 `
 
 type ControlButtonTooltipProps = {

--- a/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
+++ b/src/shared/components/VideoPlayer/PlayerControlButton.style.ts
@@ -1,0 +1,119 @@
+import { css } from '@emotion/react'
+import styled from '@emotion/styled'
+
+import { colors, sizes, transitions } from '@/shared/theme'
+
+import { Text } from '../Text'
+
+type ControlButtonProps = {
+  showTooltipOnlyOnFocus?: boolean
+  disableFocus?: boolean
+}
+
+const focusStyles = css`
+  :focus {
+    /* Provide a fallback style for browsers
+     that don't support :focus-visible e.g safari */
+    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
+  }
+
+  /* https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible */
+
+  :focus-visible {
+    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
+  }
+
+  :focus:not(:focus-visible) {
+    box-shadow: unset;
+  }
+`
+
+export const ControlButton = styled.button<ControlButtonProps>`
+  margin-right: 0.5em;
+  display: flex !important;
+  padding: 0.5em;
+  cursor: pointer;
+  border: none;
+  background: none;
+  border-radius: 100%;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: background ${transitions.timings.player} ease-in !important;
+
+  & > svg {
+    filter: drop-shadow(0 1px 2px ${colors.transparentBlack[32]});
+    width: 1.5em;
+    height: 1.5em;
+  }
+
+  :hover {
+    background-color: ${colors.transparentPrimary[18]};
+    backdrop-filter: blur(${sizes(8)});
+    transition: none !important;
+
+    ${() => ControlButtonTooltip} {
+      transition: none !important;
+      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
+    }
+  }
+
+  :active {
+    background-color: ${colors.transparentPrimary[10]};
+  }
+
+  :focus {
+    ${() => ControlButtonTooltip} {
+      /* turn off transition on mouse enter, but turn on on mouse leave */
+      transition: none !important;
+      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
+    }
+  }
+
+  :focus-visible {
+    ${() => ControlButtonTooltip} {
+      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
+    }
+  }
+
+  :focus:not(:focus-visible):hover {
+    ${() => ControlButtonTooltip} {
+      transition: none !important;
+      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
+    }
+  }
+
+  :focus:not(:focus-visible):not(:hover) {
+    ${() => ControlButtonTooltip} {
+      opacity: 0;
+    }
+  }
+
+  ${focusStyles}
+`
+
+type ControlButtonTooltipProps = {
+  tooltipPosition?: 'left' | 'right'
+}
+
+export const ControlButtonTooltip = styled.div<ControlButtonTooltipProps>`
+  ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
+  ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
+
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  bottom: calc(3em);
+  background: ${colors.transparentBlack[54]};
+  backdrop-filter: blur(${sizes(8)});
+  display: flex;
+  align-items: center;
+  padding: 0.5em;
+  white-space: nowrap;
+  transition: opacity ${transitions.timings.player} ease-in, backdrop-filter ${transitions.timings.player} ease-in !important;
+`
+
+export const ControlButtonTooltipText = styled(Text)`
+  /* 12px */
+  font-size: 0.75em;
+`

--- a/src/shared/components/VideoPlayer/PlayerControlButton.tsx
+++ b/src/shared/components/VideoPlayer/PlayerControlButton.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react'
+
+import { ControlButton, ControlButtonTooltip, ControlButtonTooltipText } from './PlayerControlButton.style'
+
+type PlayerControlButtonProps = {
+  className?: string
+  showTooltipOnlyOnFocus?: boolean
+  tooltipPosition?: 'left' | 'right'
+  onClick?: (e: React.MouseEvent) => void
+  tooltipText?: string
+}
+
+export const PlayerControlButton: React.FC<PlayerControlButtonProps> = ({
+  children,
+  onClick,
+  tooltipText,
+  tooltipPosition,
+  className,
+  showTooltipOnlyOnFocus,
+}) => {
+  const [disableFocus, setDisableFocus] = useState(true)
+
+  useEffect(() => {
+    if (disableFocus) {
+      return
+    }
+    const handler = () => setDisableFocus(true)
+    window.addEventListener('mousemove', handler)
+    return () => window.removeEventListener('mousemove', handler)
+  }, [disableFocus])
+
+  const handleButtonFocus = () => setDisableFocus(false)
+  return (
+    <ControlButton
+      showTooltipOnlyOnFocus={showTooltipOnlyOnFocus}
+      className={className}
+      onFocus={handleButtonFocus}
+      disableFocus={disableFocus}
+      onClick={onClick}
+    >
+      {children}
+      <ControlButtonTooltip tooltipPosition={tooltipPosition}>
+        <ControlButtonTooltipText variant="caption">{tooltipText}</ControlButtonTooltipText>
+      </ControlButtonTooltip>
+    </ControlButton>
+  )
+}

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -3,6 +3,9 @@ import styled from '@emotion/styled'
 
 import { SvgPlayerSoundOff } from '@/shared/icons'
 
+import { PlayerControlButton } from './PlayerControlButton'
+import { ControlButton } from './PlayerControlButton.style'
+
 import { colors, sizes, transitions, zIndex } from '../../theme'
 import { Text } from '../Text'
 
@@ -13,11 +16,6 @@ type ContainerProps = {
 type CustomControlsProps = {
   isFullScreen?: boolean
   isEnded?: boolean
-}
-
-type ControlButtonProps = {
-  showTooltipOnlyOnFocus?: boolean
-  disableFocus?: boolean
 }
 
 const focusStyles = css`
@@ -61,97 +59,6 @@ export const CustomControls = styled.div<CustomControlsProps>`
   z-index: ${zIndex.nearOverlay - 1};
   width: 100%;
   transition: transform 200ms ${transitions.easing}, opacity 200ms ${transitions.easing};
-`
-
-export const ControlButton = styled.button<ControlButtonProps>`
-  margin-right: 0.5em;
-  display: flex !important;
-  padding: 0.5em;
-  cursor: pointer;
-  border: none;
-  background: none;
-  border-radius: 100%;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  transition: background ${transitions.timings.player} ease-in !important;
-
-  & > svg {
-    filter: drop-shadow(0 1px 2px ${colors.transparentBlack[32]});
-    width: 1.5em;
-    height: 1.5em;
-  }
-
-  :hover {
-    background-color: ${colors.transparentPrimary[18]};
-    backdrop-filter: blur(${sizes(8)});
-    transition: none !important;
-
-    ${() => ControlButtonTooltip} {
-      transition: none !important;
-      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
-    }
-  }
-
-  :active {
-    background-color: ${colors.transparentPrimary[10]};
-  }
-
-  :focus {
-    ${() => ControlButtonTooltip} {
-      /* turn off transition on mouse enter, but turn on on mouse leave */
-      transition: none !important;
-      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
-    }
-  }
-
-  :focus-visible {
-    ${() => ControlButtonTooltip} {
-      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
-    }
-  }
-
-  :focus:not(:focus-visible):hover {
-    ${() => ControlButtonTooltip} {
-      transition: none !important;
-      opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
-    }
-  }
-
-  :focus:not(:focus-visible):not(:hover) {
-    ${() => ControlButtonTooltip} {
-      opacity: 0;
-    }
-  }
-
-  ${focusStyles}
-`
-
-type ControlButtonTooltipProps = {
-  tooltipPosition?: 'left' | 'right'
-  showTooltipOnlyOnFocus?: boolean
-}
-
-export const ControlButtonTooltip = styled.div<ControlButtonTooltipProps>`
-  ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
-  ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
-
-  opacity: 0;
-  pointer-events: none;
-  position: absolute;
-  bottom: calc(3em);
-  background: ${colors.transparentBlack[54]};
-  backdrop-filter: blur(${sizes(8)});
-  display: flex;
-  align-items: center;
-  padding: 0.5em;
-  white-space: nowrap;
-  transition: opacity ${transitions.timings.player} ease-in, backdrop-filter ${transitions.timings.player} ease-in !important;
-`
-
-export const ControlButtonTooltipText = styled(Text)`
-  /* 12px */
-  font-size: 0.75em;
 `
 
 export const VolumeSliderContainer = styled.div`
@@ -216,7 +123,7 @@ export const VolumeControl = styled.div`
     }
   }
 `
-export const VolumeButton = styled(ControlButton)`
+export const VolumeButton = styled(PlayerControlButton)`
   cursor: pointer;
   margin-right: 0;
   display: flex;

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -18,24 +18,6 @@ type CustomControlsProps = {
   isEnded?: boolean
 }
 
-const focusStyles = css`
-  :focus {
-    /* Provide a fallback style for browsers
-     that don't support :focus-visible e.g safari */
-    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
-  }
-
-  /* https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible */
-
-  :focus-visible {
-    box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
-  }
-
-  :focus:not(:focus-visible) {
-    box-shadow: unset;
-  }
-`
-
 export const ControlsOverlay = styled.div<CustomControlsProps>`
   font-size: ${({ isFullScreen }) => (isFullScreen ? sizes(8) : sizes(4))};
   opacity: 0;
@@ -271,7 +253,17 @@ export const Container = styled.div<ContainerProps>`
         background-color: ${colors.transparentWhite[32]};
         transition: height ${transitions.timings.player} ${transitions.easing} !important;
 
-        ${focusStyles}
+        :focus {
+          box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
+        }
+
+        :focus-visible {
+          box-shadow: inset 0 0 0 3px ${colors.transparentPrimary[18]};
+        }
+
+        :focus:not(:focus-visible) {
+          box-shadow: unset;
+        }
 
         .vjs-slider-bar {
           background-color: ${colors.blue[500]};

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -16,9 +16,8 @@ type CustomControlsProps = {
 }
 
 type ControlButtonProps = {
-  tooltipText?: string
-  tooltipPosition?: 'left' | 'right'
   showTooltipOnlyOnFocus?: boolean
+  disableFocus?: boolean
 }
 
 const focusStyles = css`
@@ -67,13 +66,13 @@ export const CustomControls = styled.div<CustomControlsProps>`
 export const ControlButton = styled.button<ControlButtonProps>`
   margin-right: 0.5em;
   display: flex !important;
+  padding: 0.5em;
   cursor: pointer;
   border: none;
   background: none;
   border-radius: 100%;
   align-items: center;
   justify-content: center;
-  padding: 0.5em;
   position: relative;
   transition: background ${transitions.timings.player} ease-in !important;
 
@@ -83,31 +82,12 @@ export const ControlButton = styled.button<ControlButtonProps>`
     height: 1.5em;
   }
 
-  ::before {
-    ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
-    ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
-
-    opacity: 0;
-    pointer-events: none;
-    content: ${({ tooltipText }) => tooltipText && `'${tooltipText}'`};
-    position: absolute;
-    font-size: 0.875em;
-    bottom: calc(3.5em - 1px);
-    background: ${colors.transparentBlack[54]};
-    backdrop-filter: blur(${sizes(8)});
-    display: flex;
-    align-items: center;
-    padding: 0.5em;
-    white-space: nowrap;
-    transition: opacity ${transitions.timings.player} ease-in !important;
-  }
-
   :hover {
     background-color: ${colors.transparentPrimary[18]};
     backdrop-filter: blur(${sizes(8)});
     transition: none !important;
 
-    ::before {
+    ${() => ControlButtonTooltip} {
       transition: none !important;
       opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
     }
@@ -118,33 +98,60 @@ export const ControlButton = styled.button<ControlButtonProps>`
   }
 
   :focus {
-    ::before {
+    ${() => ControlButtonTooltip} {
       /* turn off transition on mouse enter, but turn on on mouse leave */
       transition: none !important;
-      opacity: 1;
+      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
     }
   }
 
   :focus-visible {
-    ::before {
-      opacity: 1;
+    ${() => ControlButtonTooltip} {
+      opacity: ${({ disableFocus }) => (disableFocus ? 0 : 1)};
     }
   }
 
   :focus:not(:focus-visible):hover {
-    ::before {
+    ${() => ControlButtonTooltip} {
       transition: none !important;
       opacity: ${({ showTooltipOnlyOnFocus }) => (showTooltipOnlyOnFocus ? 0 : 1)};
     }
   }
 
   :focus:not(:focus-visible):not(:hover) {
-    ::before {
+    ${() => ControlButtonTooltip} {
       opacity: 0;
     }
   }
 
   ${focusStyles}
+`
+
+type ControlButtonTooltipProps = {
+  tooltipPosition?: 'left' | 'right'
+  showTooltipOnlyOnFocus?: boolean
+}
+
+export const ControlButtonTooltip = styled.div<ControlButtonTooltipProps>`
+  ${({ tooltipPosition }) => tooltipPosition === 'left' && 'left: 0'};
+  ${({ tooltipPosition }) => tooltipPosition === 'right' && 'right: 0'};
+
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  bottom: calc(3em);
+  background: ${colors.transparentBlack[54]};
+  backdrop-filter: blur(${sizes(8)});
+  display: flex;
+  align-items: center;
+  padding: 0.5em;
+  white-space: nowrap;
+  transition: opacity ${transitions.timings.player} ease-in, backdrop-filter ${transitions.timings.player} ease-in !important;
+`
+
+export const ControlButtonTooltipText = styled(Text)`
+  /* 12px */
+  font-size: 0.75em;
 `
 
 export const VolumeSliderContainer = styled.div`

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -18,14 +18,12 @@ import { Logger } from '@/utils/logger'
 import { formatDurationShort } from '@/utils/time'
 
 import { ControlsIndicator } from './ControlsIndicator'
+import { PlayerControlButton } from './PlayerControlButton'
 import { VideoOverlay } from './VideoOverlay'
 import {
   BigPlayButton,
   BigPlayButtonOverlay,
   Container,
-  ControlButton,
-  ControlButtonTooltip,
-  ControlButtonTooltipText,
   ControlsOverlay,
   CurrentTime,
   CurrentTimeWrapper,
@@ -68,7 +66,6 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
   const [player, playerRef] = useVideoJsPlayer(videoJsConfig)
   const cachedPlayerVolume = usePersonalDataStore((state) => state.cachedPlayerVolume)
   const updateCachedPlayerVolume = usePersonalDataStore((state) => state.actions.updateCachedPlayerVolume)
-  const [isFocusEnabled, setIsFocusEnabled] = useState(false)
 
   const [volume, setVolume] = useState(cachedPlayerVolume)
   const [isPlaying, setIsPlaying] = useState(false)
@@ -78,15 +75,6 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
 
   const [playerState, setPlayerState] = useState<PlayerState>(null)
   const [isLoaded, setIsLoaded] = useState(false)
-
-  useEffect(() => {
-    if (!isFocusEnabled) {
-      return
-    }
-    const handler = () => setIsFocusEnabled(false)
-    window.addEventListener('mousemove', handler)
-    return () => window.removeEventListener('mousemove', handler)
-  }, [isFocusEnabled])
 
   // handle hotkeys
   useEffect(() => {
@@ -405,8 +393,6 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
     }
   }
 
-  const handleButtonFocus = () => setIsFocusEnabled(true)
-
   const renderVolumeButton = () => {
     if (volume === 0) {
       return <StyledSvgPlayerSoundOff />
@@ -440,25 +426,16 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
           <>
             <ControlsOverlay isFullScreen={isFullScreen}>
               <CustomControls isFullScreen={isFullScreen} isEnded={playerState === 'ended'}>
-                <ControlButton onFocus={handleButtonFocus} disableFocus={!isFocusEnabled} onClick={handlePlayPause}>
+                <PlayerControlButton
+                  onClick={handlePlayPause}
+                  tooltipText={isPlaying ? 'Pause (k)' : 'Play (k)'}
+                  tooltipPosition="left"
+                >
                   {playerState === 'ended' ? <SvgPlayerRestart /> : isPlaying ? <SvgPlayerPause /> : <SvgPlayerPlay />}
-                  <ControlButtonTooltip tooltipPosition="left">
-                    <ControlButtonTooltipText variant="caption">
-                      {isPlaying ? 'Pause (k)' : 'Play (k)'}
-                    </ControlButtonTooltipText>
-                  </ControlButtonTooltip>
-                </ControlButton>
+                </PlayerControlButton>
                 <VolumeControl>
-                  <VolumeButton
-                    onFocus={handleButtonFocus}
-                    disableFocus={!isFocusEnabled}
-                    showTooltipOnlyOnFocus
-                    onClick={handleMute}
-                  >
+                  <VolumeButton tooltipText="Volume" showTooltipOnlyOnFocus onClick={handleMute}>
                     {renderVolumeButton()}
-                    <ControlButtonTooltip>
-                      <ControlButtonTooltipText variant="caption">Volume</ControlButtonTooltipText>
-                    </ControlButtonTooltip>
                   </VolumeButton>
                   <VolumeSliderContainer>
                     <VolumeSlider
@@ -478,25 +455,17 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
                 </CurrentTimeWrapper>
                 <ScreenControls>
                   {isPiPSupported && (
-                    <ControlButton
-                      onFocus={handleButtonFocus}
-                      disableFocus={!isFocusEnabled}
-                      onClick={handlePictureInPicture}
-                    >
+                    <PlayerControlButton onClick={handlePictureInPicture} tooltipText="Picture-in-picture">
                       {isPiPEnabled ? <SvgPlayerPipDisable /> : <SvgPlayerPip />}
-                      <ControlButtonTooltip>
-                        <ControlButtonTooltipText variant="caption">Picture-in-picture</ControlButtonTooltipText>
-                      </ControlButtonTooltip>
-                    </ControlButton>
+                    </PlayerControlButton>
                   )}
-                  <ControlButton onFocus={handleButtonFocus} disableFocus={!isFocusEnabled} onClick={handleFullScreen}>
+                  <PlayerControlButton
+                    tooltipPosition="right"
+                    tooltipText={isFullScreen ? 'Exit full screen (f)' : 'Full screen (f)'}
+                    onClick={handleFullScreen}
+                  >
                     {isFullScreen ? <SvgPlayerSmallScreen /> : <SvgPlayerFullScreen />}
-                    <ControlButtonTooltip tooltipPosition="right">
-                      <ControlButtonTooltipText variant="caption">
-                        {isFullScreen ? 'Exit full screen (f)' : 'Full screen (f)'}
-                      </ControlButtonTooltipText>
-                    </ControlButtonTooltip>
-                  </ControlButton>
+                  </PlayerControlButton>
                 </ScreenControls>
               </CustomControls>
             </ControlsOverlay>

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -24,6 +24,8 @@ import {
   BigPlayButtonOverlay,
   Container,
   ControlButton,
+  ControlButtonTooltip,
+  ControlButtonTooltipText,
   ControlsOverlay,
   CurrentTime,
   CurrentTimeWrapper,
@@ -66,6 +68,7 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
   const [player, playerRef] = useVideoJsPlayer(videoJsConfig)
   const cachedPlayerVolume = usePersonalDataStore((state) => state.cachedPlayerVolume)
   const updateCachedPlayerVolume = usePersonalDataStore((state) => state.actions.updateCachedPlayerVolume)
+  const [isFocusEnabled, setIsFocusEnabled] = useState(false)
 
   const [volume, setVolume] = useState(cachedPlayerVolume)
   const [isPlaying, setIsPlaying] = useState(false)
@@ -75,6 +78,15 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
 
   const [playerState, setPlayerState] = useState<PlayerState>(null)
   const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!isFocusEnabled) {
+      return
+    }
+    const handler = () => setIsFocusEnabled(false)
+    window.addEventListener('mousemove', handler)
+    return () => window.removeEventListener('mousemove', handler)
+  }, [isFocusEnabled])
 
   // handle hotkeys
   useEffect(() => {
@@ -393,6 +405,8 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
     }
   }
 
+  const handleButtonFocus = () => setIsFocusEnabled(true)
+
   const renderVolumeButton = () => {
     if (volume === 0) {
       return <StyledSvgPlayerSoundOff />
@@ -403,7 +417,6 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
 
   const showBigPlayButton = playerState === null && !isInBackground
   const showPlayerControls = !isInBackground && isLoaded && playerState
-
   return (
     <Container isFullScreen={isFullScreen} className={className} isInBackground={isInBackground}>
       <div data-vjs-player>
@@ -427,16 +440,25 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
           <>
             <ControlsOverlay isFullScreen={isFullScreen}>
               <CustomControls isFullScreen={isFullScreen} isEnded={playerState === 'ended'}>
-                <ControlButton
-                  onClick={handlePlayPause}
-                  tooltipText={isPlaying ? 'Pause (k)' : 'Play (k)'}
-                  tooltipPosition="left"
-                >
+                <ControlButton onFocus={handleButtonFocus} disableFocus={!isFocusEnabled} onClick={handlePlayPause}>
                   {playerState === 'ended' ? <SvgPlayerRestart /> : isPlaying ? <SvgPlayerPause /> : <SvgPlayerPlay />}
+                  <ControlButtonTooltip tooltipPosition="left">
+                    <ControlButtonTooltipText variant="caption">
+                      {isPlaying ? 'Pause (k)' : 'Play (k)'}
+                    </ControlButtonTooltipText>
+                  </ControlButtonTooltip>
                 </ControlButton>
                 <VolumeControl>
-                  <VolumeButton onClick={handleMute} showTooltipOnlyOnFocus tooltipText="Volume">
+                  <VolumeButton
+                    onFocus={handleButtonFocus}
+                    disableFocus={!isFocusEnabled}
+                    showTooltipOnlyOnFocus
+                    onClick={handleMute}
+                  >
                     {renderVolumeButton()}
+                    <ControlButtonTooltip>
+                      <ControlButtonTooltipText variant="caption">Volume</ControlButtonTooltipText>
+                    </ControlButtonTooltip>
                   </VolumeButton>
                   <VolumeSliderContainer>
                     <VolumeSlider
@@ -456,16 +478,24 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
                 </CurrentTimeWrapper>
                 <ScreenControls>
                   {isPiPSupported && (
-                    <ControlButton onClick={handlePictureInPicture} tooltipText="Picture-in-picture">
+                    <ControlButton
+                      onFocus={handleButtonFocus}
+                      disableFocus={!isFocusEnabled}
+                      onClick={handlePictureInPicture}
+                    >
                       {isPiPEnabled ? <SvgPlayerPipDisable /> : <SvgPlayerPip />}
+                      <ControlButtonTooltip>
+                        <ControlButtonTooltipText variant="caption">Picture-in-picture</ControlButtonTooltipText>
+                      </ControlButtonTooltip>
                     </ControlButton>
                   )}
-                  <ControlButton
-                    onClick={handleFullScreen}
-                    tooltipPosition="right"
-                    tooltipText={isFullScreen ? 'Exit full screen (f)' : 'Full screen (f)'}
-                  >
+                  <ControlButton onFocus={handleButtonFocus} disableFocus={!isFocusEnabled} onClick={handleFullScreen}>
                     {isFullScreen ? <SvgPlayerSmallScreen /> : <SvgPlayerFullScreen />}
+                    <ControlButtonTooltip tooltipPosition="right">
+                      <ControlButtonTooltipText variant="caption">
+                        {isFullScreen ? 'Exit full screen (f)' : 'Full screen (f)'}
+                      </ControlButtonTooltipText>
+                    </ControlButtonTooltip>
                   </ControlButton>
                 </ScreenControls>
               </CustomControls>


### PR DESCRIPTION
Partly resolves: #1036 

Should fix: 

> - [ ] Tooltips: 
> - font-size, font-family and line-height are different
> - padding is different - it should be 8px
> - color is different - we should use `colors.gray[50]`

and: 

> - [ ] When we focus on the player control and then move the cursor to another player button we should hide the tooltip on the previous player control.

Unfortunately, the backdrop-filter problem is a chrome bug. https://stackoverflow.com/questions/62454801/css-backdrop-filter-not-functioning-on-child-element-in-slideout-menu 
I could work around this by making a tooltip a sibling, but it will require some refactoring and will make our HTML code even more complicated. Not sure if it's worth it. Let me know what you think?