### PR TITLE
Prevent text select from taking up more than 1 line

### DIFF
--- a/src/shared/components/Select/Select.style.ts
+++ b/src/shared/components/Select/Select.style.ts
@@ -29,6 +29,7 @@ export const SelectButton = styled.button<SelectButtonProps>`
   text-align: left;
   display: flex;
   justify-content: space-between;
+  white-space: nowrap;
   align-items: center;
 
   ${({ size }) => {


### PR DESCRIPTION
Small fix, should prevent this to happen:


https://user-images.githubusercontent.com/51168865/129321362-2874e011-4c4c-4069-8af4-d1aff29c09f8.mov

