### PR TITLE
introduce featured content fetched from Orion

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "history": "^5.0.0",
     "immer": "^9.0.5",
     "ipfs-only-hash": "^4.0.0",
+    "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
     "msw": "^0.35.0",
     "polished": "^4.1.3",

--- a/src/api/featured/backupVideoHeroData.json
+++ b/src/api/featured/backupVideoHeroData.json
@@ -1,5 +1,0 @@
-{
-  "videoId": "1",
-  "heroTitle": "Ghost Signals",
-  "heroVideoCutUrl": "https://eu-central-1.linodeobjects.com/atlas-hero/hero-cut-1.mp4"
-}

--- a/src/api/featured/categoriesFeaturedVideos.ts
+++ b/src/api/featured/categoriesFeaturedVideos.ts
@@ -1,0 +1,36 @@
+import { useApolloClient } from '@apollo/client'
+import { useMemo } from 'react'
+
+import { useVideos } from '@/api/hooks'
+import { VideoFieldsFragment } from '@/api/queries'
+import {
+  GetCategoriesFeaturedVideosDocument,
+  GetCategoriesFeaturedVideosQuery,
+} from '@/api/queries/__generated__/featured.generated'
+import { createLookup } from '@/utils/data'
+
+import { useGenericFeaturedData } from './helpers'
+
+type CategoriesFeaturedVideos = Record<string, (VideoFieldsFragment & { videoCutUrl?: string | null })[]>
+
+export const useCategoriesFeaturedVideos = (): CategoriesFeaturedVideos | null => {
+  const client = useApolloClient()
+  const fetchCategoriesFeaturedVideos = useMemo(
+    () => async () =>
+      (await client.query<GetCategoriesFeaturedVideosQuery>({ query: GetCategoriesFeaturedVideosDocument })).data
+        .allCategoriesFeaturedVideos,
+    [client]
+  )
+  const { data: rawData } = useGenericFeaturedData('categories-featured-videos', fetchCategoriesFeaturedVideos)
+
+  const allVideosIds = rawData?.reduce((acc, cur) => [...acc, ...cur.videos.map((v) => v.videoId)], [] as string[])
+  const { videos } = useVideos({ where: { id_in: allVideosIds } }, { skip: !allVideosIds || !allVideosIds.length })
+  const videosLookup = createLookup(videos || [])
+
+  const categoriesLookup = rawData?.reduce((acc, cur) => {
+    acc[cur.categoryId] = cur.videos.map((v) => ({ ...videosLookup[v.videoId], videoCutUrl: v.videoCutUrl }))
+    return acc
+  }, {} as CategoriesFeaturedVideos)
+
+  return (rawData && videos && categoriesLookup) ?? null
+}

--- a/src/api/featured/helpers.ts
+++ b/src/api/featured/helpers.ts
@@ -1,0 +1,53 @@
+import localforage from 'localforage'
+import { useEffect, useState } from 'react'
+
+import { useEnvironmentStore } from '@/providers/environment'
+import { SentryLogger } from '@/utils/logs'
+
+const localforageInstance = localforage.createInstance({
+  driver: localforage.INDEXEDDB,
+  name: `Joystream-Atlas-${useEnvironmentStore.getState().targetDevEnv}`,
+  storeName: 'featured-content-cache',
+})
+
+type PersistedDataRecord<T> = {
+  data: T
+  cachedAt: number
+}
+
+export const useGenericFeaturedData = <T>(key: string, memoizedFetchFn: () => Promise<T>) => {
+  const [data, setData] = useState<T | null>(null)
+
+  useEffect(() => {
+    const initData = async () => {
+      const record = await localforageInstance.getItem<PersistedDataRecord<T>>(key)
+
+      if (record) {
+        setData(record.data)
+      }
+
+      try {
+        const data = await memoizedFetchFn()
+        const newRecord: PersistedDataRecord<T> = {
+          data,
+          cachedAt: Date.now(),
+        }
+
+        if (!record) {
+          // only set data if there is no previous record, otherwise use the previous record until next app visit
+          setData(newRecord.data)
+        }
+
+        await localforageInstance.setItem<PersistedDataRecord<T>>(key, newRecord)
+      } catch (e) {
+        SentryLogger.error('Failed to fetch featured data', 'useGenericFeaturedData', e, {
+          featuredData: { key },
+        })
+      }
+    }
+
+    initData()
+  }, [key, memoizedFetchFn])
+
+  return { data }
+}

--- a/src/api/queries/__generated__/baseTypes.generated.ts
+++ b/src/api/queries/__generated__/baseTypes.generated.ts
@@ -18,6 +18,12 @@ export enum AssetAvailability {
   Invalid = 'INVALID',
 }
 
+export type CategoryFeaturedVideos = {
+  __typename?: 'CategoryFeaturedVideos'
+  categoryId: Scalars['ID']
+  videos: Array<FeaturedVideo>
+}
+
 export type Channel = {
   __typename?: 'Channel'
   id: Scalars['ID']
@@ -102,6 +108,17 @@ export type EntityViewsInfo = {
   views: Scalars['Int']
 }
 
+export type FeaturedVideo = {
+  __typename?: 'FeaturedVideo'
+  videoCutUrl?: Maybe<Scalars['String']>
+  videoId: Scalars['ID']
+}
+
+export type FeaturedVideoInput = {
+  videoCutUrl?: Maybe<Scalars['String']>
+  videoId: Scalars['ID']
+}
+
 export type Language = {
   __typename?: 'Language'
   id: Scalars['ID']
@@ -148,6 +165,8 @@ export type Mutation = {
   addVideoView: EntityViewsInfo
   /** Add a single follow to the target channel */
   followChannel: ChannelFollowsInfo
+  setCategoryFeaturedVideos: Array<FeaturedVideo>
+  setVideoHero: VideoHero
   /** Remove a single follow from the target channel */
   unfollowChannel: ChannelFollowsInfo
 }
@@ -160,6 +179,17 @@ export type MutationAddVideoViewArgs = {
 
 export type MutationFollowChannelArgs = {
   channelId: Scalars['ID']
+}
+
+export type MutationSetCategoryFeaturedVideosArgs = {
+  categoryId: Scalars['ID']
+  videos: Array<FeaturedVideoInput>
+}
+
+export type MutationSetVideoHeroArgs = {
+  heroTitle: Scalars['String']
+  heroVideoCutUrl: Scalars['String']
+  videoId: Scalars['ID']
 }
 
 export type MutationUnfollowChannelArgs = {
@@ -184,12 +214,16 @@ export type ProcessorState = {
 
 export type Query = {
   __typename?: 'Query'
+  /** Get featured videos for all categories */
+  allCategoriesFeaturedVideos: Array<CategoryFeaturedVideos>
   /** Get follows counts for a list of channels */
   batchedChannelFollows: Array<Maybe<ChannelFollowsInfo>>
   /** Get views counts for a list of channels */
   batchedChannelsViews: Array<Maybe<EntityViewsInfo>>
   /** Get views counts for a list of videos */
   batchedVideoViews: Array<Maybe<EntityViewsInfo>>
+  /** Get featured videos for a given video category */
+  categoryFeaturedVideos: Array<FeaturedVideo>
   channelByUniqueInput?: Maybe<Channel>
   /** Get follows count for a single channel */
   channelFollows?: Maybe<ChannelFollowsInfo>
@@ -204,17 +238,23 @@ export type Query = {
   mostFollowedChannels: Array<ChannelFollowsInfo>
   /** Get list of most followed channels of all time */
   mostFollowedChannelsAllTime?: Maybe<Array<ChannelFollowsInfo>>
-  /** Get list of channels with most views in given period */
+  /** Get list of most viewed categories in a given time period */
+  mostViewedCategories?: Maybe<Array<EntityViewsInfo>>
+  /** Get list of most viewed categories of all time */
+  mostViewedCategoriesAllTime?: Maybe<Array<EntityViewsInfo>>
+  /** Get list of most viewed channels in a given time period */
   mostViewedChannels?: Maybe<Array<EntityViewsInfo>>
-  /** Get list of channels with most views of all time */
+  /** Get list of most viewed channels of all time */
   mostViewedChannelsAllTime?: Maybe<Array<EntityViewsInfo>>
-  /** Get most viewed list of videos */
+  /** Get list of most viewed videos in a given time period */
   mostViewedVideos?: Maybe<Array<EntityViewsInfo>>
-  /** Get most viewed list of videos of all time */
+  /** Get list of most viewed videos of all time */
   mostViewedVideosAllTime?: Maybe<Array<EntityViewsInfo>>
   search: Array<SearchFtsOutput>
   videoByUniqueInput?: Maybe<Video>
   videoCategories: Array<VideoCategory>
+  /** Get current video hero */
+  videoHero: VideoHero
   /** Get views count for a single video */
   videoViews?: Maybe<EntityViewsInfo>
   videos?: Maybe<Array<Video>>
@@ -233,6 +273,10 @@ export type QueryBatchedChannelsViewsArgs = {
 
 export type QueryBatchedVideoViewsArgs = {
   videoIdList: Array<Scalars['ID']>
+}
+
+export type QueryCategoryFeaturedVideosArgs = {
+  categoryId: Scalars['ID']
 }
 
 export type QueryChannelByUniqueInputArgs = {
@@ -280,6 +324,15 @@ export type QueryMostFollowedChannelsArgs = {
 }
 
 export type QueryMostFollowedChannelsAllTimeArgs = {
+  limit: Scalars['Int']
+}
+
+export type QueryMostViewedCategoriesArgs = {
+  limit?: Maybe<Scalars['Int']>
+  timePeriodDays: Scalars['Int']
+}
+
+export type QueryMostViewedCategoriesAllTimeArgs = {
   limit: Scalars['Int']
 }
 
@@ -405,6 +458,13 @@ export type VideoEdge = {
   __typename?: 'VideoEdge'
   node: Video
   cursor: Scalars['String']
+}
+
+export type VideoHero = {
+  __typename?: 'VideoHero'
+  heroTitle: Scalars['String']
+  heroVideoCutUrl: Scalars['String']
+  videoId: Scalars['ID']
 }
 
 export type VideoMediaMetadata = {

--- a/src/api/queries/__generated__/featured.generated.tsx
+++ b/src/api/queries/__generated__/featured.generated.tsx
@@ -1,0 +1,115 @@
+import { gql } from '@apollo/client'
+import * as Apollo from '@apollo/client'
+
+import * as Types from './baseTypes.generated'
+
+const defaultOptions = {}
+export type GetVideoHeroQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetVideoHeroQuery = {
+  __typename?: 'Query'
+  videoHero: { __typename?: 'VideoHero'; videoId: string; heroTitle: string; heroVideoCutUrl: string }
+}
+
+export type GetCategoriesFeaturedVideosQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetCategoriesFeaturedVideosQuery = {
+  __typename?: 'Query'
+  allCategoriesFeaturedVideos: Array<{
+    __typename?: 'CategoryFeaturedVideos'
+    categoryId: string
+    videos: Array<{ __typename?: 'FeaturedVideo'; videoId: string; videoCutUrl?: Types.Maybe<string> }>
+  }>
+}
+
+export const GetVideoHeroDocument = gql`
+  query GetVideoHero {
+    videoHero {
+      videoId
+      heroTitle
+      heroVideoCutUrl
+    }
+  }
+`
+
+/**
+ * __useGetVideoHeroQuery__
+ *
+ * To run a query within a React component, call `useGetVideoHeroQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVideoHeroQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetVideoHeroQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetVideoHeroQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetVideoHeroQuery, GetVideoHeroQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetVideoHeroQuery, GetVideoHeroQueryVariables>(GetVideoHeroDocument, options)
+}
+export function useGetVideoHeroLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetVideoHeroQuery, GetVideoHeroQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetVideoHeroQuery, GetVideoHeroQueryVariables>(GetVideoHeroDocument, options)
+}
+export type GetVideoHeroQueryHookResult = ReturnType<typeof useGetVideoHeroQuery>
+export type GetVideoHeroLazyQueryHookResult = ReturnType<typeof useGetVideoHeroLazyQuery>
+export type GetVideoHeroQueryResult = Apollo.QueryResult<GetVideoHeroQuery, GetVideoHeroQueryVariables>
+export const GetCategoriesFeaturedVideosDocument = gql`
+  query GetCategoriesFeaturedVideos {
+    allCategoriesFeaturedVideos {
+      categoryId
+      videos {
+        videoId
+        videoCutUrl
+      }
+    }
+  }
+`
+
+/**
+ * __useGetCategoriesFeaturedVideosQuery__
+ *
+ * To run a query within a React component, call `useGetCategoriesFeaturedVideosQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCategoriesFeaturedVideosQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCategoriesFeaturedVideosQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetCategoriesFeaturedVideosQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetCategoriesFeaturedVideosQuery, GetCategoriesFeaturedVideosQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetCategoriesFeaturedVideosQuery, GetCategoriesFeaturedVideosQueryVariables>(
+    GetCategoriesFeaturedVideosDocument,
+    options
+  )
+}
+export function useGetCategoriesFeaturedVideosLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetCategoriesFeaturedVideosQuery, GetCategoriesFeaturedVideosQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetCategoriesFeaturedVideosQuery, GetCategoriesFeaturedVideosQueryVariables>(
+    GetCategoriesFeaturedVideosDocument,
+    options
+  )
+}
+export type GetCategoriesFeaturedVideosQueryHookResult = ReturnType<typeof useGetCategoriesFeaturedVideosQuery>
+export type GetCategoriesFeaturedVideosLazyQueryHookResult = ReturnType<typeof useGetCategoriesFeaturedVideosLazyQuery>
+export type GetCategoriesFeaturedVideosQueryResult = Apollo.QueryResult<
+  GetCategoriesFeaturedVideosQuery,
+  GetCategoriesFeaturedVideosQueryVariables
+>

--- a/src/api/queries/featured.graphql
+++ b/src/api/queries/featured.graphql
@@ -1,0 +1,17 @@
+query GetVideoHero {
+  videoHero {
+    videoId
+    heroTitle
+    heroVideoCutUrl
+  }
+}
+
+query GetCategoriesFeaturedVideos {
+  allCategoriesFeaturedVideos {
+    categoryId
+    videos {
+      videoId
+      videoCutUrl
+    }
+  }
+}

--- a/src/api/schemas/orion.graphql
+++ b/src/api/schemas/orion.graphql
@@ -3,6 +3,11 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
+type CategoryFeaturedVideos {
+  categoryId: ID!
+  videos: [FeaturedVideo!]!
+}
+
 type ChannelFollowsInfo {
   follows: Int!
   id: ID!
@@ -11,6 +16,16 @@ type ChannelFollowsInfo {
 type EntityViewsInfo {
   id: ID!
   views: Int!
+}
+
+type FeaturedVideo {
+  videoCutUrl: String
+  videoId: ID!
+}
+
+input FeaturedVideoInput {
+  videoCutUrl: String
+  videoId: ID!
 }
 
 type Mutation {
@@ -23,6 +38,8 @@ type Mutation {
   Add a single follow to the target channel
   """
   followChannel(channelId: ID!): ChannelFollowsInfo!
+  setCategoryFeaturedVideos(categoryId: ID!, videos: [FeaturedVideoInput!]!): [FeaturedVideo!]!
+  setVideoHero(heroTitle: String!, heroVideoCutUrl: String!, videoId: ID!): VideoHero!
 
   """
   Remove a single follow from the target channel
@@ -31,6 +48,11 @@ type Mutation {
 }
 
 type Query {
+  """
+  Get featured videos for all categories
+  """
+  allCategoriesFeaturedVideos: [CategoryFeaturedVideos!]!
+
   """
   Get follows counts for a list of channels
   """
@@ -47,6 +69,11 @@ type Query {
   batchedVideoViews(videoIdList: [ID!]!): [EntityViewsInfo]!
 
   """
+  Get featured videos for a given video category
+  """
+  categoryFeaturedVideos(categoryId: ID!): [FeaturedVideo!]!
+
+  """
   Get follows count for a single channel
   """
   channelFollows(channelId: ID!): ChannelFollowsInfo
@@ -59,7 +86,14 @@ type Query {
   """
   Get list of most followed channels
   """
-  mostFollowedChannels(limit: Int, timePeriodDays: Int!): [ChannelFollowsInfo!]!
+  mostFollowedChannels(
+    limit: Int
+
+    """
+    timePeriodDays must take one of the following values: 7, 30
+    """
+    timePeriodDays: Int!
+  ): [ChannelFollowsInfo!]!
 
   """
   Get list of most followed channels of all time
@@ -67,27 +101,69 @@ type Query {
   mostFollowedChannelsAllTime(limit: Int!): [ChannelFollowsInfo!]
 
   """
-  Get list of channels with most views in given period
+  Get list of most viewed categories in a given time period
   """
-  mostViewedChannels(limit: Int, timePeriodDays: Int!): [EntityViewsInfo!]
+  mostViewedCategories(
+    limit: Int
+
+    """
+    timePeriodDays must take one of the following values: 7, 30
+    """
+    timePeriodDays: Int!
+  ): [EntityViewsInfo!]
 
   """
-  Get list of channels with most views of all time
+  Get list of most viewed categories of all time
+  """
+  mostViewedCategoriesAllTime(limit: Int!): [EntityViewsInfo!]
+
+  """
+  Get list of most viewed channels in a given time period
+  """
+  mostViewedChannels(
+    limit: Int
+
+    """
+    timePeriodDays must take one of the following values: 7, 30
+    """
+    timePeriodDays: Int!
+  ): [EntityViewsInfo!]
+
+  """
+  Get list of most viewed channels of all time
   """
   mostViewedChannelsAllTime(limit: Int!): [EntityViewsInfo!]
 
   """
-  Get most viewed list of videos
+  Get list of most viewed videos in a given time period
   """
-  mostViewedVideos(limit: Int, timePeriodDays: Int!): [EntityViewsInfo!]
+  mostViewedVideos(
+    limit: Int
+
+    """
+    timePeriodDays must take one of the following values: 7, 30
+    """
+    timePeriodDays: Int!
+  ): [EntityViewsInfo!]
 
   """
-  Get most viewed list of videos of all time
+  Get list of most viewed videos of all time
   """
   mostViewedVideosAllTime(limit: Int!): [EntityViewsInfo!]
+
+  """
+  Get current video hero
+  """
+  videoHero: VideoHero!
 
   """
   Get views count for a single video
   """
   videoViews(videoId: ID!): EntityViewsInfo
+}
+
+type VideoHero {
+  heroTitle: String!
+  heroVideoCutUrl: String!
+  videoId: ID!
 }

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -12,8 +12,6 @@ export const SENTRY_DSN = readEnv('SENTRY_DSN', false)
 export const WEB3_APP_NAME = 'Joystream Atlas'
 export const STORAGE_URL_PATH = 'asset/v0'
 
-export const VIDEO_HERO_DATA_URL = 'https://eu-central-1.linodeobjects.com/atlas-hero/hero-info.json'
-
 export const JOYSTREAM_DISCORD_URL = 'https://discord.gg/DE9UN3YpRP'
 
 export const PIONEER_URL = 'https://testnet.joystream.org'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7044,6 +7044,7 @@ __metadata:
     immer: ^9.0.5
     ipfs-only-hash: ^4.0.0
     lint-staged: ^10.2.7
+    localforage: ^1.10.0
     lodash-es: ^4.17.21
     msw: ^0.35.0
     polished: ^4.1.3
@@ -12422,6 +12423,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
+  languageName: node
+  linkType: hard
+
 "immer@npm:8.0.1":
   version: 8.0.1
   resolution: "immer@npm:8.0.1"
@@ -13989,6 +13997,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lie@npm:3.1.1":
+  version: 3.1.1
+  resolution: "lie@npm:3.1.1"
+  dependencies:
+    immediate: ~3.0.5
+  checksum: 6da9f2121d2dbd15f1eca44c0c7e211e66a99c7b326ec8312645f3648935bc3a658cf0e9fa7b5f10144d9e2641500b4f55bd32754607c3de945b5f443e50ddd1
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.1.6
   resolution: "lines-and-columns@npm:1.1.6"
@@ -14131,6 +14148,15 @@ fsevents@^1.2.7:
     emojis-list: ^3.0.0
     json5: ^1.0.1
   checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  languageName: node
+  linkType: hard
+
+"localforage@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "localforage@npm:1.10.0"
+  dependencies:
+    lie: 3.1.1
+  checksum: f2978b434dafff9bcb0d9498de57d97eba165402419939c944412e179cab1854782830b5ec196212560b22712d1dd03918939f59cf1d4fc1d756fca7950086cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds ability for Atlas to fetch featured content from Orion. This currently includes video hero and featured videos for video categories. Raw featured data is fetched from Orion and later additional data (title, etc) is fetched from query node. Data is also cached in indexeddb so that cached values will always be available without a need to wait for Orion to respond. Once fresh data is fetched, it will replace the persisted cache, but will only be used from the next app visit.