### PR TITLE
NFT issuance follow up fixes

### DIFF
--- a/packages/atlas/src/providers/videoWorkspace/types.ts
+++ b/packages/atlas/src/providers/videoWorkspace/types.ts
@@ -36,7 +36,7 @@ export type VideoWorkspaceVideoFormFields = {
   licenseCustomText: string | null
   licenseAttribution: string | null
   hasMarketing: boolean | null
-  isPublic: boolean
+  isPublic: boolean | null
   isExplicit: boolean
   publishedBeforeJoystream: Date | null
   assets: VideoWorkspaceVideoAssets

--- a/packages/atlas/src/views/studio/VideoWorkspace/NftForm/AcceptTerms/AcceptTerms.styles.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/NftForm/AcceptTerms/AcceptTerms.styles.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 
+import { Information } from '@/components/Information'
 import { Text } from '@/components/Text'
 import { SvgActionArrowRight } from '@/components/_icons'
 import { cVar, media, sizes } from '@/styles'
@@ -55,4 +56,8 @@ export const Divider = styled.hr`
   border: 0;
   box-shadow: ${cVar('effectDividersTop')};
   margin: ${sizes(10)} 0;
+`
+
+export const StyledInformation = styled(Information)`
+  margin-left: ${sizes(1)};
 `

--- a/packages/atlas/src/views/studio/VideoWorkspace/NftForm/AcceptTerms/AcceptTerms.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/NftForm/AcceptTerms/AcceptTerms.tsx
@@ -2,12 +2,20 @@ import { differenceInMilliseconds, format, isValid } from 'date-fns'
 import React from 'react'
 
 import { Banner } from '@/components/Banner'
-import { Information } from '@/components/Information'
 import { Text } from '@/components/Text'
 import { Checkbox } from '@/components/_inputs/Checkbox'
 import { useBlockTimeEstimation } from '@/hooks/useBlockTimeEstimation'
 
-import { Description, Divider, Header, Row, StyledSvgActionArrowRight, TermsBox, Title } from './AcceptTerms.styles'
+import {
+  Description,
+  Divider,
+  Header,
+  Row,
+  StyledInformation,
+  StyledSvgActionArrowRight,
+  TermsBox,
+  Title,
+} from './AcceptTerms.styles'
 
 import { StyledSvgWarning, YellowText } from '../../VideoWorkspace.style'
 import { useNftForm } from '../NftForm.hooks'
@@ -61,7 +69,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
       <Row>
         <Title>
           <TitleText>Listing type</TitleText>
-          <Information
+          <StyledInformation
             text="Offers can be received. You can accept any bid at any time unless auction duration is set (then the highest offer wins)"
             placement="top"
           />
@@ -74,13 +82,15 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
         <Row>
           <Title>
             <TitleText>Minimum bid</TitleText>
-            <Information
+            <StyledInformation
               text="Its the starting price of your auction. No lower bids will be accepted"
               placement="top"
             />
           </Title>
           <Description>
-            <DescriptionText>{formData.startingPrice}</DescriptionText>
+            <DescriptionText>
+              {Number(formData.startingPrice).toLocaleString('no', { maximumFractionDigits: 1 })} tJoy
+            </DescriptionText>
           </Description>
         </Row>
       )}
@@ -88,13 +98,15 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
         <Row>
           <Title>
             <TitleText>Fixed price</TitleText>
-            <Information
+            <StyledInformation
               text="Sell your NFT for a predefined price. When this price is reached it automatically ends auction"
               placement="top"
             />
           </Title>
           <Description>
-            <DescriptionText>{formData.buyNowPrice}</DescriptionText>
+            <DescriptionText>
+              {Number(formData.buyNowPrice).toLocaleString('no', { maximumFractionDigits: 1 })} tJoy
+            </DescriptionText>
           </Description>
         </Row>
       )}
@@ -103,7 +115,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
           <Row>
             <Title>
               <TitleText>Starting date</TitleText>
-              <Information
+              <StyledInformation
                 text="It’s the time when your auction will become active and buyer will be able to make an offer"
                 placement="top"
               />
@@ -115,7 +127,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
           <Row>
             <Title>
               <TitleText>Expiration date</TitleText>
-              <Information
+              <StyledInformation
                 text="It’s the time when your auction ends. You cannot finish it earlier. Highest bidder wins."
                 placement="top"
               />
@@ -130,7 +142,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
         <Row>
           <Title>
             <TitleText>Total auction duration</TitleText>
-            <Information
+            <StyledInformation
               text="Auctions are run and settled on-chain and use tJoy’s blocks, rather than clock time."
               footer={
                 <AuctionDurationTooltipFooter>
@@ -145,7 +157,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
           <Description>
             <DescriptionText>{daysAndHours}</DescriptionText>
             <Text variant="h400" secondary>
-              &nbsp;/ {numberOfBlocks}
+              &nbsp;/ {numberOfBlocks} Blocks
             </Text>
           </Description>
         </Row>
@@ -154,7 +166,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
         <Row>
           <Title>
             <TitleText>Royalties</TitleText>
-            <Information
+            <StyledInformation
               text="By setting royalties you will be entitled to a percentage share in revenue from any future secondary market sale. So if someone sells your work you will get paid."
               footer={<RoyaltiesTooltipFooter />}
               placement="top"
@@ -170,7 +182,7 @@ export const AcceptTerms: React.FC<AcceptTermsProps> = ({
       <Row>
         <Title>
           <TitleText>Fee</TitleText>
-          <Information
+          <StyledInformation
             text="By setting royalties you will be entitled to a percentage share in revenue from any future secondary market sale. So if someone sells your work you will get paid."
             footer={<RoyaltiesTooltipFooter />}
             placement="top"

--- a/packages/atlas/src/views/studio/VideoWorkspace/NftForm/NftForm.hooks.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/NftForm/NftForm.hooks.ts
@@ -6,7 +6,7 @@ import { Listing } from '@/views/studio/VideoWorkspace/NftForm/types'
 export const useNftForm = () => {
   const [activeInputs, setActiveInputs] = useState<string[]>([])
   const [termsAccepted, setTermsAccepted] = useState(false)
-  const [listingType, setListingType] = useState<Listing>(undefined)
+  const [listingType, setListingType] = useState<Listing>('Auction')
   const [currentStep, setCurrentStep] = useState(0)
 
   const getTotalDaysAndHoursText = (start: Date, end: Date) => {

--- a/packages/atlas/src/views/studio/VideoWorkspace/NftForm/SetUp/SetUp.styles.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/NftForm/SetUp/SetUp.styles.ts
@@ -16,7 +16,7 @@ export const OptionsWrapper = styled.div`
 export const AuctionDatePickerWrapper = styled.div`
   display: grid;
   grid-template-rows: 1fr;
-  grid-template-columns: auto auto;
+  grid-template-columns: 1fr 1fr;
   gap: ${sizes(4)};
 `
 

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
@@ -248,12 +248,12 @@ export const VideoForm: React.FC<VideoFormProps> = React.memo(
       if (isValid) {
         return isEdit ? isDirty || isIssuedAsNft : true
       }
-      return false
+      return isIssuedAsNft
     }, [isValid, isEdit, isDirty, isIssuedAsNft])
 
     const actionBarPrimaryText = useMemo(() => {
       if (isIssuedAsNft) {
-        return 'Next'
+        return 'Next step'
       }
       if (isEdit) {
         return 'Publish changes'

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/utils.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/utils.ts
@@ -1,7 +1,11 @@
 import { VideoFormData, VideoWorkspaceVideoFormFields } from '@/providers/videoWorkspace'
 
+type Public = {
+  isPublic?: boolean
+}
+
 export const convertVideoFormDataToFormFields = (
-  videoFormData: VideoFormData
+  videoFormData: Omit<VideoFormData, 'isPublic'> & Public
 ): Partial<VideoWorkspaceVideoFormFields> => {
   const {
     metadata: {
@@ -57,7 +61,7 @@ export const convertVideoFormDataToFormFields = (
     ...(category ? { category: category?.toString() } : {}),
     ...(hasMarketing ? { hasMarketing } : {}),
     ...(language ? { language } : {}),
-    ...(isPublic ? { isPublic } : {}),
+    ...(isPublic !== undefined ? { isPublic } : {}),
     ...(isExplicit ? { isExplicit } : {}),
     ...(license?.attribution ? { licenseAttribution: license?.attribution } : {}),
     ...(license?.code ? { licenseCode: license?.code } : {}),

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/utils.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/utils.ts
@@ -1,11 +1,7 @@
 import { VideoFormData, VideoWorkspaceVideoFormFields } from '@/providers/videoWorkspace'
 
-type Public = {
-  isPublic?: boolean
-}
-
 export const convertVideoFormDataToFormFields = (
-  videoFormData: Omit<VideoFormData, 'isPublic'> & Public
+  videoFormData: VideoFormData
 ): Partial<VideoWorkspaceVideoFormFields> => {
   const {
     metadata: {


### PR DESCRIPTION
Closes #2212 

- [x] Lack of margin between header and info icon on summary screen
- [x] No formatting for price, check Figma
- [x] No blocks suffix for number of blocks for auction duration
- [x] Shifts in action bar when moving between video and NFT forms (button values change at different times I think, also the action bar occasionally disappears):
- [x] Auction duration selects shifting layout
- [x] Video Visibility setting is not preserved when moving between video and NFT form
