### PR TITLE
Fix storybook build

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,5 +1,8 @@
 <link rel="stylesheet" href="https://eu-central-1.linodeobjects.com/atlas-assets/fonts/PxGrotesk/PxGrotesk.css" />
 <link rel="stylesheet" href="https://eu-central-1.linodeobjects.com/atlas-assets/fonts/Inter/inter.css" />
+<script>
+  window.setImmediate = window.setTimeout
+</script>
 <style>
   body {
     margin: 0;


### PR DESCRIPTION
We were getting `setImmediate is not defined` on the storybook build. I'm not sure what's `setImmediate`  and why storybook needs it, but it should resolve the issue. 

To test it locally, you can run 
```
yarn build-storybook
npx http-server storybook-static
```
