### PR TITLE
fix VideoTile animation

### DIFF
--- a/packages/atlas/src/components/_video/VideoThumbnail/VideoThumbnail.tsx
+++ b/packages/atlas/src/components/_video/VideoThumbnail/VideoThumbnail.tsx
@@ -113,8 +113,8 @@ export const VideoThumbnail = forwardRef<HTMLAnchorElement, VideoThumbnailProps>
                   key={position}
                   type={properties.type}
                   position={position as keyof SlotsObject}
-                  onMouseMove={() => clickable && setActiveDisabled(true)}
-                  onMouseOut={() => clickable && setActiveDisabled(false)}
+                  onMouseMove={() => clickable && properties.clickable && setActiveDisabled(true)}
+                  onMouseOut={() => clickable && properties.clickable && setActiveDisabled(false)}
                 >
                   {properties.element}
                 </SlotContainer>


### PR DESCRIPTION
The title could be confusing so I provided two small videos. In both videos, I'm clicking the area where we have `duration` slot.
Before - thumbnail drag down animation doesn't work: 

https://user-images.githubusercontent.com/51168865/152754274-73772443-c78b-4c52-acb0-5790f5ba8fbc.mov

After - thumbnail drag down animation works: 

https://user-images.githubusercontent.com/51168865/152754313-54f14796-bb4c-4aa0-896a-1c4c81fb73d4.mov


