### PR TITLE
Fix animation tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "lint:css": "stylelint './src/**/*.{tsx,ts}'",
     "lint": "yarn lint:css && yarn lint:ts && yarn lint:prettier",
     "fetch-tokens": "node ./src/styles/scripts/fetchTokens",
+    "build-tokens": "style-dictionary build --config ./sd.config.js && prettier --write src/styles/generated/variables.ts",
     "codegen:graphql": "graphql-codegen --config codegen.config.yml",
     "codegen:graphql-watch": "yarn codegen:graphql --watch",
     "codegen:icons": "svgr --config-file svgr.config.js -d src/shared/icons src/shared/icons/svgs",
     "codegen:illustrations": "svgr --config-file svgr.config.js -d src/shared/illustrations src/shared/illustrations/svgs",
     "codegen:svgs": "yarn codegen:illustrations && yarn codegen:icons",
-    "codegen:styles": "yarn fetch-tokens && style-dictionary build --config ./sd.config.js && prettier --write src/styles/generated/variables.ts"
+    "codegen:styles": "yarn fetch-tokens && yarn build-tokens"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json}": [

--- a/sd.config.js
+++ b/sd.config.js
@@ -38,13 +38,13 @@ module.exports = {
       type: 'value',
       matcher: (token) => token.attributes.category === 'easing',
       // [1, 2, 3, 4] will become 1, 2, 3, 4
-      transformer: (token) => token.value.replaceAll(/\[|\]/g, ''),
+      transformer: (token) => `cubic-bezier(${token.value.replaceAll(/\[|\]/g, '')})`,
     },
     transitionTransform: {
       type: 'value',
       transitive: true,
       matcher: (token) => token.attributes.category === 'transition' && token.value.timing && token.value.easing,
-      transformer: (token) => `${token.value.timing.value} cubic-bezier(${token.value.easing.value})`,
+      transformer: (token) => `${token.value.timing.value} ${token.value.easing.value}`,
     },
   },
   format: {

--- a/sd.config.js
+++ b/sd.config.js
@@ -19,28 +19,24 @@ module.exports = {
   source: [`./src/styles/tokens/**/*.json`],
   transform: {
     referencedValueTransform: {
+      // style dictionary requires adding ".value" suffix to all referenced value,  e.g.  "value": "{core.neutral.default.900}" should be  e.g.  "value": "{core.neutral.default.900.value}"
+      // this transform should fix it, although it just a workaround
+      // we could remove this when they do something about it https://github.com/amzn/style-dictionary/issues/721
       type: 'value',
       transitive: true,
-      matcher: (token) => token.value.value,
-      transformer: (token) => {
-        return token.value.value
-      },
+      matcher: (token) => token.value.value && token.type !== 'typedef',
+      transformer: (token) => token.value.value,
     },
     easingTransform: {
       type: 'value',
       matcher: (token) => token.attributes.category === 'easing',
-      transformer: (token) => {
-        // transforms [1, 2, 3, 4] to 1, 2, 3, 4
-        return token.value.replaceAll(/\[|\]/g, '')
-      },
+      transformer: (token) => token.value.replaceAll(/\[|\]/g, ''),
     },
     transitionTransform: {
       type: 'value',
       transitive: true,
       matcher: (token) => token.attributes.category === 'transition' && token.value.timing && token.value.easing,
-      transformer: (token) => {
-        return `${token.value.timing.value} cubic-bezier(${token.value.easing.value})`
-      },
+      transformer: (token) => `${token.value.timing.value} cubic-bezier(${token.value.easing.value})`,
     },
   },
   format: {
@@ -48,22 +44,31 @@ module.exports = {
       return variablesTemplate({
         cssVariables: dictionary.allTokens
           .map((token) => {
+            if (token.type === 'typedef') {
+              return
+            }
             const baseFileName = basename(token.filePath).replace('.token.json', '')
             // singularize string
             const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName
-            let value = `--${prefix}-${token.name.replaceAll('-default', '')}: ${token.value};`
+            let keyValuePair = `--${prefix}-${token.name.replaceAll('-default', '')}: ${token.value};`
             if (dictionary.usesReference(token.original.value)) {
               const refs = dictionary.getReferences(token.original.value)
 
               refs.forEach((ref) => {
-                value = value.replace(ref.value, ` var(--${prefix}-${ref.name.replaceAll('-default', '')})`)
+                keyValuePair = keyValuePair.replace(
+                  ref.value,
+                  ` var(--${prefix}-${ref.name.replaceAll('-default', '')})`
+                )
               })
             }
-            return value
+            return keyValuePair
           })
           .join('\n'),
         themeVariables: dictionary.allTokens
           .map((token) => {
+            if (token.type === 'typedef') {
+              return
+            }
             const baseFileName = basename(token.filePath).replace('.token.json', '')
             // singularize string
             const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName

--- a/sd.config.js
+++ b/sd.config.js
@@ -15,6 +15,13 @@ export const cVar = (key: keyof typeof theme) => {
 }
 `)
 
+const createTokenKey = (token) => {
+  const baseFileName = basename(token.filePath).replace('.token.json', '')
+  // singularize string
+  const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName
+  return `${prefix}-${token.name.replaceAll('-default', '')}`
+}
+
 module.exports = {
   source: [`./src/styles/tokens/**/*.json`],
   transform: {
@@ -47,18 +54,13 @@ module.exports = {
             if (token.type === 'typedef') {
               return
             }
-            const baseFileName = basename(token.filePath).replace('.token.json', '')
-            // singularize string
-            const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName
-            let keyValuePair = `--${prefix}-${token.name.replaceAll('-default', '')}: ${token.value};`
+
+            let keyValuePair = `--${createTokenKey(token)}: ${token.value};`
             if (dictionary.usesReference(token.original.value)) {
               const refs = dictionary.getReferences(token.original.value)
 
               refs.forEach((ref) => {
-                keyValuePair = keyValuePair.replace(
-                  ref.value,
-                  ` var(--${prefix}-${ref.name.replaceAll('-default', '')})`
-                )
+                keyValuePair = keyValuePair.replace(ref.value, ` var(--${createTokenKey(ref)})`)
               })
             }
             return keyValuePair
@@ -69,10 +71,7 @@ module.exports = {
             if (token.type === 'typedef') {
               return
             }
-            const baseFileName = basename(token.filePath).replace('.token.json', '')
-            // singularize string
-            const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName
-            const variableName = `${prefix}-${token.name.replaceAll('-default', '')}`
+            const variableName = createTokenKey(token)
             const key = camelCase(variableName)
             const value = `'var(--${kebabCase(variableName)})'`
 

--- a/sd.config.js
+++ b/sd.config.js
@@ -37,6 +37,7 @@ module.exports = {
     easingTransform: {
       type: 'value',
       matcher: (token) => token.attributes.category === 'easing',
+      // [1, 2, 3, 4] will become 1, 2, 3, 4
       transformer: (token) => token.value.replaceAll(/\[|\]/g, ''),
     },
     transitionTransform: {

--- a/sd.config.js
+++ b/sd.config.js
@@ -27,6 +27,16 @@ module.exports = {
       },
     },
   ],
+  transform: {
+    easingTransform: {
+      type: 'value',
+      matcher: (token) => token.attributes.category === 'easing',
+      transformer: (token) => {
+        // transforms [1, 2, 3, 4] to 1, 2, 3, 4
+        return token.value.replaceAll(/\[|\]/g, '')
+      },
+    },
+  },
   format: {
     customFormat: ({ dictionary }) => {
       return variablesTemplate({
@@ -35,9 +45,7 @@ module.exports = {
             const baseFileName = basename(token.filePath).replace('.token.json', '')
             // singularize string
             const prefix = baseFileName.substr(-1) === 's' ? baseFileName.slice(0, -1) : baseFileName
-
             let value = `--${prefix}-${token.name.replaceAll('-default', '')}: ${token.value};`
-
             if (dictionary.usesReference(token.original.value)) {
               const refs = dictionary.getReferences(token.original.value)
 
@@ -65,7 +73,7 @@ module.exports = {
   },
   platforms: {
     ts: {
-      transforms: [`attribute/cti`, `name/cti/kebab`],
+      transforms: [`attribute/cti`, `name/cti/kebab`, 'easingTransform'],
       buildPath: 'src/styles/generated/',
       files: [
         {

--- a/src/styles/generated/variables.ts
+++ b/src/styles/generated/variables.ts
@@ -5,9 +5,9 @@ export const variables = css`
     --animation-timing-fast: 150ms;
     --animation-timing-medium: 250ms;
     --animation-timing-slow: 500ms;
-    --animation-easing-fast: [0, 0, 0.3, 1];
-    --animation-easing-medium: [0.03, 0.5, 0.25, 1];
-    --animation-easing-bounce: [0.3, 1.5, 0.6, 0.95];
+    --animation-easing-fast: 0, 0, 0.3, 1;
+    --animation-easing-medium: 0.03, 0.5, 0.25, 1;
+    --animation-easing-bounce: 0.3, 1.5, 0.6, 0.95;
     --animation-transition-transition-type: [object Object];
     --animation-transition-fast: [object Object];
     --animation-transition-medium: [object Object];
@@ -228,7 +228,6 @@ export const theme = {
   colorBackgroundSuccess: 'var(--color-background-success)',
   colorBackgroundSuccessStrong: 'var(--color-background-success-strong)',
 }
-
 export const cVar = (key: keyof typeof theme) => {
   return theme[key]
 }

--- a/src/styles/generated/variables.ts
+++ b/src/styles/generated/variables.ts
@@ -8,11 +8,11 @@ export const variables = css`
     --animation-easing-fast: 0, 0, 0.3, 1;
     --animation-easing-medium: 0.03, 0.5, 0.25, 1;
     --animation-easing-bounce: 0.3, 1.5, 0.6, 0.95;
-    --animation-transition-transition-type: [object Object];
-    --animation-transition-fast: [object Object];
-    --animation-transition-medium: [object Object];
-    --animation-transition-slow: [object Object];
-    --animation-transition-callout: [object Object];
+    --animation-transition-transition-type: undefined cubic-bezier(undefined);
+    --animation-transition-fast: var(--animation-timing-fast) cubic-bezier(var(--animation-easing-fast));
+    --animation-transition-medium: var(--animation-timing-medium) cubic-bezier(var(--animation-easing-medium));
+    --animation-transition-slow: var(--animation-timing-slow) cubic-bezier(var(--animation-easing-medium));
+    --animation-transition-callout: var(--animation-timing-medium) cubic-bezier(var(--animation-easing-bounce));
     --color-core-neutral-50: #f4f6f8;
     --color-core-neutral-50-lighten: #fafafafa;
     --color-core-neutral-50-darken: #234a710d;

--- a/src/styles/generated/variables.ts
+++ b/src/styles/generated/variables.ts
@@ -8,7 +8,7 @@ export const variables = css`
     --animation-easing-fast: 0, 0, 0.3, 1;
     --animation-easing-medium: 0.03, 0.5, 0.25, 1;
     --animation-easing-bounce: 0.3, 1.5, 0.6, 0.95;
-    --animation-transition-transition-type: undefined cubic-bezier(undefined);
+
     --animation-transition-fast: var(--animation-timing-fast) cubic-bezier(var(--animation-easing-fast));
     --animation-transition-medium: var(--animation-timing-medium) cubic-bezier(var(--animation-easing-medium));
     --animation-transition-slow: var(--animation-timing-slow) cubic-bezier(var(--animation-easing-medium));
@@ -122,7 +122,7 @@ export const theme = {
   animationEasingFast: 'var(--animation-easing-fast)',
   animationEasingMedium: 'var(--animation-easing-medium)',
   animationEasingBounce: 'var(--animation-easing-bounce)',
-  animationTransitionTransitionType: 'var(--animation-transition-transition-type)',
+
   animationTransitionFast: 'var(--animation-transition-fast)',
   animationTransitionMedium: 'var(--animation-transition-medium)',
   animationTransitionSlow: 'var(--animation-transition-slow)',

--- a/src/styles/generated/variables.ts
+++ b/src/styles/generated/variables.ts
@@ -5,14 +5,14 @@ export const variables = css`
     --animation-timing-fast: 150ms;
     --animation-timing-medium: 250ms;
     --animation-timing-slow: 500ms;
-    --animation-easing-fast: 0, 0, 0.3, 1;
-    --animation-easing-medium: 0.03, 0.5, 0.25, 1;
-    --animation-easing-bounce: 0.3, 1.5, 0.6, 0.95;
+    --animation-easing-fast: cubic-bezier(0, 0, 0.3, 1);
+    --animation-easing-medium: cubic-bezier(0.03, 0.5, 0.25, 1);
+    --animation-easing-bounce: cubic-bezier(0.3, 1.5, 0.6, 0.95);
 
-    --animation-transition-fast: var(--animation-timing-fast) cubic-bezier(var(--animation-easing-fast));
-    --animation-transition-medium: var(--animation-timing-medium) cubic-bezier(var(--animation-easing-medium));
-    --animation-transition-slow: var(--animation-timing-slow) cubic-bezier(var(--animation-easing-medium));
-    --animation-transition-callout: var(--animation-timing-medium) cubic-bezier(var(--animation-easing-bounce));
+    --animation-transition-fast: var(--animation-timing-fast) var(--animation-easing-fast);
+    --animation-transition-medium: var(--animation-timing-medium) var(--animation-easing-medium);
+    --animation-transition-slow: var(--animation-timing-slow) var(--animation-easing-medium);
+    --animation-transition-callout: var(--animation-timing-medium) var(--animation-easing-bounce);
     --color-core-neutral-50: #f4f6f8;
     --color-core-neutral-50-lighten: #fafafafa;
     --color-core-neutral-50-darken: #234a710d;

--- a/src/views/playground/Playgrounds/DesignTokens.tsx
+++ b/src/views/playground/Playgrounds/DesignTokens.tsx
@@ -35,6 +35,10 @@ const GreenDiv = styled(Box)`
 `
 const RedDiv = styled(Box)`
   background-color: ${cVar('colorBackgroundErrorMuted')};
+  transition: background-color ${cVar('animationTransitionMedium')};
+  :hover {
+    background-color: ${cVar('colorBackgroundErrorStrong')};
+  }
 `
 const AlphaContainer = styled.div`
   position: relative;

--- a/src/views/playground/Playgrounds/DesignTokens.tsx
+++ b/src/views/playground/Playgrounds/DesignTokens.tsx
@@ -28,6 +28,10 @@ const Box = styled.div`
 
 const GreenDiv = styled(Box)`
   background-color: ${cVar('colorCoreGreen800')};
+  transition: background-color 200ms cubic-bezier(${cVar('animationEasingBounce')});
+  :hover {
+    background-color: ${cVar('colorCoreGreen300')};
+  }
 `
 const RedDiv = styled(Box)`
   background-color: ${cVar('colorBackgroundErrorMuted')};

--- a/src/views/playground/Playgrounds/DesignTokens.tsx
+++ b/src/views/playground/Playgrounds/DesignTokens.tsx
@@ -28,7 +28,7 @@ const Box = styled.div`
 
 const GreenDiv = styled(Box)`
   background-color: ${cVar('colorCoreGreen800')};
-  transition: background-color 200ms cubic-bezier(${cVar('animationEasingBounce')});
+  transition: background-color 200ms ${cVar('animationEasingBounce')};
   :hover {
     background-color: ${cVar('colorCoreGreen300')};
   }


### PR DESCRIPTION
Fix #1535 
Also did some slight refactoring:
- removed parser and add `referencedValueTransform` instead
- refactored `customFormat`

It should correctly generate tokens for all animations(easings, timings and transitions)