### PR TITLE
add useMsTimestamp hook, clean up time estimation

### DIFF
--- a/packages/atlas/src/components/NftTile/NftTile.tsx
+++ b/packages/atlas/src/components/NftTile/NftTile.tsx
@@ -4,7 +4,6 @@ import { NftTileDetails } from '@/components/NftTileDetails'
 import { Pill, PillGroup } from '@/components/Pill'
 import { SvgActionAuction, SvgActionBuyNow, SvgActionNotForSale, SvgActionShow } from '@/components/_icons'
 import { VideoThumbnail, VideoThumbnailProps } from '@/components/_video/VideoThumbnail'
-import { useMsTimestamp } from '@/hooks/useMsTimestamp'
 import { formatNumberShort } from '@/utils/number'
 import { formatDurationShort } from '@/utils/time'
 
@@ -29,7 +28,7 @@ export type NftTileProps = {
   buyNowPrice?: number | null
   minBid?: number | null
   topBid?: number | null
-  expireMsTimestamp?: number
+  timeLeftMs?: number
   role: 'owner' | 'viewer'
   fullWidth?: boolean
 }
@@ -46,13 +45,12 @@ export const NftTile: React.FC<NftTileProps> = ({
   buyNowPrice,
   minBid,
   topBid,
-  expireMsTimestamp,
+  timeLeftMs,
   role,
   fullWidth,
 }) => {
   const [hovered, setHovered] = useState(false)
-  const msTimestamp = useMsTimestamp()
-  const secondsLeft = expireMsTimestamp && Math.round((expireMsTimestamp - msTimestamp) / 1000)
+  const timeLeftSec = timeLeftMs && Math.max(Math.round(timeLeftMs / 1000), 1) // provide 1s fallback if the timer runs slightly faster than the auction end block is processed
 
   const getBottomLeft = useMemo(() => {
     switch (auction) {
@@ -68,12 +66,12 @@ export const NftTile: React.FC<NftTileProps> = ({
             items={[
               {
                 icon: <SvgActionAuction />,
-                label: secondsLeft
-                  ? secondsLeft < 60
+                label: timeLeftSec
+                  ? timeLeftSec < 60
                     ? 'Less than a minute'
-                    : formatDurationShort(secondsLeft, true)
+                    : formatDurationShort(timeLeftSec, true)
                   : undefined,
-                variant: secondsLeft && secondsLeft < 3600 ? 'danger' : 'overlay',
+                variant: timeLeftSec && timeLeftSec < 3600 ? 'danger' : 'overlay',
               },
               { icon: <SvgActionBuyNow /> },
             ]}
@@ -83,18 +81,18 @@ export const NftTile: React.FC<NftTileProps> = ({
           <Pill
             icon={<SvgActionAuction />}
             label={
-              secondsLeft
-                ? secondsLeft < 60
+              timeLeftSec
+                ? timeLeftSec < 60
                   ? 'Less than a minute'
-                  : formatDurationShort(secondsLeft, true)
+                  : formatDurationShort(timeLeftSec, true)
                 : undefined
             }
             size="medium"
-            variant={secondsLeft && secondsLeft < 3600 ? 'danger' : 'overlay'}
+            variant={timeLeftSec && timeLeftSec < 3600 ? 'danger' : 'overlay'}
           />
         )
     }
-  }, [auction, buyNowPrice, secondsLeft])
+  }, [auction, buyNowPrice, timeLeftSec])
 
   return (
     <Container fullWidth={fullWidth}>

--- a/packages/atlas/src/components/NftTile/NftTile.tsx
+++ b/packages/atlas/src/components/NftTile/NftTile.tsx
@@ -4,6 +4,7 @@ import { NftTileDetails } from '@/components/NftTileDetails'
 import { Pill, PillGroup } from '@/components/Pill'
 import { SvgActionAuction, SvgActionBuyNow, SvgActionNotForSale, SvgActionShow } from '@/components/_icons'
 import { VideoThumbnail, VideoThumbnailProps } from '@/components/_video/VideoThumbnail'
+import { useMsTimestamp } from '@/hooks/useMsTimestamp'
 import { formatNumberShort } from '@/utils/number'
 import { formatDurationShort } from '@/utils/time'
 
@@ -28,7 +29,7 @@ export type NftTileProps = {
   buyNowPrice?: number | null
   minBid?: number | null
   topBid?: number | null
-  timeLeft?: number
+  expireMsTimestamp?: number
   role: 'owner' | 'viewer'
   fullWidth?: boolean
 }
@@ -45,11 +46,13 @@ export const NftTile: React.FC<NftTileProps> = ({
   buyNowPrice,
   minBid,
   topBid,
-  timeLeft,
+  expireMsTimestamp,
   role,
   fullWidth,
 }) => {
   const [hovered, setHovered] = useState(false)
+  const msTimestamp = useMsTimestamp()
+  const secondsLeft = expireMsTimestamp && Math.round((expireMsTimestamp - msTimestamp) / 1000)
 
   const getBottomLeft = useMemo(() => {
     switch (auction) {
@@ -65,12 +68,12 @@ export const NftTile: React.FC<NftTileProps> = ({
             items={[
               {
                 icon: <SvgActionAuction />,
-                label: timeLeft
-                  ? timeLeft < 60
+                label: secondsLeft
+                  ? secondsLeft < 60
                     ? 'Less than a minute'
-                    : formatDurationShort(timeLeft, true)
+                    : formatDurationShort(secondsLeft, true)
                   : undefined,
-                variant: timeLeft && timeLeft < 3600 ? 'danger' : 'overlay',
+                variant: secondsLeft && secondsLeft < 3600 ? 'danger' : 'overlay',
               },
               { icon: <SvgActionBuyNow /> },
             ]}
@@ -79,13 +82,19 @@ export const NftTile: React.FC<NftTileProps> = ({
         ) : (
           <Pill
             icon={<SvgActionAuction />}
-            label={timeLeft ? (timeLeft < 60 ? 'Less than a minute' : formatDurationShort(timeLeft, true)) : undefined}
+            label={
+              secondsLeft
+                ? secondsLeft < 60
+                  ? 'Less than a minute'
+                  : formatDurationShort(secondsLeft, true)
+                : undefined
+            }
             size="medium"
-            variant={timeLeft && timeLeft < 3600 ? 'danger' : 'overlay'}
+            variant={secondsLeft && secondsLeft < 3600 ? 'danger' : 'overlay'}
           />
         )
     }
-  }, [auction, buyNowPrice, timeLeft])
+  }, [auction, buyNowPrice, secondsLeft])
 
   return (
     <Container fullWidth={fullWidth}>

--- a/packages/atlas/src/hooks/useMsTimestamp.ts
+++ b/packages/atlas/src/hooks/useMsTimestamp.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+export const useMsTimestamp = () => {
+  const [timestamp, setTimestamp] = useState(Date.now())
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimestamp(Date.now())
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return timestamp
+}

--- a/packages/atlas/src/providers/joystream/useJoystream.ts
+++ b/packages/atlas/src/providers/joystream/useJoystream.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 
 import { JoystreamContext } from './provider'
 
@@ -16,11 +16,25 @@ export const useTokenPrice = () => {
     throw new Error('useJoystream must be used within JoystreamProvider')
   }
 
-  const { price } = ctx
-  const convertToUSD = (tJoy: number) => tJoy * price
-  const convertToTJoy = (USD: number) => USD / price
+  const { getTokenPrice } = ctx
+
+  const convertToUSD = useCallback(
+    (tokens: number) => {
+      const price = getTokenPrice()
+      return tokens * price
+    },
+    [getTokenPrice]
+  )
+  const convertToTJoy = useCallback(
+    (dollars: number) => {
+      const price = getTokenPrice()
+      if (!price) return 0
+      return dollars / price
+    },
+    [getTokenPrice]
+  )
+
   return {
-    price,
     convertToUSD,
     convertToTJoy,
   }

--- a/packages/atlas/src/views/playground/Playgrounds/EstimatingBlockTime.tsx
+++ b/packages/atlas/src/views/playground/Playgrounds/EstimatingBlockTime.tsx
@@ -1,36 +1,27 @@
 import { formatDistanceToNowStrict } from 'date-fns'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { Text } from '@/components/Text'
 import { FormField } from '@/components/_inputs/FormField'
 import { TextField } from '@/components/_inputs/TextField'
 import { useBlockTimeEstimation } from '@/hooks/useBlockTimeEstimation'
+import { useMsTimestamp } from '@/hooks/useMsTimestamp'
+import { useJoystream } from '@/providers/joystream'
 
 export const EstimatingBlockTime = () => {
   const [datetimeLocal, setDatetimeLocal] = useState('')
   const [blockNumber, setBlockNumber] = useState(0)
-  const [currentBlock, setCurrentBlock] = useState<number>()
 
-  const [currentTime, setCurrentTime] = useState(new Date())
-
-  const { convertBlockToDate, convertDateToBlock } = useBlockTimeEstimation()
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCurrentTime(new Date())
-      setCurrentBlock(convertDateToBlock(Date.now()))
-    }, 1000)
-    return () => {
-      clearInterval(timer)
-    }
-  }, [convertDateToBlock])
+  const { getCurrentBlock } = useJoystream()
+  const { convertBlockToMsTimestamp, convertMsTimestampToBlock } = useBlockTimeEstimation()
+  const msTimestamp = useMsTimestamp()
 
   return (
     <div>
       <div>
         <Text variant="h700">Current state</Text>
-        <Text variant="h300">Current block number: {currentBlock}</Text>
-        <Text variant="h300">Current time: {new Date(currentTime).toLocaleString()}</Text>
+        <Text variant="h300">Current block number: {getCurrentBlock()}</Text>
+        <Text variant="h300">Current time: {new Date(msTimestamp).toLocaleString()}</Text>
       </div>
       <br />
       <div>
@@ -44,9 +35,9 @@ export const EstimatingBlockTime = () => {
         </FormField>
         <Text variant="h500">Results:</Text>
         <Text variant="h300">Block number: {blockNumber}</Text>
-        <Text variant="h300">Date: {new Date(convertBlockToDate(blockNumber)).toLocaleString()} </Text>
+        <Text variant="h300">Date: {new Date(convertBlockToMsTimestamp(blockNumber)).toLocaleString()} </Text>
         <Text variant="h300">
-          Timeleft: {formatDistanceToNowStrict(new Date(convertBlockToDate(blockNumber)), { addSuffix: true })}{' '}
+          Timeleft: {formatDistanceToNowStrict(new Date(convertBlockToMsTimestamp(blockNumber)), { addSuffix: true })}{' '}
         </Text>
       </div>
       <br />
@@ -61,7 +52,7 @@ export const EstimatingBlockTime = () => {
           />
         </FormField>
         <Text variant="h500">Results:</Text>
-        <Text variant="h300">Block number: {convertDateToBlock(Date.parse(datetimeLocal))}</Text>
+        <Text variant="h300">Block number: {convertMsTimestampToBlock(Date.parse(datetimeLocal))}</Text>
         <Text variant="h300">Date: {datetimeLocal}</Text>
       </div>
     </div>

--- a/packages/atlas/src/views/playground/Playgrounds/TJoyPrice.tsx
+++ b/packages/atlas/src/views/playground/Playgrounds/TJoyPrice.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { useTokenPrice } from '@/providers/joystream'
 
 export const TJoyPrice = () => {
-  const { price, convertToUSD, convertToTJoy } = useTokenPrice()
+  const { convertToUSD, convertToTJoy } = useTokenPrice()
   const [toConvert, setToConvert] = useState(0)
   const [unit, setUnit] = useState('tJoy')
   const [converted, setConverted] = useState(0)
@@ -15,9 +15,8 @@ export const TJoyPrice = () => {
   const convertedUnit = unit === 'usd' ? 'tJoy' : 'usd'
   return (
     <div>
-      <div>tJoy price: {price}$ / tJoy</div>
       <div>
-        Converter:{' '}
+        Converter:
         <input
           type="number"
           value={toConvert}


### PR DESCRIPTION
Summary of changes:
- added `useMsTimestamp` hook that sends time updates to components
- updated block time estimation to always use ms timestamps
- cleaned up block time estimation logic slightly
- moved block subscription to joystream context provider so we always use a single one
- changed `NftTile` to accept timestamp instead of `timeLeft`