### PR TITLE
Add missing separator on browse channels and some other style changes

### DIFF
--- a/src/components/InfiniteGrids/InfiniteChannelWithVideosGrid.tsx
+++ b/src/components/InfiniteGrids/InfiniteChannelWithVideosGrid.tsx
@@ -112,7 +112,7 @@ export const InfiniteChannelWithVideosGrid: FC<InfiniteChannelWithVideosGridProp
               items={mappedLanguages || []}
               disabled={languagesLoading}
               value={selectedLanguage}
-              size="small"
+              size="regular"
               onChange={onSelectLanguage}
             />
           </LanguageSelectWrapper>

--- a/src/components/InfiniteGrids/InfiniteChannelWithVideosGrid.tsx
+++ b/src/components/InfiniteGrids/InfiniteChannelWithVideosGrid.tsx
@@ -105,7 +105,7 @@ export const InfiniteChannelWithVideosGrid: FC<InfiniteChannelWithVideosGridProp
   return (
     <section className={className}>
       <TitleWrapper>
-        {title && <Text variant="h5">{title}</Text>}
+        {title && <Text variant="h4">{title}</Text>}
         {languageSelector && (
           <LanguageSelectWrapper>
             <Select

--- a/src/components/InfiniteGrids/InfiniteGrid.style.ts
+++ b/src/components/InfiniteGrids/InfiniteGrid.style.ts
@@ -17,6 +17,8 @@ export const LoadMoreButtonWrapper = styled.div`
 
 export const TitleWrapper = styled.div`
   display: flex;
+  padding-bottom: ${sizes(4)};
+  border-bottom: 1px solid ${colors.gray[700]};
 `
 
 export const LanguageSelectWrapper = styled.div`

--- a/src/components/InfiniteGrids/InfiniteGrid.style.ts
+++ b/src/components/InfiniteGrids/InfiniteGrid.style.ts
@@ -23,11 +23,6 @@ export const TitleWrapper = styled.div`
 export const LanguageSelectWrapper = styled.div`
   margin-left: ${sizes(6)};
   width: ${sizes(34)};
-
-  button {
-    /* change height of custom select */
-    min-height: ${sizes(10)};
-  }
 `
 
 export const Separator = styled.div`

--- a/src/components/InfiniteGrids/InfiniteGrid.style.ts
+++ b/src/components/InfiniteGrids/InfiniteGrid.style.ts
@@ -17,7 +17,6 @@ export const LoadMoreButtonWrapper = styled.div`
 
 export const TitleWrapper = styled.div`
   display: flex;
-  padding-bottom: ${sizes(4)};
   border-bottom: 1px solid ${colors.gray[700]};
 `
 

--- a/src/components/InfiniteGrids/InfiniteGrid.style.ts
+++ b/src/components/InfiniteGrids/InfiniteGrid.style.ts
@@ -24,6 +24,11 @@ export const TitleWrapper = styled.div`
 export const LanguageSelectWrapper = styled.div`
   margin-left: ${sizes(6)};
   width: ${sizes(34)};
+
+  button {
+    /* change height of custom select */
+    min-height: ${sizes(10)};
+  }
 `
 
 export const Separator = styled.div`

--- a/src/shared/components/Select/Select.style.ts
+++ b/src/shared/components/Select/Select.style.ts
@@ -35,7 +35,7 @@ export const SelectButton = styled.button<SelectButtonProps>`
     switch (size) {
       case 'regular':
         return css`
-          min-height: 42px;
+          min-height: 40px;
         `
       case 'small':
         return css`

--- a/src/shared/components/Select/Select.style.ts
+++ b/src/shared/components/Select/Select.style.ts
@@ -35,7 +35,7 @@ export const SelectButton = styled.button<SelectButtonProps>`
     switch (size) {
       case 'regular':
         return css`
-          min-height: 40px;
+          min-height: ${sizes(10)};
         `
       case 'small':
         return css`


### PR DESCRIPTION
There were some inconsistencies between design and implementation.
Before: 
![image](https://user-images.githubusercontent.com/51168865/128503903-6eef95f0-95de-4dc4-ae54-8378d41d7910.png)
Should be: 
![image](https://user-images.githubusercontent.com/51168865/128503980-203decb1-1ec4-421d-a009-ed02ca9e5f2f.png)
