### PR TITLE
remove automatic title for video, remove unneeded TODO items

### DIFF
--- a/src/api/client/cache.ts
+++ b/src/api/client/cache.ts
@@ -63,9 +63,6 @@ const getSearchKeyArgs = (args: Record<string, SearchQueryVariables['whereVideo'
 const createDateHandler = () => ({
   merge: (_: unknown, existingData: string | Date): Date => {
     if (typeof existingData !== 'string') {
-      // TODO: investigate further
-      // rarely, for some reason the object that arrives here is already a date object
-      // in this case parsing attempt will cause an error
       return existingData
     }
     return parseISO(existingData)

--- a/src/components/Searchbar/Searchbar.styles.ts
+++ b/src/components/Searchbar/Searchbar.styles.ts
@@ -82,7 +82,6 @@ export const InnerContainer = styled.div<{ hasFocus: boolean; hasQuery: boolean 
   }
 `
 
-// TODO: remove override on viewer update
 export const StyledSvgOutlineSearch = styled(SvgControlsSearchAlt, { shouldForwardProp: isPropValid })<{
   highlighted?: boolean
 }>`

--- a/src/providers/uploadsManager/useStartFileUpload.ts
+++ b/src/providers/uploadsManager/useStartFileUpload.ts
@@ -147,7 +147,6 @@ export const useStartFileUpload = () => {
           onUploadProgress: setUploadProgress,
         })
 
-        // TODO: remove assets from the same parent if all finished
         setAssetStatus({ lastStatus: 'processing', progress: 100 })
         addProcessingAssetId(asset.contentId)
 

--- a/src/views/studio/VideoWorkspace/VideoWorkspaceForm/VideoWorkspaceForm.tsx
+++ b/src/views/studio/VideoWorkspace/VideoWorkspaceForm/VideoWorkspaceForm.tsx
@@ -540,22 +540,9 @@ export const VideoWorkspaceForm: React.FC<VideoWorkspaceFormProps> = React.memo(
           onVideoFileChange(video.blob)
         }
 
-        if (!dirtyFields.title && video?.title) {
-          // TODO: don't change it if the draft was saved and reloaded
-          const videoNameWithoutExtension = video.title.replace(/\.[^.]+$/, '')
-          setValue('title', videoNameWithoutExtension, { shouldDirty: true })
-        }
         setFileSelectError(null)
       },
-      [
-        addAsset,
-        dirtyFields.title,
-        getValues,
-        onVideoFileChange,
-        selectedVideoTab?.isDraft,
-        setSelectedVideoTabCachedAssets,
-        setValue,
-      ]
+      [addAsset, getValues, onVideoFileChange, selectedVideoTab?.isDraft, setSelectedVideoTabCachedAssets, setValue]
     )
 
     const handleThumbnailFileChange = useCallback(


### PR DESCRIPTION
Removed the behavior of auto-populating video name with the file name. We discussed this with Bedeho and think it's better to force the user to input a name

Other than that, removed some TODO items that we had in the app that aren't really actionable