### PR TITLE
update .env to use new atlas-dev domain

### DIFF
--- a/.env
+++ b/.env
@@ -3,10 +3,10 @@
 VITE_ENV=development
 
 # default target env is development
-VITE_DEVELOPMENT_ORION_URL=https://3.91.205.218.nip.io/orion/graphql
-VITE_DEVELOPMENT_QUERY_NODE_SUBSCRIPTION_URL=wss://3.91.205.218.nip.io/query-node/server/graphql
-VITE_DEVELOPMENT_NODE_URL=wss://3.91.205.218.nip.io/ws-rpc
-VITE_DEVELOPMENT_FAUCET_URL=https://3.91.205.218.nip.io/member-faucet/register
+VITE_DEVELOPMENT_ORION_URL=https://atlas-dev.joystream.app/orion/graphql
+VITE_DEVELOPMENT_QUERY_NODE_SUBSCRIPTION_URL=wss://atlas-dev.joystream.app/query-node/server/graphql
+VITE_DEVELOPMENT_NODE_URL=wss://atlas-dev.joystream.app/ws-rpc
+VITE_DEVELOPMENT_FAUCET_URL=https://atlas-dev.joystream.app/member-faucet/register
 VITE_DEVELOPMENT_OFFICIAL_JOYSTREAM_CHANNEL_ID=12
 
 VITE_PRODUCTION_ORION_URL=https://orion.joystream.org/graphql

--- a/src/providers/assets/assetsManager.tsx
+++ b/src/providers/assets/assetsManager.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 
 import { StorageDataObjectFieldsFragment } from '@/api/queries'
 import { ASSET_RESPONSE_TIMEOUT } from '@/config/assets'
+import { BUILD_ENV } from '@/config/envs'
 import { DISTRIBUTOR_ASSET_PATH } from '@/config/urls'
 import { joinUrlFragments } from '@/utils/asset'
 import { AssetLogger, ConsoleLogger, DataObjectResponseMetric, DistributorEventEntry, SentryLogger } from '@/utils/logs'
@@ -129,13 +130,15 @@ const createDistributionOperatorDataObjectUrl = (
 }
 
 const logDistributorPerformance = async (assetUrl: string, eventEntry: DistributorEventEntry) => {
+  if (!AssetLogger.isEnabled) return
+
   // delay execution for 1s to make sure performance entries get populated
   await new Promise((resolve) => setTimeout(resolve, 1000))
 
   const performanceEntries = window.performance.getEntriesByName(assetUrl)
   const performanceEntry = performanceEntries[0] as PerformanceResourceTiming
 
-  if (!performanceEntry) {
+  if (!performanceEntry && BUILD_ENV === 'production') {
     ConsoleLogger.debug('Performance entry not found', { assetUrl })
     return
   }

--- a/src/utils/logs/asset.ts
+++ b/src/utils/logs/asset.ts
@@ -36,11 +36,12 @@ class _AssetLogger {
   private user?: Record<string, unknown>
 
   initialize(logUrl: string | null) {
+    // increase the size of performance entry buffer, so we don't skip any assets
+    window.performance.setResourceTimingBufferSize(1000)
+
     if (!logUrl) return
 
     this.logUrl = logUrl
-    // increase the size of performance entry buffer, so we don't skip any assets
-    window.performance.setResourceTimingBufferSize(1000)
   }
 
   setUser(user?: Record<string, unknown>) {

--- a/src/utils/logs/asset.ts
+++ b/src/utils/logs/asset.ts
@@ -48,6 +48,10 @@ class _AssetLogger {
     this.user = user
   }
 
+  get isEnabled() {
+    return !!this.logUrl
+  }
+
   private pendingEvents: StorageEvent[] = []
 
   private sendEvents = debounce(async () => {


### PR DESCRIPTION
- replaced the `nip.io` domains with our own domain
- moved the buffer size set to happen if the log URL is not set so that we don't get `performance entry not found` logs in dev