### PR TITLE
Fix wrong button order in dialogs

### DIFF
--- a/src/components/_overlays/Dialog/Dialog.styles.ts
+++ b/src/components/_overlays/Dialog/Dialog.styles.ts
@@ -115,9 +115,5 @@ export const FooterButtonsContainer = styled.div`
     grid-auto-flow: column;
     grid-auto-columns: auto;
     justify-content: end;
-
-    > :first-of-type {
-      order: 2;
-    }
   }
 `

--- a/src/components/_overlays/Dialog/Dialog.styles.ts
+++ b/src/components/_overlays/Dialog/Dialog.styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 
+import { Button } from '@/components/_buttons/Button'
 import { media, oldColors, sizes } from '@/styles'
 
 export type DialogSize = 'default' | 'compact'
@@ -108,15 +109,20 @@ export const Footer = styled.div<FooterProps>`
 `
 
 export const FooterButtonsContainer = styled.div`
-  display: grid;
-  gap: ${sizes(2)};
+  display: flex;
+  flex-direction: column-reverse;
 
   ${media.sm} {
+    display: grid;
+    gap: ${sizes(2)};
     grid-auto-flow: column;
+    justify-content: flex-end;
     grid-auto-columns: auto;
-
-    /* those two properties below will reverse order of button */
-    direction: rtl;
-    justify-content: flex-start;
+  }
+`
+export const StyledPrimaryButton = styled(Button)`
+  margin-bottom: ${sizes(2)};
+  ${media.sm} {
+    margin-bottom: unset;
   }
 `

--- a/src/components/_overlays/Dialog/Dialog.styles.ts
+++ b/src/components/_overlays/Dialog/Dialog.styles.ts
@@ -114,6 +114,9 @@ export const FooterButtonsContainer = styled.div`
   ${media.sm} {
     grid-auto-flow: column;
     grid-auto-columns: auto;
-    justify-content: end;
+
+    /* those two properties below will reverse order of button */
+    direction: rtl;
+    justify-content: flex-start;
   }
 `

--- a/src/components/_overlays/Dialog/Dialog.tsx
+++ b/src/components/_overlays/Dialog/Dialog.tsx
@@ -15,6 +15,7 @@ import {
   Header,
   HeaderContent,
   HeaderIconContainer,
+  StyledPrimaryButton,
 } from './Dialog.styles'
 
 type DialogButtonProps = {
@@ -94,16 +95,15 @@ export const Dialog: React.FC<DialogProps> = ({
         <Footer dividers={dividers} hasAdditionalActions={!!additionalActionsNode}>
           {additionalActionsNode}
           <FooterButtonsContainer>
-            {/* order of buttons on desktop is reversed via CSS direction property */}
-            {primaryButton && (
-              <Button variant="primary" {...buttonProps} {...primaryButton}>
-                {primaryButton.text}
-              </Button>
-            )}
             {secondaryButton && (
               <Button variant="secondary" {...buttonProps} {...secondaryButton}>
                 {secondaryButton.text}
               </Button>
+            )}
+            {primaryButton && (
+              <StyledPrimaryButton variant="primary" {...buttonProps} {...primaryButton}>
+                {primaryButton.text}
+              </StyledPrimaryButton>
             )}
           </FooterButtonsContainer>
         </Footer>

--- a/src/components/_overlays/Dialog/Dialog.tsx
+++ b/src/components/_overlays/Dialog/Dialog.tsx
@@ -94,15 +94,14 @@ export const Dialog: React.FC<DialogProps> = ({
         <Footer dividers={dividers} hasAdditionalActions={!!additionalActionsNode}>
           {additionalActionsNode}
           <FooterButtonsContainer>
-            {/* order of buttons on desktop is reversed via CSS order property */}
-            {primaryButton && (
-              <Button variant="primary" {...buttonProps} {...primaryButton}>
-                {primaryButton.text}
-              </Button>
-            )}
             {secondaryButton && (
               <Button variant="secondary" {...buttonProps} {...secondaryButton}>
                 {secondaryButton.text}
+              </Button>
+            )}
+            {primaryButton && (
+              <Button variant="primary" {...buttonProps} {...primaryButton}>
+                {primaryButton.text}
               </Button>
             )}
           </FooterButtonsContainer>

--- a/src/components/_overlays/Dialog/Dialog.tsx
+++ b/src/components/_overlays/Dialog/Dialog.tsx
@@ -94,14 +94,15 @@ export const Dialog: React.FC<DialogProps> = ({
         <Footer dividers={dividers} hasAdditionalActions={!!additionalActionsNode}>
           {additionalActionsNode}
           <FooterButtonsContainer>
-            {secondaryButton && (
-              <Button variant="secondary" {...buttonProps} {...secondaryButton}>
-                {secondaryButton.text}
-              </Button>
-            )}
+            {/* order of buttons on desktop is reversed via CSS direction property */}
             {primaryButton && (
               <Button variant="primary" {...buttonProps} {...primaryButton}>
                 {primaryButton.text}
+              </Button>
+            )}
+            {secondaryButton && (
+              <Button variant="secondary" {...buttonProps} {...secondaryButton}>
+                {secondaryButton.text}
               </Button>
             )}
           </FooterButtonsContainer>

--- a/src/components/_overlays/DialogModal/DialogModal.stories.tsx
+++ b/src/components/_overlays/DialogModal/DialogModal.stories.tsx
@@ -27,8 +27,7 @@ export default {
 
 const OpenTemplate: Story<DialogModalProps> = ({ ...args }) => {
   return (
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    <DialogModal {...args} show={true} onExitClick={() => {}}>
+    <DialogModal {...args} show={true} onExitClick={() => null}>
       <p>Content spanning multiple lines</p>
       <p>Content spanning multiple lines</p>
       <p>Content spanning multiple lines</p>
@@ -66,3 +65,12 @@ const ToggleableTemplate: Story<DialogModalProps> = ({ ...args }) => {
   )
 }
 export const Toggleable = ToggleableTemplate.bind({})
+
+export const WithLink = OpenTemplate.bind({})
+
+WithLink.args = {
+  primaryButton: {
+    text: 'Go to google',
+    to: 'https://google.com',
+  },
+}


### PR DESCRIPTION
Fix #1601 

I'm not sure, what's was the reason for using `order` here. Please double-check if removing this property breaks anything 