### PR TITLE
Remove size variant in TitleArea

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-router": "6.0.0-beta.3",
     "react-router-dom": "6.0.0-beta.3",
     "react-spring": "^9.2.4",
+    "react-textarea-autosize": "^8.3.3",
     "react-transition-group": "^4.4.1",
     "react-use-measure": "^2.0.4",
     "retry-axios": "^2.4.0",

--- a/src/shared/components/TitleArea/TitleArea.style.tsx
+++ b/src/shared/components/TitleArea/TitleArea.style.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import TextareaAutosize from 'react-textarea-autosize'
 
 import { colors, media, sizes, typography } from '@/shared/theme'
 
@@ -18,7 +19,7 @@ export const TitleAreaInfo = styled.div<TitleAreaInfoProps>`
   justify-content: space-between;
 `
 
-export const StyledTextArea = styled.textarea`
+export const StyledTextArea = styled(TextareaAutosize)`
   caret-color: ${colors.blue[500]};
   color: white;
   background-color: ${colors.transparent};

--- a/src/shared/components/TitleArea/TitleArea.style.tsx
+++ b/src/shared/components/TitleArea/TitleArea.style.tsx
@@ -30,8 +30,10 @@ export const StyledTextArea = styled(TextareaAutosize)`
   resize: none;
   height: auto;
   font-size: ${typography.sizes.h4};
+  line-height: ${typography.lineHeights.h4};
   ${media.lg} {
     font-size: ${typography.sizes.h2};
+    line-height: ${typography.lineHeights.h2};
   }
 
   &:hover {

--- a/src/shared/components/TitleArea/TitleArea.style.tsx
+++ b/src/shared/components/TitleArea/TitleArea.style.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled'
 
-import { colors, typography } from '@/shared/theme'
-
-import { TitleAreaVariant } from './'
+import { colors, media, sizes, typography } from '@/shared/theme'
 
 import { Text } from '../Text'
 
@@ -10,22 +8,17 @@ export const Container = styled.div`
   position: relative;
 `
 
-type StyledTextAreaProps = {
-  touchedAndEmpty?: boolean
-  variant?: TitleAreaVariant
-}
-
 type TitleAreaInfoProps = {
-  error?: boolean
   visible?: boolean
 }
 
 export const TitleAreaInfo = styled.div<TitleAreaInfoProps>`
-  display: none;
+  display: ${({ visible }) => (visible ? 'flex' : 'none')};
+  flex-wrap: wrap;
   justify-content: space-between;
 `
 
-export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
+export const StyledTextArea = styled.textarea`
   caret-color: ${colors.blue[500]};
   color: white;
   background-color: ${colors.transparent};
@@ -35,14 +28,10 @@ export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
   width: 100%;
   resize: none;
   height: auto;
-  font-size: ${({ variant }) => {
-    if (variant === 'large') {
-      return typography.sizes.h4
-    }
-    if (variant === 'small') {
-      return typography.sizes.h2
-    }
-  }};
+  font-size: ${typography.sizes.h4};
+  ${media.lg} {
+    font-size: ${typography.sizes.h2};
+  }
 
   &:hover {
     opacity: 75%;
@@ -50,10 +39,6 @@ export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
 
   ::placeholder {
     color: ${colors.gray[500]};
-  }
-
-  + ${TitleAreaInfo} {
-    ${({ touchedAndEmpty }) => touchedAndEmpty && `display: flex`};
   }
 
   :focus,
@@ -70,6 +55,8 @@ type CharactersCounterProps = {
 
 export const MinMaxChars = styled(Text)`
   white-space: nowrap;
+  margin-right: ${sizes(2)};
+  margin-bottom: ${sizes(1)};
 `
 
 export const CharactersCounter = styled(Text)<CharactersCounterProps>`

--- a/src/shared/components/TitleArea/TitleArea.tsx
+++ b/src/shared/components/TitleArea/TitleArea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import { CharactersCounter, Container, MinMaxChars, StyledTextArea, TitleAreaInfo } from './TitleArea.style'
 
@@ -27,21 +27,10 @@ export const TitleArea: React.FC<TitleAreaProps> = ({
 }) => {
   const [touched, setTouched] = useState(false)
   const invalidInput = (value?.length || 0) < min || (value?.length || 0) > max
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleFocus = () => {
     setTouched(true)
   }
-
-  useEffect(() => {
-    const textarea = textareaRef.current
-    if (!textarea) {
-      return
-    }
-    textarea.style.height = 'initial'
-    const scrollHeight = textarea.scrollHeight
-    textarea.style.height = scrollHeight + 'px'
-  }, [value])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -52,7 +41,6 @@ export const TitleArea: React.FC<TitleAreaProps> = ({
   return (
     <Container className={className}>
       <StyledTextArea
-        ref={textareaRef}
         rows={1}
         minLength={min}
         maxLength={max}

--- a/src/shared/components/TitleArea/TitleArea.tsx
+++ b/src/shared/components/TitleArea/TitleArea.tsx
@@ -4,10 +4,7 @@ import { CharactersCounter, Container, MinMaxChars, StyledTextArea, TitleAreaInf
 
 import { Text } from '../Text'
 
-export type TitleAreaVariant = 'small' | 'large'
-
 export type TitleAreaProps = {
-  variant?: TitleAreaVariant
   name?: string
   value?: string
   min?: number
@@ -21,7 +18,6 @@ export type TitleAreaProps = {
 export const TitleArea: React.FC<TitleAreaProps> = ({
   name,
   value,
-  variant = 'small',
   placeholder = 'Enter text here',
   onChange,
   onBlur,
@@ -56,7 +52,6 @@ export const TitleArea: React.FC<TitleAreaProps> = ({
   return (
     <Container className={className}>
       <StyledTextArea
-        variant={variant}
         ref={textareaRef}
         rows={1}
         minLength={min}
@@ -64,14 +59,13 @@ export const TitleArea: React.FC<TitleAreaProps> = ({
         name={name}
         placeholder={placeholder}
         onFocus={handleFocus}
-        touchedAndEmpty={touched && !value?.length}
         value={value}
         onChange={onChange}
         onKeyDown={handleKeyDown}
         onBlur={onBlur}
       />
 
-      <TitleAreaInfo>
+      <TitleAreaInfo visible={touched && !value?.length}>
         <MinMaxChars secondary variant="caption">
           Min {min} Chars | Max {max} Chars
         </MinMaxChars>

--- a/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -11,7 +11,6 @@ import { ViewErrorFallback } from '@/components/ViewErrorFallback'
 import { languages } from '@/config/languages'
 import { absoluteRoutes } from '@/config/routes'
 import { useDisplayDataLostWarning } from '@/hooks/useDisplayDataLostWarning'
-import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { ChannelAssets, ChannelId, CreateChannelMetadata } from '@/joystream-lib'
 import { AssetType, useAsset, useAssetStore, useRawAsset } from '@/providers/assets'
 import { useConnectionStatusStore } from '@/providers/connectionStatus'
@@ -71,7 +70,6 @@ type CreateEditChannelViewProps = {
 export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ newChannel }) => {
   const avatarDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
   const coverDialogRef = useRef<ImageCropDialogImperativeHandle>(null)
-  const smMatch = useMediaMatch('sm')
 
   const [avatarHashPromise, setAvatarHashPromise] = useState<Promise<string> | null>(null)
   const [coverHashPromise, setCoverHashPromise] = useState<Promise<string> | null>(null)
@@ -430,14 +428,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
                 rules={textFieldValidation({ name: 'Channel name', minLength: 3, maxLength: 40, required: true })}
                 render={({ field: { value, onChange } }) => (
                   <Tooltip text="Click to edit channel title" placement="top-start">
-                    <StyledTitleArea
-                      variant={smMatch ? 'small' : 'large'}
-                      min={3}
-                      max={40}
-                      placeholder="Channel title"
-                      value={value}
-                      onChange={onChange}
-                    />
+                    <StyledTitleArea min={3} max={40} placeholder="Channel title" value={value} onChange={onChange} />
                   </Tooltip>
                 )}
               />

--- a/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
+++ b/src/views/studio/EditVideoSheet/EditVideoForm/EditVideoForm.tsx
@@ -10,7 +10,6 @@ import { ViewErrorFallback } from '@/components/ViewErrorFallback'
 import { languages } from '@/config/languages'
 import knownLicenses from '@/data/knownLicenses.json'
 import { useDeleteVideo } from '@/hooks/useDeleteVideo'
-import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useAssetStore, useRawAsset } from '@/providers/assets'
 import { useConnectionStatusStore } from '@/providers/connectionStatus'
 import { RawDraft, useDraftStore } from '@/providers/drafts'
@@ -89,7 +88,6 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
   const isEdit = !selectedVideoTab?.isDraft
   const [actionBarRef, actionBarBounds] = useMeasure()
   const [moreSettingsVisible, setMoreSettingsVisible] = useState(false)
-  const smMatch = useMediaMatch('sm')
 
   const [forceReset, setForceReset] = useState(false)
   const [fileSelectError, setFileSelectError] = useState<string | null>(null)
@@ -437,14 +435,7 @@ export const EditVideoForm: React.FC<EditVideoFormProps> = ({
               control={control}
               rules={textFieldValidation({ name: 'Video Title', minLength: 3, maxLength: 40, required: true })}
               render={({ field: { value, onChange } }) => (
-                <StyledTitleArea
-                  variant={smMatch ? 'small' : 'large'}
-                  onChange={onChange}
-                  value={value}
-                  min={3}
-                  max={40}
-                  placeholder="Video title"
-                />
+                <StyledTitleArea onChange={onChange} value={value} min={3} max={40} placeholder="Video title" />
               )}
             />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7059,6 +7059,7 @@ __metadata:
     react-router: 6.0.0-beta.3
     react-router-dom: 6.0.0-beta.3
     react-spring: ^9.2.4
+    react-textarea-autosize: ^8.3.3
     react-transition-group: ^4.4.1
     react-use-measure: ^2.0.4
     retry-axios: ^2.4.0
@@ -17503,7 +17504,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-textarea-autosize@npm:^8.3.0":
+"react-textarea-autosize@npm:^8.3.0, react-textarea-autosize@npm:^8.3.3":
   version: 8.3.3
   resolution: "react-textarea-autosize@npm:8.3.3"
   dependencies:


### PR DESCRIPTION
Fix #1393 

I also decided to install `react-textarea-autosize`. I just didn't like how we handled autosizing previously. 
it's a small library that just works out of the box https://bundlephobia.com/package/react-textarea-autosize@8.3.3