### PR TITLE
use ListItem in ContextMenu

### DIFF
--- a/src/components/ListItem/ListItem.styles.ts
+++ b/src/components/ListItem/ListItem.styles.ts
@@ -45,6 +45,7 @@ export const Container = styled.div<ContainerProps>`
   grid-template-columns: ${({ hasNodeStart }) => (hasNodeStart ? 'auto 1fr' : '1fr')};
   align-items: center;
   user-select: none;
+  cursor: pointer;
 
   ${({ disabled }) => disabled && disabledStyles};
   ${({ size }) => getContainerPadding(size)};

--- a/src/components/_overlays/ContextMenu/ContextMenu.styles.ts
+++ b/src/components/_overlays/ContextMenu/ContextMenu.styles.ts
@@ -1,25 +1,13 @@
 import styled from '@emotion/styled'
 
 import { Text } from '@/components/Text'
-import { cVar, oldColors, sizes, transitions } from '@/styles'
+import { cVar, sizes, transitions } from '@/styles'
 
 export const StyledContainer = styled.div`
-  background-color: ${oldColors.gray[800]};
+  background-color: ${cVar('colorBackgroundStrong')};
   width: 200px;
-  color: ${oldColors.white};
+  color: ${cVar('colorText')};
   word-break: break-all;
-`
-
-export const StyledMenuItem = styled.div`
-  display: flex;
-  align-items: center;
-  padding: ${sizes(4)};
-  transition: background-color 200ms ${transitions.easing};
-
-  &:hover {
-    cursor: pointer;
-    background-color: ${oldColors.gray[700]};
-  }
 `
 
 export const StyledText = styled(Text)`

--- a/src/components/_overlays/ContextMenu/ContextMenu.styles.ts
+++ b/src/components/_overlays/ContextMenu/ContextMenu.styles.ts
@@ -1,18 +1,9 @@
 import styled from '@emotion/styled'
 
-import { Text } from '@/components/Text'
-import { cVar, sizes, transitions } from '@/styles'
+import { cVar } from '@/styles'
 
 export const StyledContainer = styled.div`
   background-color: ${cVar('colorBackgroundStrong')};
   width: 200px;
-  color: ${cVar('colorText')};
   word-break: break-all;
-`
-
-export const StyledText = styled(Text)`
-  font: ${cVar('typographyDesktopH200')};
-  letter-spacing: ${cVar('typographyDesktopH200LetterSpacing')};
-  text-transform: ${cVar('typographyDesktopH200TextTransform')};
-  margin-left: ${sizes(3)};
 `

--- a/src/components/_overlays/ContextMenu/ContextMenu.tsx
+++ b/src/components/_overlays/ContextMenu/ContextMenu.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useRef } from 'react'
 
 import { ListItem } from '@/components/ListItem'
 
-import { StyledContainer, StyledText } from './ContextMenu.styles'
+import { StyledContainer } from './ContextMenu.styles'
 
 import { Popover, PopoverImperativeHandle, PopoverProps } from '../Popover'
 
@@ -13,12 +13,6 @@ export type MenuItemProps = {
   disabled?: boolean
 }
 
-export const ContextMenuItem: React.FC<MenuItemProps> = React.memo(({ icon, onClick, title }) => {
-  return <ListItem onClick={onClick} label={title} nodeStart={icon} />
-})
-
-ContextMenuItem.displayName = 'ContextMenuItem'
-
 type ContextMenuProps = { items: MenuItemProps[] } & Omit<PopoverProps, 'content' | 'instanceRef'>
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({ children, items, ...rest }) => {
@@ -27,14 +21,14 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ children, items, ...re
     <Popover hideOnClick ref={contextMenuInstanceRef} {...rest}>
       <StyledContainer>
         {items.map((item, index) => (
-          <ContextMenuItem
+          <ListItem
             key={index}
-            icon={item.icon}
-            title={item.title}
             onClick={() => {
               item.onClick?.()
               contextMenuInstanceRef.current?.hide()
             }}
+            label={item.title}
+            nodeStart={item.icon}
           />
         ))}
       </StyledContainer>

--- a/src/components/_overlays/ContextMenu/ContextMenu.tsx
+++ b/src/components/_overlays/ContextMenu/ContextMenu.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode, useRef } from 'react'
 
-import { StyledContainer, StyledMenuItem, StyledText } from './ContextMenu.styles'
+import { ListItem } from '@/components/ListItem'
+
+import { StyledContainer, StyledText } from './ContextMenu.styles'
 
 import { Popover, PopoverImperativeHandle, PopoverProps } from '../Popover'
 
@@ -12,12 +14,7 @@ export type MenuItemProps = {
 }
 
 export const ContextMenuItem: React.FC<MenuItemProps> = React.memo(({ icon, onClick, title }) => {
-  return (
-    <StyledMenuItem onClick={onClick}>
-      {icon}
-      <StyledText variant="t200">{title}</StyledText>
-    </StyledMenuItem>
-  )
+  return <ListItem onClick={onClick} label={title} nodeStart={icon} />
 })
 
 ContextMenuItem.displayName = 'ContextMenuItem'


### PR DESCRIPTION
**What is this?**

This update the MenuContext component to use the new ListItem instead of a custom styling. This also uses the new color scheme. 

**Issue** 

https://github.com/Joystream/atlas/issues/1863

**Illustration**

![contextmenu](https://user-images.githubusercontent.com/96242244/150754461-438054b4-4d23-4eea-9190-814c3ca0debb.gif)

