### PR TITLE
Skip videos without assets when fetching most viewed videos

### DIFF
--- a/src/api/hooks/video.ts
+++ b/src/api/hooks/video.ts
@@ -126,6 +126,10 @@ export const useMostViewedVideos = (
     {
       where: {
         id_in: mostViewedVideosIds,
+        thumbnailPhotoAvailability_eq: AssetAvailability.Accepted,
+        mediaAvailability_eq: AssetAvailability.Accepted,
+        isPublic_eq: true,
+        isCensored_eq: false,
       },
     },
     { skip: !mostViewedVideosIds }


### PR DESCRIPTION
#Fixes 1462