### PR TITLE
Remove polished library

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "ipfs-only-hash": "^4.0.0",
     "localforage": "^1.10.0",
     "lodash-es": "^4.17.21",
-    "polished": "^4.1.3",
     "rc-slider": "^9.7.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/_video/VideoCategoryCard/VideoCategoryCard.stories.tsx
+++ b/src/components/_video/VideoCategoryCard/VideoCategoryCard.stories.tsx
@@ -1,20 +1,40 @@
+import { ApolloProvider } from '@apollo/client'
 import styled from '@emotion/styled'
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+
+import { createApolloClient } from '@/api'
+import { SvgCategoriesAutosAndVehicles } from '@/components/_icons'
 
 import { VideoCategoryCard, VideoCategoryCardProps } from './VideoCategoryCard'
 
 import { FeaturedVideoCategoryCard } from '.'
 
 export default {
-  title: 'Shared/V/VideoCategoryCard',
-  argTypes: {
-    color: { defaultValue: '#D92E61' },
-    variant: { defaultValue: 'default' },
-    categoryId: { defaultValue: '1' },
-    videosTotalCount: { defaultValue: 300 },
-  },
+  title: 'video/VideoCategoryCard',
+  args: {
+    color: '#D92E61',
+    variant: 'default',
+    categoryId: '1',
+    videosTotalCount: 300,
+    icon: <SvgCategoriesAutosAndVehicles />,
+    title: 'Category',
+  } as VideoCategoryCardProps,
   component: VideoCategoryCard,
+  decorators: [
+    (Story) => {
+      const apolloClient = createApolloClient()
+
+      return (
+        <BrowserRouter>
+          <ApolloProvider client={apolloClient}>
+            <Story />
+          </ApolloProvider>
+        </BrowserRouter>
+      )
+    },
+  ],
 } as Meta
 
 const Template: Story<VideoCategoryCardProps> = (args) => {

--- a/src/components/_video/VideoCategoryCard/VideoCategoryCard.style.ts
+++ b/src/components/_video/VideoCategoryCard/VideoCategoryCard.style.ts
@@ -1,13 +1,12 @@
 import isPropValid from '@emotion/is-prop-valid'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import { transparentize } from 'polished'
 import { Link } from 'react-router-dom'
 
 import { Text } from '@/components/Text'
-import { oldColors, sizes, transitions } from '@/styles'
+import { cVar, oldColors, sizes, transitions } from '@/styles'
 
-type ColorProps = { color: string }
+type ColorProps = { color?: string }
 type LoadingProps = { isLoading?: boolean }
 type VariantProps = { variantCategory?: 'default' | 'compact' }
 
@@ -97,15 +96,24 @@ export const Content = styled.div<VariantProps>`
   padding: ${({ variantCategory }) => (variantCategory === 'default' ? sizes(8) : sizes(4))};
 `
 
+export const CircleDefaultBackground = styled.div<ColorProps>`
+  position: absolute;
+  background: ${({ color = cVar('colorCoreNeutral300') }) => color};
+  opacity: 0.2;
+  width: 100%;
+  height: 100%;
+`
+
 export const IconCircle = styled.div<ColorProps>`
+  position: relative;
   display: flex;
+  overflow: hidden;
   margin-bottom: ${sizes(4)};
   align-items: center;
   justify-content: center;
   width: ${sizes(10)};
   height: ${sizes(10)};
   border-radius: 100%;
-  background: ${({ color }) => transparentize(0.8, color)};
 
   path {
     fill: ${({ color }) => color};
@@ -119,7 +127,6 @@ export const Title = styled(Text)<VariantProps>`
 // ref https://codeburst.io/how-to-pure-css-pie-charts-w-css-variables-38287aea161e
 export const PieChart = styled.div`
   margin-right: ${sizes(2)};
-  background: ${transparentize(0.8, '#7b8a95')};
   border-radius: 100%;
   height: ${sizes(4)};
   width: ${sizes(4)};

--- a/src/components/_video/VideoCategoryCard/VideoCategoryCard.tsx
+++ b/src/components/_video/VideoCategoryCard/VideoCategoryCard.tsx
@@ -9,6 +9,7 @@ import { sizes, transitions } from '@/styles'
 import { SentryLogger } from '@/utils/logs'
 
 import {
+  CircleDefaultBackground,
   Content,
   CoverImg,
   CoverImgContainer,
@@ -72,7 +73,10 @@ export const VideoCategoryCard: React.FC<VideoCategoryCardProps> = ({
             {loading ? (
               <SkeletonLoader bottomSpace={sizes(4)} width="40px" height="40px" rounded />
             ) : (
-              <IconCircle color={color}>{icon}</IconCircle>
+              <IconCircle color={color}>
+                <CircleDefaultBackground color={color} />
+                {icon}
+              </IconCircle>
             )}
 
             {loading ? (
@@ -93,6 +97,7 @@ export const VideoCategoryCard: React.FC<VideoCategoryCardProps> = ({
               ) : (
                 <>
                   <PieChart>
+                    <CircleDefaultBackground />
                     <PieSegment value={pieChartValue}></PieSegment>
                   </PieChart>
                   <Text variant={variant === 'default' ? 't200' : 't100'} secondary>

--- a/src/views/viewer/ChannelView/ChannelView.styles.ts
+++ b/src/views/viewer/ChannelView/ChannelView.styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import { fluidRange } from 'polished'
 
 import { Tabs } from '@/components/Tabs'
 import { Text } from '@/components/Text'
@@ -52,9 +51,6 @@ export const TitleContainer = styled.div`
 `
 
 export const Title = styled(Text)`
-  ${fluidRange({ prop: 'fontSize', fromSize: '24px', toSize: '40px' })};
-
-  line-height: 1;
   margin-bottom: 0;
   padding: ${sizes(1)} ${sizes(2)} 5px;
   white-space: nowrap;
@@ -73,8 +69,6 @@ export const SortContainer = styled.div`
 `
 
 export const SubTitle = styled(Text)`
-  ${fluidRange({ prop: 'fontSize', fromSize: '14px', toSize: '18px' })};
-
   padding: ${sizes(1)} ${sizes(2)};
   margin-top: ${sizes(1)};
   color: ${oldColors.gray[300]};
@@ -86,11 +80,11 @@ export const VideoSection = styled.section`
 `
 
 export const StyledChannelLink = styled(ChannelLink)`
-  margin-bottom: ${sizes(3)};
+  margin: 0 ${sizes(5)} ${sizes(3)} 0;
   position: relative;
 
   ${media.sm} {
-    margin: 0 ${sizes(6)} 0 0;
+    margin: 0 ${sizes(5)} 0 0;
   }
 `
 

--- a/src/views/viewer/ChannelView/ChannelView.tsx
+++ b/src/views/viewer/ChannelView/ChannelView.tsx
@@ -23,6 +23,7 @@ import { VideoTile } from '@/components/_video/VideoTile'
 import { absoluteRoutes } from '@/config/routes'
 import { SORT_OPTIONS } from '@/config/sorting'
 import { useHandleFollowChannel } from '@/hooks/useHandleFollowChannel'
+import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useVideoGridRows } from '@/hooks/useVideoGridRows'
 import { AssetType, useAsset } from '@/providers/assets'
 import { transitions } from '@/styles'
@@ -56,6 +57,7 @@ const INITIAL_FIRST = 50
 const INITIAL_VIDEOS_PER_ROW = 4
 export const ChannelView: React.FC = () => {
   const videoRows = useVideoGridRows('main')
+  const xsMatch = useMediaMatch('xs')
   const { id } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const { channel, loading, error } = useChannel(id ?? '', {
@@ -240,8 +242,8 @@ export const ChannelView: React.FC = () => {
           <TitleContainer>
             {channel ? (
               <>
-                <Title variant="h800">{channel.title}</Title>
-                <SubTitle variant="t200">{channel.follows ? formatNumberShort(channel.follows) : 0} Followers</SubTitle>
+                <Title variant={xsMatch ? 'h700' : 'h500'}>{channel.title}</Title>
+                <SubTitle variant="t300">{channel.follows ? formatNumberShort(channel.follows) : 0} Followers</SubTitle>
               </>
             ) : (
               <>

--- a/src/views/viewer/VideoView/VideoView.styles.ts
+++ b/src/views/viewer/VideoView/VideoView.styles.ts
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled'
-import { fluidRange } from 'polished'
 
 import { Text } from '@/components/Text'
 import { ViewWrapper } from '@/components/ViewWrapper'
 import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
-import { breakpoints, cVar, media, oldColors, sizes } from '@/styles'
+import { cVar, media, oldColors, sizes } from '@/styles'
 
 export const StyledViewWrapper = styled(ViewWrapper)`
   display: flex;
@@ -42,14 +41,9 @@ export const InfoContainer = styled.div`
 export const Meta = styled(Text)`
   display: block;
   margin-top: ${sizes(1)};
-  color: ${oldColors.gray[300]};
-
-  ${fluidRange({ prop: 'fontSize', fromSize: '13px', toSize: '18px' }, breakpoints.xxs, breakpoints.xl)};
 `
 
 export const TitleText = styled(Text)`
-  ${fluidRange({ prop: 'fontSize', fromSize: '24px', toSize: '40px' }, breakpoints.xxs, breakpoints.xl)};
-
   word-break: break-word;
 `
 

--- a/src/views/viewer/VideoView/VideoView.tsx
+++ b/src/views/viewer/VideoView/VideoView.tsx
@@ -12,6 +12,7 @@ import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
 import { VideoPlayer } from '@/components/_video/VideoPlayer'
 import { absoluteRoutes } from '@/config/routes'
 import knownLicenses from '@/data/knownLicenses.json'
+import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useRouterQuery } from '@/hooks/useRouterQuery'
 import { AssetType, useAsset } from '@/providers/assets'
 import { usePersonalDataStore } from '@/providers/personalData'
@@ -40,6 +41,7 @@ export const VideoView: React.FC = () => {
   const { loading, video, error } = useVideo(id ?? '', {
     onError: (error) => SentryLogger.error('Failed to load video data', 'VideoView', error),
   })
+  const xsMatch = useMediaMatch('sm')
   const { addVideoView } = useAddVideoView()
   const watchedVideos = usePersonalDataStore((state) => state.watchedVideos)
   const updateWatchedVideos = usePersonalDataStore((state) => state.actions.updateWatchedVideos)
@@ -163,12 +165,16 @@ export const VideoView: React.FC = () => {
         </PlayerContainer>
       </PlayerWrapper>
       <InfoContainer className={transitions.names.slide}>
-        {video ? <TitleText variant="h700">{video.title}</TitleText> : <SkeletonLoader height={46} width={400} />}
-        <Meta variant="t300">
+        {video ? (
+          <TitleText variant={xsMatch ? 'h700' : 'h500'}>{video.title}</TitleText>
+        ) : (
+          <SkeletonLoader height={xsMatch ? 56 : 32} width={400} />
+        )}
+        <Meta variant="t300" secondary>
           {video ? (
             formatVideoViewsAndDate(video.views || null, video.createdAt, { fullViews: true })
           ) : (
-            <SkeletonLoader height={18} width={200} />
+            <SkeletonLoader height={24} width={200} />
           )}
         </Meta>
         <ChannelContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7513,7 +7513,6 @@ __metadata:
     lint-staged: ^12.1.2
     localforage: ^1.10.0
     lodash-es: ^4.17.21
-    polished: ^4.1.3
     postcss-syntax: ^0.36.2
     prettier: ~2.5.0
     rc-slider: ^9.7.4
@@ -17092,7 +17091,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"polished@npm:^4.0.5, polished@npm:^4.1.3":
+"polished@npm:^4.0.5":
   version: 4.1.3
   resolution: "polished@npm:4.1.3"
   dependencies:


### PR DESCRIPTION
Fix #290

FYI, I allowed myself to choose the values for font sizes. Didn't want to set hardcoded values, I wanted to use values that were generated from design tokens. They differ from the designs, but designs for the ChannelView and the VideoView are quite old now and I think they're using different fonts anyway. 

VideoView: https://www.figma.com/file/Vk2Z4QOiVa5bB6q3cBIG5J/Joystream-Atlas?node-id=6345%3A149653
ChannelView: https://www.figma.com/file/Vk2Z4QOiVa5bB6q3cBIG5J/Joystream-Atlas?node-id=6277%3A8778
CategoryCards: https://www.figma.com/file/UdBMxrLspjcf6IVYYJS8YP/%5BPage%5D-Discover-%26-Video-category?node-id=244%3A97798