### PR TITLE
trim titles&descriptions on submit

### DIFF
--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -230,8 +230,8 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
     setIsWorkspaceOpen(false)
 
     const metadata: ChannelInputMetadata = {
-      ...(dirtyFields.title ? { title: data.title ?? '' } : {}),
-      ...(dirtyFields.description ? { description: data.description ?? '' } : {}),
+      ...(dirtyFields.title ? { title: data.title?.trim() ?? '' } : {}),
+      ...(dirtyFields.description ? { description: data.description?.trim() ?? '' } : {}),
       ...(dirtyFields.language || newChannel ? { language: data.language } : {}),
       ...(dirtyFields.isPublic || newChannel ? { isPublic: data.isPublic } : {}),
     }

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
@@ -141,15 +141,15 @@ export const VideoForm: React.FC<VideoFormProps> = React.memo(({ onSubmit, setFo
 
       const license = {
         code: data.licenseCode ?? undefined,
-        attribution: data.licenseAttribution ?? undefined,
-        customText: data.licenseCustomText ?? undefined,
+        attribution: data.licenseAttribution?.trim() ?? undefined,
+        customText: data.licenseCustomText?.trim() ?? undefined,
       }
       const anyLicenseFieldsDirty =
         dirtyFields.licenseCode || dirtyFields.licenseAttribution || dirtyFields.licenseCustomText
 
       const metadata: VideoInputMetadata = {
-        ...(isNew || dirtyFields.title ? { title: data.title } : {}),
-        ...(isNew || dirtyFields.description ? { description: data.description } : {}),
+        ...(isNew || dirtyFields.title ? { title: data.title.trim() } : {}),
+        ...(isNew || dirtyFields.description ? { description: data.description.trim() } : {}),
         ...(isNew || dirtyFields.category ? { category: Number(data.category) } : {}),
         ...(isNew || dirtyFields.isPublic ? { isPublic: data.isPublic } : {}),
         ...((isNew || dirtyFields.hasMarketing) && data.hasMarketing != null


### PR DESCRIPTION
I've noticed a couple videos published with a trailing space in the title, I suspect adding an empty space at the start/end will never be user's intention so let's save them the trouble