### PR TITLE
Fix player's seeking issue on IOS 

### DIFF
--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -154,7 +154,7 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
     }
     player.on(['waiting', 'canplay', 'seeking', 'seeked'], handler)
     return () => {
-      player.off(['waiting', 'canplay', 'seeking', 'seekeed'], handler)
+      player.off(['waiting', 'canplay', 'seeking', 'seeked'], handler)
     }
   }, [player, playerState])
 

--- a/src/shared/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/shared/components/VideoPlayer/VideoPlayer.tsx
@@ -143,18 +143,18 @@ const VideoPlayerComponent: React.ForwardRefRenderFunction<HTMLVideoElement, Vid
       return
     }
     const handler = (event: Event) => {
-      if (event.type === 'waiting') {
+      if (event.type === 'waiting' || event.type === 'seeking') {
         setPlayerState('loading')
       }
-      if (event.type === 'canplay') {
+      if (event.type === 'canplay' || event.type === 'seeked') {
         if (playerState !== null) {
           setPlayerState('playing')
         }
       }
     }
-    player.on(['waiting', 'canplay'], handler)
+    player.on(['waiting', 'canplay', 'seeking', 'seeked'], handler)
     return () => {
-      player.off(['waiting', 'canplay'], handler)
+      player.off(['waiting', 'canplay', 'seeking', 'seekeed'], handler)
     }
   }, [player, playerState])
 


### PR DESCRIPTION
Fix #1091

For some reason on ios, the player doesn't trigger the `waiting` event when the `seeking` event occurs. 
Need to be tested on an IOS device, I have access only to the Xcode simulator(ios emulator) and am not 100% sure if it resolves the problem. 