### PR TITLE
Cover video thumbnail fix and other smaller improvements

### DIFF
--- a/src/shared/components/VideoPlayer/ControlsIndicator.style.ts
+++ b/src/shared/components/VideoPlayer/ControlsIndicator.style.ts
@@ -93,10 +93,10 @@ export const ControlsIndicatorTransitions = styled.div`
       opacity: 1;
       transform: scale(1);
       transition: opacity, transform;
-      transition-timing-function: ease-in;
-      transition-duration: 150ms;
+      transition-timing-function: ${animationEasing};
+      transition-duration: 200ms;
       @media (hover: hover) {
-        transition-delay: ${INDICATOR_TIMEOUT - 150}ms;
+        transition-delay: ${INDICATOR_TIMEOUT - 200}ms;
       }
     }
   }
@@ -114,7 +114,7 @@ export const ControlsIndicatorTransitions = styled.div`
       opacity: 0;
       transform: scale(0.5);
       transition: opacity, transform;
-      transition-timing-function: ease-in;
+      transition-timing-function: ${animationEasing};
     }
     ${ControlsIndicatorIconWrapper} {
       transform: scale(1);

--- a/src/shared/components/VideoPlayer/CustomTimeline.style.ts
+++ b/src/shared/components/VideoPlayer/CustomTimeline.style.ts
@@ -144,9 +144,9 @@ export const PlayProgressThumb = styled.button`
   border-radius: 100%;
   background: ${colors.white};
   transition: opacity ${transitions.timings.player} ${TRANSITION_DELAY} ${transitions.easing};
-  top: -0.5em;
-  height: 1.5em;
-  width: 1.5em;
+  top: -0.75em;
+  height: 2em;
+  width: 2em;
   ${media.compact} {
     cursor: pointer;
     top: -0.25em;

--- a/src/shared/components/VideoPlayer/CustomTimeline.style.ts
+++ b/src/shared/components/VideoPlayer/CustomTimeline.style.ts
@@ -138,16 +138,19 @@ export const PlayProgressThumb = styled.button`
   opacity: 0;
   z-index: 1;
   content: '';
-  height: 1em;
-  top: -0.25em;
-  width: 1em;
   padding: 0;
   position: absolute;
   box-shadow: 0 1px 2px ${colors.transparentBlack[32]};
   border-radius: 100%;
   background: ${colors.white};
   transition: opacity ${transitions.timings.player} ${TRANSITION_DELAY} ${transitions.easing};
+  top: -0.5em;
+  height: 1.5em;
+  width: 1.5em;
   ${media.compact} {
     cursor: pointer;
+    top: -0.25em;
+    height: 1em;
+    width: 1em;
   }
 `

--- a/src/shared/components/VideoPlayer/VideoOverlays/EndingOverlay.style.ts
+++ b/src/shared/components/VideoPlayer/VideoOverlays/EndingOverlay.style.ts
@@ -33,7 +33,7 @@ type InnerContainerProps = {
 
 export const InnerContainer = styled.div<InnerContainerProps>`
   padding: ${sizes(4)};
-  height: calc(100% - 76px);
+  height: calc(100% - 4em);
   overflow-y: auto;
   width: 100%;
   display: flex;

--- a/src/shared/components/VideoPlayer/VideoOverlays/EndingOverlay.style.ts
+++ b/src/shared/components/VideoPlayer/VideoOverlays/EndingOverlay.style.ts
@@ -33,7 +33,7 @@ type InnerContainerProps = {
 
 export const InnerContainer = styled.div<InnerContainerProps>`
   padding: ${sizes(4)};
-  height: calc(100% - 72px);
+  height: calc(100% - 76px);
   overflow-y: auto;
   width: 100%;
   display: flex;

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -44,7 +44,7 @@ export const ControlsOverlay = styled.div<CustomControlsProps>`
 export const CustomControls = styled.div<CustomControlsProps>`
   position: absolute;
   transform: translateY(0.5em);
-  padding: ${({ isFullScreen }) => (isFullScreen ? ' 0.5em 0.5em 0 0.5em' : '1em 0.5em 0 0.5em')};
+  padding: ${({ isFullScreen }) => (isFullScreen ? ' 0.5em 0.5em 0 0.5em' : '0.25em 0.5em 0 0.5em')};
   bottom: ${({ isFullScreen }) => (isFullScreen ? '2.5em' : '1.25em')};
   border-top: ${({ isEnded }) => (isEnded ? `1px solid ${colors.transparentPrimary[18]}` : 'unset')};
   left: 0;

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -223,10 +223,6 @@ export const ScreenControls = styled.div`
 `
 
 const backgroundContainerCss = css`
-  .vjs-error-display {
-    display: block;
-  }
-
   .vjs-poster {
     display: block;
     opacity: 0;

--- a/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.style.tsx
@@ -6,7 +6,7 @@ import { SvgPlayerSoundOff } from '@/shared/icons'
 import { PlayerControlButton } from './PlayerControlButton'
 import { ControlButton } from './PlayerControlButton.style'
 
-import { colors, sizes, transitions, zIndex } from '../../theme'
+import { colors, media, sizes, transitions, zIndex } from '../../theme'
 import { Text } from '../Text'
 
 type ContainerProps = {
@@ -45,7 +45,7 @@ export const CustomControls = styled.div<CustomControlsProps>`
   position: absolute;
   transform: translateY(0.5em);
   padding: ${({ isFullScreen }) => (isFullScreen ? ' 0.5em 0.5em 0 0.5em' : '1em 0.5em 0 0.5em')};
-  bottom: ${({ isFullScreen }) => (isFullScreen ? '2.5em' : '1em')};
+  bottom: ${({ isFullScreen }) => (isFullScreen ? '2.5em' : '1.25em')};
   border-top: ${({ isEnded }) => (isEnded ? `1px solid ${colors.transparentPrimary[18]}` : 'unset')};
   left: 0;
   z-index: ${zIndex.nearOverlay - 1};
@@ -211,11 +211,14 @@ export const CurrentTime = styled(Text)`
 export const ScreenControls = styled.div`
   display: grid;
   grid-template-columns: auto auto;
-  gap: 0.5em;
+  gap: 0.25em;
   margin-left: auto;
 
   ${ControlButton}:last-of-type {
     margin-right: 0;
+  }
+  ${media.small} {
+    gap: 0.5em;
   }
 `
 
@@ -227,6 +230,7 @@ const backgroundContainerCss = css`
   .vjs-poster {
     display: block;
     opacity: 0;
+    height: 100%;
     transition: opacity ${transitions.timings.loading} ${transitions.easing};
   }
 
@@ -266,7 +270,8 @@ export const Container = styled.div<ContainerProps>`
   }
 
   .vjs-user-inactive.vjs-playing,
-  .vjs-user-inactive:not(.vjs-ended) {
+  /* don't hide player controls when paused(mobile) */
+  .vjs-user-inactive:not(.vjs-ended):not(.vjs-paused) {
     ${ControlsOverlay} {
       opacity: 0;
       visibility: hidden;


### PR DESCRIPTION
Fix #1097 
Also, I added some smaller improvements based on Adam's feedback
- from now controls should be always visible on compact view when the player is paused
- changed animation transition duration, delay and easing of loader
- increased thumb size on seek bar
- some small position fixes