### PR TITLE
Fix: clicking video end overlay makes it playback

### DIFF
--- a/src/components/_channel/ChannelLink/ChannelLink.tsx
+++ b/src/components/_channel/ChannelLink/ChannelLink.tsx
@@ -15,7 +15,7 @@ import { Container, StyledAvatar, StyledText } from './ChannelLink.styles'
 
 type ChannelLinkProps = {
   id?: string
-  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
   hideHandle?: boolean
   hideAvatar?: boolean
   noLink?: boolean
@@ -29,6 +29,7 @@ type ChannelLinkProps = {
 
 export const ChannelLink: React.FC<ChannelLinkProps> = ({
   id,
+  onClick,
   hideHandle,
   hideAvatar,
   noLink,
@@ -53,7 +54,7 @@ export const ChannelLink: React.FC<ChannelLinkProps> = ({
 
   const _textVariant = textVariant ?? textSecondary ? 't200-strong' : 't300-strong'
   return (
-    <Container to={absoluteRoutes.viewer.channel(id)} disabled={!id || noLink} className={className}>
+    <Container onClick={onClick} to={absoluteRoutes.viewer.channel(id)} disabled={!id || noLink} className={className}>
       {!hideAvatar && (
         <StyledAvatar
           withHandle={!hideHandle}

--- a/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.styles.ts
+++ b/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.styles.ts
@@ -47,6 +47,7 @@ export const InnerContainer = styled.div`
   overflow-y: auto;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 
   ${media.md} {
     width: 100%;

--- a/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.tsx
+++ b/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.tsx
@@ -32,7 +32,7 @@ type EndingOverlayProps = {
   isEnded: boolean
 }
 // 10 seconds
-const NEXT_VIDEO_TIMEOUT = 10000
+const NEXT_VIDEO_TIMEOUT = 10 * 1000
 
 export const EndingOverlay: React.FC<EndingOverlayProps> = ({
   onPlayAgain,
@@ -103,17 +103,32 @@ export const EndingOverlay: React.FC<EndingOverlayProps> = ({
   }, [currentThumbnailUrl, randomNextVideo, randomNextVideoThumbnailUrl])
 
   return (
-    <OverlayBackground>
+    <OverlayBackground
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
+    >
       {randomNextVideo ? (
         <Container isFullScreen={isFullScreen}>
-          <InnerContainer>
+          <InnerContainer
+            onClick={() => {
+              navigate(absoluteRoutes.viewer.video(randomNextVideo.id))
+            }}
+          >
             <VideoThumbnail src={thumbnailUrl} />
             <VideoInfo>
               <Text variant={mdMatch ? 't300' : 't200'} secondary>
                 Up next
               </Text>
               <Heading variant={mdMatch ? 'h500' : 'h400'}>{randomNextVideo.title}</Heading>
-              <StyledChannelLink id={channelId} avatarSize="default" textVariant={mdMatch ? 't300' : 't200'} />
+              <StyledChannelLink
+                onClick={(e) => {
+                  e.stopPropagation()
+                }}
+                id={channelId}
+                avatarSize="default"
+                textVariant={mdMatch ? 't300' : 't200'}
+              />
             </VideoInfo>
           </InnerContainer>
           <CountDownWrapper>

--- a/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.tsx
+++ b/src/components/_video/VideoPlayer/VideoOverlays/EndingOverlay.tsx
@@ -102,12 +102,12 @@ export const EndingOverlay: React.FC<EndingOverlayProps> = ({
     }
   }, [currentThumbnailUrl, randomNextVideo, randomNextVideoThumbnailUrl])
 
+  const stopPropagationx = (e: React.MouseEvent) => {
+    e.stopPropagation()
+  }
+
   return (
-    <OverlayBackground
-      onClick={(e) => {
-        e.stopPropagation()
-      }}
-    >
+    <OverlayBackground onClick={stopPropagationx}>
       {randomNextVideo ? (
         <Container isFullScreen={isFullScreen}>
           <InnerContainer
@@ -122,9 +122,7 @@ export const EndingOverlay: React.FC<EndingOverlayProps> = ({
               </Text>
               <Heading variant={mdMatch ? 'h500' : 'h400'}>{randomNextVideo.title}</Heading>
               <StyledChannelLink
-                onClick={(e) => {
-                  e.stopPropagation()
-                }}
+                onClick={stopPropagationx}
                 id={channelId}
                 avatarSize="default"
                 textVariant={mdMatch ? 't300' : 't200'}


### PR DESCRIPTION
Fixes: #1768

Additional quality of life change:
Made it so clicking on the next video card on the video end overlay
takes you to that video