### PR TITLE
Fix upload button on my videos view

### DIFF
--- a/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
+++ b/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
@@ -277,6 +277,7 @@ export const MyVideosView = () => {
           to={absoluteRoutes.studio.videoWorkspace()}
           icon={<SvgActionAddVideo />}
           onClick={handleAddVideoTab}
+          fullWidth
         >
           Upload video
         </MobileButton>


### PR DESCRIPTION
I've just noticed that the `Upload video` mobile button on `/studio/videos` has no longer full width.  This PR should fix this
Before: 
![image](https://user-images.githubusercontent.com/51168865/153888818-3a555a53-a8e8-4774-919a-ebe78f7d0913.png)
After: 
![image](https://user-images.githubusercontent.com/51168865/153888858-ca6e07f4-d4b7-4f45-af71-69dac1f4c2ea.png)

Design: 
https://www.figma.com/file/LF7LOMhOA46bRcYHWlw1Bq/My-videos-page?node-id=217%3A6627