### PR TITLE
Player various fixes

### DIFF
--- a/src/providers/personalData/store.tsx
+++ b/src/providers/personalData/store.tsx
@@ -17,8 +17,8 @@ export type PersonalDataStoreState = {
   followedChannels: FollowedChannel[]
   recentSearches: RecentSearch[]
   dismissedMessages: DismissedMessage[]
-  cachedPlayerVolume: number
-  volumeBeforeMuted: number
+  currentVolume: number
+  cachedVolume: number
 }
 
 const WHITELIST = [
@@ -26,8 +26,8 @@ const WHITELIST = [
   'followedChannels',
   'recentSearches',
   'dismissedMessages',
-  'cachedPlayerVolume',
-  'volumeBeforeMuted',
+  'currentVolume',
+  'cachedVolume',
 ] as (keyof PersonalDataStoreState)[]
 
 export type PersonalDataStoreActions = {
@@ -35,25 +35,25 @@ export type PersonalDataStoreActions = {
   updateChannelFollowing: (id: string, follow: boolean) => void
   updateRecentSearches: (id: string, type: RecentSearchType) => void
   updateDismissedMessages: (id: string, add?: boolean) => void
-  updateCachedPlayerVolume: (volume: number) => void
-  updateVolumeBeforeMuted: (volume: number) => void
+  setCurrentVolume: (volume: number) => void
+  setCachedVolume: (volume: number) => void
 }
 
 const watchedVideos = readFromLocalStorage<WatchedVideo[]>('watchedVideos') ?? []
 const followedChannels = readFromLocalStorage<FollowedChannel[]>('followedChannels') ?? []
 const recentSearches = readFromLocalStorage<RecentSearch[]>('recentSearches') ?? []
 const dismissedMessages = readFromLocalStorage<DismissedMessage[]>('dismissedMessages') ?? []
-const cachedPlayerVolume = readFromLocalStorage<number>('playerVolume') ?? 1
+const currentVolume = readFromLocalStorage<number>('playerVolume') ?? 1
 
 export const usePersonalDataStore = createStore<PersonalDataStoreState, PersonalDataStoreActions>(
   {
     state: {
-      volumeBeforeMuted: 0,
+      cachedVolume: 0,
       watchedVideos,
       followedChannels,
       recentSearches,
       dismissedMessages,
-      cachedPlayerVolume,
+      currentVolume,
     },
     actionsFactory: (set) => ({
       updateWatchedVideos: (__typename, id, timestamp) => {
@@ -93,13 +93,13 @@ export const usePersonalDataStore = createStore<PersonalDataStoreState, Personal
           }
         })
       },
-      updateCachedPlayerVolume: (volume) =>
+      setCurrentVolume: (volume) =>
         set((state) => {
-          state.cachedPlayerVolume = round(volume, 2)
+          state.currentVolume = round(volume, 2)
         }),
-      updateVolumeBeforeMuted: (volume) =>
+      setCachedVolume: (volume) =>
         set((state) => {
-          state.volumeBeforeMuted = round(volume, 2)
+          state.cachedVolume = round(volume, 2)
         }),
     }),
   },

--- a/src/providers/personalData/store.tsx
+++ b/src/providers/personalData/store.tsx
@@ -1,3 +1,5 @@
+import { round } from 'lodash'
+
 import { createStore } from '@/store'
 import { readFromLocalStorage } from '@/utils/localStorage'
 
@@ -16,6 +18,7 @@ export type PersonalDataStoreState = {
   recentSearches: RecentSearch[]
   dismissedMessages: DismissedMessage[]
   cachedPlayerVolume: number
+  volumeBeforeMuted: number
 }
 
 const WHITELIST = [
@@ -24,6 +27,7 @@ const WHITELIST = [
   'recentSearches',
   'dismissedMessages',
   'cachedPlayerVolume',
+  'volumeBeforeMuted',
 ] as (keyof PersonalDataStoreState)[]
 
 export type PersonalDataStoreActions = {
@@ -32,6 +36,7 @@ export type PersonalDataStoreActions = {
   updateRecentSearches: (id: string, type: RecentSearchType) => void
   updateDismissedMessages: (id: string, add?: boolean) => void
   updateCachedPlayerVolume: (volume: number) => void
+  updateVolumeBeforeMuted: (volume: number) => void
 }
 
 const watchedVideos = readFromLocalStorage<WatchedVideo[]>('watchedVideos') ?? []
@@ -43,6 +48,7 @@ const cachedPlayerVolume = readFromLocalStorage<number>('playerVolume') ?? 1
 export const usePersonalDataStore = createStore<PersonalDataStoreState, PersonalDataStoreActions>(
   {
     state: {
+      volumeBeforeMuted: 0,
       watchedVideos,
       followedChannels,
       recentSearches,
@@ -89,7 +95,11 @@ export const usePersonalDataStore = createStore<PersonalDataStoreState, Personal
       },
       updateCachedPlayerVolume: (volume) =>
         set((state) => {
-          state.cachedPlayerVolume = volume
+          state.cachedPlayerVolume = round(volume, 2)
+        }),
+      updateVolumeBeforeMuted: (volume) =>
+        set((state) => {
+          state.volumeBeforeMuted = round(volume, 2)
         }),
     }),
   },


### PR DESCRIPTION
Partly resolves #1036
Should fix: 

> - [x]  When the screen with the big play button is showing up, we should be able to play the video by clicking the video container, not just the big play button. 
> - [x] Saving volume in local storage doesn't work perfectly. If the user mutes the video, information about setting volume to 0 will not be saved. We should fix this
> 