### PR TITLE
chore: get rid of useMeasure

### DIFF
--- a/packages/atlas/.storybook/preview.jsx
+++ b/packages/atlas/.storybook/preview.jsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
 
 const StylesWrapperDecorator = (styleFn) => {
   const ref = useRef(null)
-  const { width, height } = useResizeObserver({ ref })
+  const { width, height } = useResizeObserver({ ref, box: 'border-box' })
   return (
     <Wrapper ref={ref}>
       <div style={{ position: 'absolute', fontSize: '12px', right: '4px', top: '4px' }}>

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -72,7 +72,6 @@
     "react-spring": "^9.4.2",
     "react-textarea-autosize": "^8.3.3",
     "react-transition-group": "^4.4.2",
-    "react-use-measure": "^2.1.1",
     "retry-axios": "^2.6.0",
     "scroll-lock": "^2.1.5",
     "subscriptions-transport-ws": "^0.11.0",

--- a/packages/atlas/src/components/Grid/Grid.tsx
+++ b/packages/atlas/src/components/Grid/Grid.tsx
@@ -27,6 +27,7 @@ export const Grid: React.FC<GridProps> = ({
   const gridRef = useRef<HTMLImageElement>(null)
   useResizeObserver<HTMLDivElement>({
     ref: gridRef,
+    box: 'border-box',
     onResize: () => {
       if (onResize && gridRef.current) {
         const computedStyles = window.getComputedStyle(gridRef.current)

--- a/packages/atlas/src/components/NftTileDetails/NftTileDetails.tsx
+++ b/packages/atlas/src/components/NftTileDetails/NftTileDetails.tsx
@@ -73,6 +73,7 @@ export const NftTileDetails: React.FC<NftTileDetailsProps> = ({
   const toggleContentHover = () => setContentHovered((prevState) => !prevState)
   const [tileSize, setTileSize] = useState<TileSize>()
   const { ref: contentRef } = useResizeObserver<HTMLDivElement>({
+    box: 'border-box',
     onResize: (size) => {
       const { width } = size
       if (width) {

--- a/packages/atlas/src/components/Pagination/Pagination.tsx
+++ b/packages/atlas/src/components/Pagination/Pagination.tsx
@@ -26,7 +26,7 @@ export const Pagination: React.FC<PaginationProps> = ({
 }) => {
   const [paginationLength, setPaginationLength] = useState(maxPaginationLinks)
 
-  const { width, ref: paginationWrapperRef } = useResizeObserver()
+  const { width, ref: paginationWrapperRef } = useResizeObserver({ box: 'border-box' })
 
   useLayoutEffect(() => {
     if (!width) {

--- a/packages/atlas/src/components/_inputs/MultiFileSelect/MultiFileSelect.tsx
+++ b/packages/atlas/src/components/_inputs/MultiFileSelect/MultiFileSelect.tsx
@@ -75,6 +75,7 @@ export const MultiFileSelect: React.FC<MultiFileSelectProps> = React.memo(
     const [underlineLeft, setUnderlineLeft] = useState(0)
 
     useResizeObserver({
+      box: 'border-box',
       ref: thumbnailStepRef,
       onResize: () => {
         setUnderlineWidth(thumbnailStepRef?.current?.offsetWidth || 0)

--- a/packages/atlas/src/components/_inputs/TextField/TextField.tsx
+++ b/packages/atlas/src/components/_inputs/TextField/TextField.tsx
@@ -43,11 +43,6 @@ const TextFieldComponent: React.ForwardRefRenderFunction<HTMLInputElement, TextF
   },
   ref
 ) => {
-  /*
-  const [nodeLeftRef, nodeLeftBounds] = useMeasure()
-  const [nodeRightRef, nodeRightBounds] = useMeasure()
-*/
-
   const { ref: nodeLeftRef, width: nodeLeftBoundsWidth = 1 } = useResizeObserver()
   const { ref: nodeRightRef, width: nodeRightBoundsWidth = 1 } = useResizeObserver()
 

--- a/packages/atlas/src/components/_inputs/TextField/TextField.tsx
+++ b/packages/atlas/src/components/_inputs/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import useMeasure from 'react-use-measure'
+import useResizeObserver from 'use-resize-observer'
 
 import { InputBase, InputBaseProps } from '@/components/_inputs/InputBase'
 
@@ -43,8 +43,14 @@ const TextFieldComponent: React.ForwardRefRenderFunction<HTMLInputElement, TextF
   },
   ref
 ) => {
+  /*
   const [nodeLeftRef, nodeLeftBounds] = useMeasure()
   const [nodeRightRef, nodeRightBounds] = useMeasure()
+*/
+
+  const { ref: nodeLeftRef, width: nodeLeftBoundsWidth = 1 } = useResizeObserver()
+  const { ref: nodeRightRef, width: nodeRightBoundsWidth = 1 } = useResizeObserver()
+
   return (
     <InputBase error={error} disabled={disabled} {...inputBaseProps}>
       <TextFieldContainer>
@@ -54,8 +60,8 @@ const TextFieldComponent: React.ForwardRefRenderFunction<HTMLInputElement, TextF
           </NodeContainer>
         )}
         <TextInput
-          leftNodeWidth={nodeLeftBounds.width}
-          rightNodeWidth={nodeRightBounds.width}
+          leftNodeWidth={nodeLeftBoundsWidth}
+          rightNodeWidth={nodeRightBoundsWidth}
           autoComplete={autoComplete}
           ref={ref}
           name={name}

--- a/packages/atlas/src/components/_inputs/TextField/TextField.tsx
+++ b/packages/atlas/src/components/_inputs/TextField/TextField.tsx
@@ -43,8 +43,8 @@ const TextFieldComponent: React.ForwardRefRenderFunction<HTMLInputElement, TextF
   },
   ref
 ) => {
-  const { ref: nodeLeftRef, width: nodeLeftBoundsWidth = 1 } = useResizeObserver()
-  const { ref: nodeRightRef, width: nodeRightBoundsWidth = 1 } = useResizeObserver()
+  const { ref: nodeLeftRef, width: nodeLeftBoundsWidth = 0 } = useResizeObserver({ box: 'border-box' })
+  const { ref: nodeRightRef, width: nodeRightBoundsWidth = 0 } = useResizeObserver({ box: 'border-box' })
 
   return (
     <InputBase error={error} disabled={disabled} {...inputBaseProps}>

--- a/packages/atlas/src/components/_navigation/NavItem/NavItem.tsx
+++ b/packages/atlas/src/components/_navigation/NavItem/NavItem.tsx
@@ -36,7 +36,7 @@ export const NavItem: React.FC<NavItemProps> = ({
   badgeNumber,
   isSecondary,
 }) => {
-  const { height: subitemsHeight, ref: subitemsRef } = useResizeObserver<HTMLUListElement>()
+  const { height: subitemsHeight, ref: subitemsRef } = useResizeObserver<HTMLUListElement>({ box: 'border-box' })
   const match = useMatch(to)
   return (
     <SidebarNavItem data-badge={badgeNumber} expanded={expanded}>

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.styles.ts
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.styles.ts
@@ -25,7 +25,7 @@ export const Container = styled.div`
 
 export const InnerContainer = styled.div<{ isActive: boolean; containerHeight: number }>`
   width: 280px;
-  position: 'relative';
+  position: relative;
   max-height: calc(100vh - ${sizes(4)} - var(--size-topbar-height));
   height: ${({ containerHeight }) => containerHeight}px;
   transform: translateY(

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
@@ -64,7 +64,7 @@ export const MemberDropdown = React.forwardRef<HTMLDivElement, MemberDropdownPro
     const { activeChannelId, activeMembership, setActiveUser, memberships, signIn } = useUser()
     const containerRef = useRef<HTMLDivElement>(null)
     const { joystream, proxyCallback } = useJoystream()
-    const { ref: measureContainerRef, height: containerHeight = 1 } = useResizeObserver()
+    const { ref: measureContainerRef, height: containerHeight = 0 } = useResizeObserver({ box: 'border-box' })
     const transRef = useSpringRef()
     const transitions = useTransition(isSwitchingMember, {
       ref: transRef,

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
@@ -2,7 +2,7 @@ import { easings, useSpringRef, useTransition } from '@react-spring/web'
 import React, { useEffect, useRef, useState } from 'react'
 import mergeRefs from 'react-merge-refs'
 import { useLocation, useNavigate } from 'react-router'
-import useMeasure from 'react-use-measure'
+import useResizeObserver from 'use-resize-observer'
 
 import { useChannel } from '@/api/hooks'
 import { Avatar } from '@/components/Avatar'
@@ -64,7 +64,7 @@ export const MemberDropdown = React.forwardRef<HTMLDivElement, MemberDropdownPro
     const { activeChannelId, activeMembership, setActiveUser, memberships, signIn } = useUser()
     const containerRef = useRef<HTMLDivElement>(null)
     const { joystream, proxyCallback } = useJoystream()
-    const [measureContainerRef, { height: containerHeight }] = useMeasure()
+    const { ref: measureContainerRef, height: containerHeight = 1 } = useResizeObserver()
     const transRef = useSpringRef()
     const transitions = useTransition(isSwitchingMember, {
       ref: transRef,

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -88,7 +88,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
   const nodeConnectionStatus = useConnectionStatusStore((state) => state.nodeConnectionStatus)
   const addNewChannelIdToUploadsStore = useUploadsStore((state) => state.actions.addNewChannelId)
   const navigate = useNavigate()
-  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 0 } = useResizeObserver({ box: 'border-box' })
 
   const {
     channel,

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Controller, FieldError, useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { CSSTransition } from 'react-transition-group'
-import useMeasure from 'react-use-measure'
+import useResizeObserver from 'use-resize-observer'
 
 import { useChannel } from '@/api/hooks'
 import { ActionBar } from '@/components/ActionBar'
@@ -88,7 +88,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
   const nodeConnectionStatus = useConnectionStatusStore((state) => state.nodeConnectionStatus)
   const addNewChannelIdToUploadsStore = useUploadsStore((state) => state.actions.addNewChannelId)
   const navigate = useNavigate()
-  const [actionBarRef, actionBarBounds] = useMeasure()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
 
   const {
     channel,
@@ -460,7 +460,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
         </TitleContainer>
       </StyledTitleSection>
       <LimitedWidthContainer>
-        <InnerFormContainer actionBarHeight={actionBarBounds.height}>
+        <InnerFormContainer actionBarHeight={actionBarBoundsHeight}>
           <FormField title="Description">
             <Tooltip text="Click to edit channel description">
               <TextArea

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { CSSTransition } from 'react-transition-group'
-import useMeasure from 'react-use-measure'
+import useResizeObserver from 'use-resize-observer'
 
 import { DrawerHeader } from '@/components/DrawerHeader'
 import { SvgControlsCancel } from '@/components/_icons'
@@ -117,10 +117,10 @@ const VideoWorkspaceActionBar: React.FC<VideoWorkspaceActionBarProps> = ({
   onResize,
 }) => {
   const mdMatch = useMediaMatch('md')
-  const [actionBarRef, actionBarBounds] = useMeasure()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
 
   const isActive = !isEdit || canSubmit
-  const height = isActive ? actionBarBounds.height : 0
+  const height = isActive ? actionBarBoundsHeight : 0
 
   // send update to VideoWorkspace whenever height changes
   useEffect(() => {

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.tsx
@@ -117,7 +117,7 @@ const VideoWorkspaceActionBar: React.FC<VideoWorkspaceActionBarProps> = ({
   onResize,
 }) => {
   const mdMatch = useMediaMatch('md')
-  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 0 } = useResizeObserver({ box: 'border-box' })
 
   const isActive = !isEdit || canSubmit
   const height = isActive ? actionBarBoundsHeight : 0

--- a/packages/atlas/src/views/viewer/EditMembershipView/EditMembershipView.tsx
+++ b/packages/atlas/src/views/viewer/EditMembershipView/EditMembershipView.tsx
@@ -17,7 +17,7 @@ import { StyledActionBar, TextFieldsWrapper, Wrapper } from './EditMembershipVie
 export const EditMembershipView: React.FC = () => {
   const navigate = useNavigate()
   const { activeAccountId, activeMembership, activeMembershipLoading, refetchActiveMembership } = useUser()
-  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 0 } = useResizeObserver({ box: 'border-box' })
   const { joystream, proxyCallback } = useJoystream()
   const handleTransaction = useTransaction()
 

--- a/packages/atlas/src/views/viewer/EditMembershipView/EditMembershipView.tsx
+++ b/packages/atlas/src/views/viewer/EditMembershipView/EditMembershipView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router'
-import useMeasure from 'react-use-measure'
+import useResizeObserver from 'use-resize-observer'
 
 import { LimitedWidthContainer } from '@/components/LimitedWidthContainer'
 import { MembershipInfo } from '@/components/MembershipInfo'
@@ -17,7 +17,7 @@ import { StyledActionBar, TextFieldsWrapper, Wrapper } from './EditMembershipVie
 export const EditMembershipView: React.FC = () => {
   const navigate = useNavigate()
   const { activeAccountId, activeMembership, activeMembershipLoading, refetchActiveMembership } = useUser()
-  const [actionBarRef, actionBarBounds] = useMeasure()
+  const { ref: actionBarRef, height: actionBarBoundsHeight = 1 } = useResizeObserver()
   const { joystream, proxyCallback } = useJoystream()
   const handleTransaction = useTransaction()
 
@@ -96,7 +96,7 @@ export const EditMembershipView: React.FC = () => {
           editable
           handle={getValues('handle')}
         />
-        <Wrapper actionBarHeight={actionBarBounds.height}>
+        <Wrapper actionBarHeight={actionBarBoundsHeight}>
           <TextFieldsWrapper>
             <CreateEditMemberInputs register={register} errors={errors} watch={watch} />
           </TextFieldsWrapper>

--- a/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
@@ -2,7 +2,6 @@ import { generateVideoMetaTags } from '@joystream/atlas-meta-server/src/tags'
 import { throttle } from 'lodash-es'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import useResizeObserver from 'use-resize-observer'
 
 import { useAddVideoView, useVideo } from '@/api/hooks'
 import { EmptyFallback } from '@/components/EmptyFallback'
@@ -80,7 +79,6 @@ export const VideoView: React.FC = () => {
   const headTags = useHeadTags(video?.title, videoMetaTags)
 
   const { startTimestamp, setStartTimestamp } = useVideoStartTimestamp(video?.duration)
-  const { ref: videoGridRef } = useResizeObserver()
 
   // Restore an interrupted video state
   useEffect(() => {
@@ -296,7 +294,7 @@ export const VideoView: React.FC = () => {
     <>
       <PlayerGridWrapper cinematicView={isCinematic}>
         <PlayerWrapper cinematicView={isCinematic}>
-          <PlayerGridItem colSpan={{ xxs: 12, md: cinematicView ? 12 : 8 }} ref={videoGridRef}>
+          <PlayerGridItem colSpan={{ xxs: 12, md: cinematicView ? 12 : 8 }}>
             <PlayerContainer className={transitions.names.slide} cinematicView={cinematicView}>
               {!isMediaLoading && video ? (
                 <VideoPlayer

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,7 +3974,6 @@ __metadata:
     react-spring: ^9.4.2
     react-textarea-autosize: ^8.3.3
     react-transition-group: ^4.4.2
-    react-use-measure: ^2.1.1
     retry-axios: ^2.6.0
     rimraf: ^3.0.2
     rollup-plugin-visualizer: ^5.5.4
@@ -10716,7 +10715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debounce@npm:^1.2.0, debounce@npm:^1.2.1":
+"debounce@npm:^1.2.0":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
   checksum: 682a89506d9e54fb109526f4da255c5546102fbb8e3ae75eef3b04effaf5d4853756aee97475cd4650641869794e44f410eeb20ace2b18ea592287ab2038519e
@@ -18825,18 +18824,6 @@ fsevents@^1.2.7:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
   checksum: b67bf5b3e86dbab72d658b9a52a3589e5960583ab28c7c66272427d8fe30d4c7de422d5046ae96bd2683cdf80cc3264b2516f5ce80cae1dbe6cf3ca6dda392c5
-  languageName: node
-  linkType: hard
-
-"react-use-measure@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "react-use-measure@npm:2.1.1"
-  dependencies:
-    debounce: ^1.2.1
-  peerDependencies:
-    react: ">=16.13"
-    react-dom: ">=16.13"
-  checksum: b8e8939229d463c3c505f7b617925c0228efae0cd6f651371f463846417b06c9170be57df51293a61027c41770f8a090fdb8a08717c4e36290ccb496e0318f1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this?**

This uses `useResizeObserver` instead of `useMeasure` to lean dependencies list.

**Issue**

#2118 