### PR TITLE
Add MembershipHeader component

### DIFF
--- a/src/components/MembershipInfo/MembershipInfo.stories.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from '@storybook/react'
+import React from 'react'
+
+import { MembershipInfo, MembershipInfoProps } from './'
+
+export default {
+  title: 'other/MembershipInfo',
+  component: MembershipInfo,
+  args: {
+    address: '5CrLvuj3zAVYNYSUSiScr5gH9sLrcgME4oKjQf4xu1Zj5B7e',
+    avatarUrl: 'https://thispersondoesnotexist.com/image',
+    handle: 'doesnotexist',
+  },
+} as Meta
+
+const Template: Story<MembershipInfoProps> = (args) => <MembershipInfo {...args} />
+
+export const Default = Template.bind({})

--- a/src/components/MembershipInfo/MembershipInfo.stories.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.stories.tsx
@@ -10,6 +10,7 @@ export default {
     address: '5CrLvuj3zAVYNYSUSiScr5gH9sLrcgME4oKjQf4xu1Zj5B7e',
     avatarUrl: 'https://thispersondoesnotexist.com/image',
     handle: 'doesnotexist',
+    loading: false,
   },
 } as Meta
 

--- a/src/components/MembershipInfo/MembershipInfo.stories.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.stories.tsx
@@ -11,6 +11,7 @@ export default {
     avatarUrl: 'https://thispersondoesnotexist.com/image',
     handle: 'doesnotexist',
     loading: false,
+    isOwner: false,
   },
 } as Meta
 

--- a/src/components/MembershipInfo/MembershipInfo.style.ts
+++ b/src/components/MembershipInfo/MembershipInfo.style.ts
@@ -40,9 +40,9 @@ export const StyledText = styled(Text)`
   margin-top: ${sizes(2)};
   display: flex;
   align-items: center;
+  cursor: pointer;
 `
 export const StyledSvgActionCopy = styled(SvgActionCopy)`
-  cursor: pointer;
   margin-left: ${sizes(2)};
 
   path {

--- a/src/components/MembershipInfo/MembershipInfo.style.ts
+++ b/src/components/MembershipInfo/MembershipInfo.style.ts
@@ -5,6 +5,17 @@ import { cVar, media, sizes } from '@/styles'
 import { Text } from '../Text'
 import { SvgActionCopy } from '../_icons'
 
+export const MembershipHeader = styled.header`
+  display: flex;
+  flex-direction: column;
+  gap: ${sizes(6)};
+  align-items: center;
+  ${media.sm} {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+`
+
 export const MembershipInfoContainer = styled.div`
   display: grid;
   grid-template-rows: repeat(2, auto);

--- a/src/components/MembershipInfo/MembershipInfo.style.ts
+++ b/src/components/MembershipInfo/MembershipInfo.style.ts
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled'
+
+import { cVar, media, sizes } from '@/styles'
+
+import { Text } from '../Text'
+import { SvgActionCopy } from '../_icons'
+
+export const MembershipInfoContainer = styled.div`
+  display: grid;
+  grid-template-rows: repeat(2, auto);
+  justify-items: center;
+  gap: ${sizes(6)};
+  ${media.sm} {
+    gap: ${sizes(8)};
+    grid-template-columns: repeat(2, auto);
+    display: inline-grid;
+  }
+`
+export const MembershipDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  ${media.sm} {
+    align-items: unset;
+  }
+`
+export const StyledText = styled(Text)`
+  margin-top: ${sizes(2)};
+  display: flex;
+  align-items: center;
+`
+export const StyledSvgActionCopy = styled(SvgActionCopy)`
+  cursor: pointer;
+  margin-left: ${sizes(2)};
+
+  path {
+    fill: ${cVar('colorCoreNeutral300')};
+    transition: ${cVar('animationTransitionFast')};
+  }
+
+  :hover {
+    path {
+      fill: ${cVar('colorCoreNeutral50')};
+    }
+  }
+`

--- a/src/components/MembershipInfo/MembershipInfo.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.tsx
@@ -5,51 +5,70 @@ import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { cVar, transitions } from '@/styles'
 import { copyToClipboard } from '@/utils/browser'
 
-import { MembershipDetails, MembershipInfoContainer, StyledSvgActionCopy, StyledText } from './MembershipInfo.style'
+import {
+  MembershipDetails,
+  MembershipHeader,
+  MembershipInfoContainer,
+  StyledSvgActionCopy,
+  StyledText,
+} from './MembershipInfo.style'
 
 import { Avatar } from '../Avatar'
 import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
+import { Button } from '../_buttons/Button'
+import { SvgActionEdit } from '../_icons'
 import { SkeletonLoader } from '../_loaders/SkeletonLoader'
 
 export type MembershipInfoProps = {
   avatarUrl?: string
-  handle: string
-  address: string
-  loading: boolean
+  handle?: string
+  address?: string
+  loading?: boolean
+  isOwner?: boolean
 }
 
-export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarUrl, handle, loading }) => {
+export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarUrl, handle, loading, isOwner }) => {
   const smMatch = useMediaMatch('sm')
   return (
-    <MembershipInfoContainer>
-      <Avatar size={smMatch ? 'preview' : 'channel-card'} assetUrl={avatarUrl} loading={loading} />
-      <SwitchTransition>
-        <CSSTransition
-          key={String(loading)}
-          timeout={parseInt(cVar('animationTimingFast', true))}
-          classNames={transitions.names.fade}
-        >
-          <MembershipDetails>
-            {loading ? (
-              <SkeletonLoader width={200} height={smMatch ? 56 : 40} bottomSpace={8} />
+    <SwitchTransition>
+      <CSSTransition
+        key={String(loading)}
+        timeout={parseInt(cVar('animationTimingFast', true))}
+        classNames={transitions.names.fade}
+      >
+        <MembershipHeader>
+          <MembershipInfoContainer>
+            <Avatar size={smMatch ? 'preview' : 'channel-card'} assetUrl={avatarUrl} loading={loading} />
+            <MembershipDetails>
+              {loading || !handle ? (
+                <SkeletonLoader width={200} height={smMatch ? 56 : 40} bottomSpace={8} />
+              ) : (
+                <Text variant={smMatch ? 'h700' : 'h600'}>{handle}</Text>
+              )}
+              {loading || !address ? (
+                <SkeletonLoader width={140} height={24} />
+              ) : (
+                <StyledText variant="t300" secondary>
+                  {shortenAddress(address, 6, 4)}
+                  <Tooltip text="Copy address" arrowDisabled placement="top">
+                    <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
+                  </Tooltip>
+                </StyledText>
+              )}
+            </MembershipDetails>
+          </MembershipInfoContainer>
+          {isOwner &&
+            (loading ? (
+              <SkeletonLoader width={smMatch ? 148 : '100%'} height={48} />
             ) : (
-              <Text variant={smMatch ? 'h700' : 'h600'}>{handle}</Text>
-            )}
-            {loading ? (
-              <SkeletonLoader width={140} height={24} />
-            ) : (
-              <StyledText variant="t300" secondary>
-                {shortenAddress(address, 6, 4)}
-                <Tooltip text="Copy address" arrowDisabled placement="top">
-                  <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
-                </Tooltip>
-              </StyledText>
-            )}
-          </MembershipDetails>
-        </CSSTransition>
-      </SwitchTransition>
-    </MembershipInfoContainer>
+              <Button icon={<SvgActionEdit />} size="large" variant="secondary" fullWidth={!smMatch}>
+                Edit profile
+              </Button>
+            ))}
+        </MembershipHeader>
+      </CSSTransition>
+    </SwitchTransition>
   )
 }
 

--- a/src/components/MembershipInfo/MembershipInfo.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.tsx
@@ -3,6 +3,7 @@ import { CSSTransition, SwitchTransition } from 'react-transition-group'
 
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { cVar, transitions } from '@/styles'
+import { shortenAddress } from '@/utils/address'
 import { copyToClipboard } from '@/utils/browser'
 
 import {
@@ -49,10 +50,10 @@ export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarU
               {loading || !address ? (
                 <SkeletonLoader width={140} height={24} />
               ) : (
-                <StyledText variant="t300" secondary>
+                <StyledText variant="t300" secondary onClick={() => copyToClipboard(address)}>
                   {shortenAddress(address, 6, 4)}
                   <Tooltip text="Copy address" arrowDisabled placement="top">
-                    <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
+                    <StyledSvgActionCopy />
                   </Tooltip>
                 </StyledText>
               )}
@@ -70,11 +71,4 @@ export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarU
       </CSSTransition>
     </SwitchTransition>
   )
-}
-
-export const shortenAddress = (text: string, firstLettersAmount: number, lastLettersAmount: number) => {
-  const arrayFromString = text.split('')
-  const firstLetters = arrayFromString.slice(0, firstLettersAmount).join('')
-  const lastLetters = arrayFromString.slice(arrayFromString.length - 1 - lastLettersAmount).join('')
-  return `${firstLetters}...${lastLetters}`
 }

--- a/src/components/MembershipInfo/MembershipInfo.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
 
 import { useMediaMatch } from '@/hooks/useMediaMatch'
+import { cVar, transitions } from '@/styles'
 import { copyToClipboard } from '@/utils/browser'
 
 import { MembershipDetails, MembershipInfoContainer, StyledSvgActionCopy, StyledText } from './MembershipInfo.style'
@@ -8,27 +10,45 @@ import { MembershipDetails, MembershipInfoContainer, StyledSvgActionCopy, Styled
 import { Avatar } from '../Avatar'
 import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
+import { SkeletonLoader } from '../_loaders/SkeletonLoader'
 
 export type MembershipInfoProps = {
   avatarUrl?: string
   handle: string
   address: string
+  loading: boolean
 }
 
-export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarUrl, handle }) => {
+export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarUrl, handle, loading }) => {
   const smMatch = useMediaMatch('sm')
   return (
     <MembershipInfoContainer>
-      <Avatar size={smMatch ? 'preview' : 'channel-card'} assetUrl={avatarUrl} />
-      <MembershipDetails>
-        <Text variant={smMatch ? 'h700' : 'h600'}>{handle}</Text>
-        <StyledText variant="t300" secondary>
-          {shortenAddress(address, 6, 4)}
-          <Tooltip text="Copy address" arrowDisabled placement="top">
-            <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
-          </Tooltip>
-        </StyledText>
-      </MembershipDetails>
+      <Avatar size={smMatch ? 'preview' : 'channel-card'} assetUrl={avatarUrl} loading={loading} />
+      <SwitchTransition>
+        <CSSTransition
+          key={String(loading)}
+          timeout={parseInt(cVar('animationTimingFast', true))}
+          classNames={transitions.names.fade}
+        >
+          <MembershipDetails>
+            {loading ? (
+              <SkeletonLoader width={200} height={smMatch ? 56 : 40} bottomSpace={8} />
+            ) : (
+              <Text variant={smMatch ? 'h700' : 'h600'}>{handle}</Text>
+            )}
+            {loading ? (
+              <SkeletonLoader width={140} height={24} />
+            ) : (
+              <StyledText variant="t300" secondary>
+                {shortenAddress(address, 6, 4)}
+                <Tooltip text="Copy address" arrowDisabled placement="top">
+                  <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
+                </Tooltip>
+              </StyledText>
+            )}
+          </MembershipDetails>
+        </CSSTransition>
+      </SwitchTransition>
     </MembershipInfoContainer>
   )
 }

--- a/src/components/MembershipInfo/MembershipInfo.tsx
+++ b/src/components/MembershipInfo/MembershipInfo.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import { useMediaMatch } from '@/hooks/useMediaMatch'
+import { copyToClipboard } from '@/utils/browser'
+
+import { MembershipDetails, MembershipInfoContainer, StyledSvgActionCopy, StyledText } from './MembershipInfo.style'
+
+import { Avatar } from '../Avatar'
+import { Text } from '../Text'
+import { Tooltip } from '../Tooltip'
+
+export type MembershipInfoProps = {
+  avatarUrl?: string
+  handle: string
+  address: string
+}
+
+export const MembershipInfo: React.FC<MembershipInfoProps> = ({ address, avatarUrl, handle }) => {
+  const smMatch = useMediaMatch('sm')
+  return (
+    <MembershipInfoContainer>
+      <Avatar size={smMatch ? 'preview' : 'channel-card'} assetUrl={avatarUrl} />
+      <MembershipDetails>
+        <Text variant={smMatch ? 'h700' : 'h600'}>{handle}</Text>
+        <StyledText variant="t300" secondary>
+          {shortenAddress(address, 6, 4)}
+          <Tooltip text="Copy address" arrowDisabled placement="top">
+            <StyledSvgActionCopy onClick={() => copyToClipboard(address)} />
+          </Tooltip>
+        </StyledText>
+      </MembershipDetails>
+    </MembershipInfoContainer>
+  )
+}
+
+export const shortenAddress = (text: string, firstLettersAmount: number, lastLettersAmount: number) => {
+  const arrayFromString = text.split('')
+  const firstLetters = arrayFromString.slice(0, firstLettersAmount).join('')
+  const lastLetters = arrayFromString.slice(arrayFromString.length - 1 - lastLettersAmount).join('')
+  return `${firstLetters}...${lastLetters}`
+}

--- a/src/components/MembershipInfo/index.ts
+++ b/src/components/MembershipInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './MembershipInfo'

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,6 @@
+export const shortenAddress = (text: string, firstLettersAmount: number, lastLettersAmount: number) => {
+  const arrayFromString = text.split('')
+  const firstLetters = arrayFromString.slice(0, firstLettersAmount).join('')
+  const lastLetters = arrayFromString.slice(arrayFromString.length - 1 - lastLettersAmount).join('')
+  return `${firstLetters}...${lastLetters}`
+}


### PR DESCRIPTION
Partly fixes #1755 
This PR adds the `MembershipInfo` component, which could be used in membership views: 
![image](https://user-images.githubusercontent.com/51168865/148188572-5aa5ed05-7763-4df9-a294-fa948538d30e.png)
Design: https://www.figma.com/file/yhZpTHdf1sxJx13uRZ71GV/Membership-profile?node-id=564%3A98784