### PR TITLE
add BottomDrawer component

### DIFF
--- a/packages/atlas/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/packages/atlas/src/components/DrawerHeader/DrawerHeader.tsx
@@ -8,7 +8,7 @@ import { Tab, TabContainer, TabTitle, Tabbar } from './DrawerHeader.styles'
 
 export type DrawerHeaderProps = {
   title?: string
-  label: string
+  label?: string
   onCloseClick: () => void
 }
 

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.stories.tsx
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.stories.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled'
+import { Meta, Story } from '@storybook/react'
+import React, { useState } from 'react'
+
+import { Button } from '@/components/_buttons/Button'
+import { FormField } from '@/components/_inputs/FormField'
+import { TextField } from '@/components/_inputs/TextField'
+import { OverlayManagerProvider } from '@/providers/overlayManager'
+
+import { BottomDrawer, BottomDrawerProps } from './BottomDrawer'
+
+export default {
+  title: 'overlays/BottomDrawer',
+  component: BottomDrawer,
+  args: {
+    title: 'Test drawer',
+    titleLabel: 'Test',
+  },
+  argTypes: {
+    isOpen: { table: { disable: true } },
+    onClose: { table: { disable: true } },
+    actionBar: { table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <OverlayManagerProvider>
+        <Story />
+      </OverlayManagerProvider>
+    ),
+  ],
+} as Meta
+
+const Template: Story<BottomDrawerProps> = (args) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [actionBarOpen, setActionBarOpen] = useState(false)
+  return (
+    <div>
+      <Button onClick={() => setIsOpen(true)}>Open drawer</Button>
+      <BottomDrawer
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={args.title}
+        titleLabel={args.titleLabel}
+        actionBar={{
+          variant: 'edit',
+          primaryButton: {
+            text: 'Submit',
+            disabled: !actionBarOpen,
+          },
+          secondaryButton: {
+            text: 'Cancel',
+            onClick: () => setActionBarOpen(false),
+          },
+        }}
+      >
+        <Content>
+          <Button onClick={() => setActionBarOpen((prev) => !prev)}>Toggle action bar</Button>
+          <FormField title="Test field">
+            <TextField />
+          </FormField>
+          <FormField title="Test field">
+            <TextField />
+          </FormField>
+          <FormField title="Test field">
+            <TextField />
+          </FormField>
+          <FormField title="Test field">
+            <TextField />
+          </FormField>
+          <FormField title="Test field">
+            <TextField />
+          </FormField>
+        </Content>
+      </BottomDrawer>
+    </div>
+  )
+}
+
+export const Regular = Template.bind({})
+
+const Content = styled.div`
+  padding: 20px 60px;
+  width: 100%;
+`

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.stories.tsx
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.stories.tsx
@@ -52,6 +52,7 @@ const Template: Story<BottomDrawerProps> = (args) => {
             onClick: () => setActionBarOpen(false),
           },
         }}
+        coverTopbar={args.coverTopbar}
       >
         <Content>
           <Button onClick={() => setActionBarOpen((prev) => !prev)}>Toggle action bar</Button>

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled'
+
+import { ActionBar } from '@/components/ActionBar'
+import { cVar, zIndex } from '@/styles'
+
+export const DrawerOverlay = styled.div`
+  position: fixed;
+  z-index: ${zIndex.videoWorkspaceOverlay};
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: ${cVar('colorBackgroundOverlay')};
+  transition: opacity ${cVar('animationTransitionSlow')};
+
+  &.bottom-drawer-overlay {
+    &-enter-active,
+    &-exit {
+      opacity: 1;
+      pointer-events: initial;
+    }
+
+    &-enter,
+    &-exit-active {
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
+`
+
+export const Container = styled.div`
+  transform: translateY(100%);
+  opacity: 0;
+  position: fixed;
+  z-index: ${zIndex.videoWorkspaceOverlay};
+  top: var(--size-topbar-height);
+  left: 0;
+  right: 0;
+  height: calc(100vh - var(--size-topbar-height));
+  display: flex;
+  flex-direction: column;
+  background-color: ${cVar('colorBackground')};
+  box-shadow: ${cVar('effectElevation24Layer1')}, ${cVar('effectElevation24Layer2')};
+  transition: transform ${cVar('animationTransitionSlow')}, opacity ${cVar('animationTransitionSlow')};
+  will-change: transform, opacity;
+
+  &.bottom-drawer {
+    &-exit,
+    &-enter-active,
+    &-enter-done {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    &-enter,
+    &-exit-active {
+      transform: translateY(100%);
+      opacity: 0;
+    }
+  }
+`
+
+type ScrollContainerProps = {
+  actionBarHeight?: number
+  isEdit?: boolean
+}
+export const ScrollContainer = styled.div<ScrollContainerProps>`
+  flex: 1;
+  margin-bottom: ${({ actionBarHeight = 0 }) => actionBarHeight}px;
+  overflow-y: auto;
+  overflow-x: hidden;
+`
+
+export const StyledActionBar = styled(ActionBar)`
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+`

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
@@ -39,7 +39,7 @@ export const Container = styled.div<ContainerProps>`
   top: ${({ coverTopbar }) => (coverTopbar ? 0 : 'var(--size-topbar-height)')};
   left: 0;
   right: 0;
-  height: calc(100vh - ${({ coverTopbar }) => (coverTopbar ? 0 : 'var(--size-topbar-height)')};);
+  height: calc(100vh - ${({ coverTopbar }) => (coverTopbar ? '0px' : 'var(--size-topbar-height)')});
   display: flex;
   flex-direction: column;
   background-color: ${cVar('colorBackground')};

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.styles.ts
@@ -28,15 +28,18 @@ export const DrawerOverlay = styled.div`
   }
 `
 
-export const Container = styled.div`
+type ContainerProps = {
+  coverTopbar: boolean
+}
+export const Container = styled.div<ContainerProps>`
   transform: translateY(100%);
   opacity: 0;
   position: fixed;
   z-index: ${zIndex.videoWorkspaceOverlay};
-  top: var(--size-topbar-height);
+  top: ${({ coverTopbar }) => (coverTopbar ? 0 : 'var(--size-topbar-height)')};
   left: 0;
   right: 0;
-  height: calc(100vh - var(--size-topbar-height));
+  height: calc(100vh - ${({ coverTopbar }) => (coverTopbar ? 0 : 'var(--size-topbar-height)')};);
   display: flex;
   flex-direction: column;
   background-color: ${cVar('colorBackground')};
@@ -62,7 +65,6 @@ export const Container = styled.div`
 
 type ScrollContainerProps = {
   actionBarHeight?: number
-  isEdit?: boolean
 }
 export const ScrollContainer = styled.div<ScrollContainerProps>`
   flex: 1;

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.tsx
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react'
+import { CSSTransition } from 'react-transition-group'
+import useResizeObserver from 'use-resize-observer'
+
+import { ActionBarProps } from '@/components/ActionBar'
+import { DrawerHeader } from '@/components/DrawerHeader'
+import { useHeadTags } from '@/hooks/useHeadTags'
+import { useOverlayManager } from '@/providers/overlayManager'
+import { cVar } from '@/styles'
+
+import { Container, DrawerOverlay, ScrollContainer, StyledActionBar } from './BottomDrawer.styles'
+
+export type BottomDrawerProps = {
+  isOpen: boolean
+  onClose: () => void
+  title?: string
+  titleLabel?: string
+  actionBar?: ActionBarProps
+}
+
+export const BottomDrawer: React.FC<BottomDrawerProps> = ({
+  isOpen,
+  onClose,
+  title,
+  titleLabel,
+  children,
+  actionBar: actionBarProps,
+}) => {
+  const headTags = useHeadTags(title)
+
+  const [cachedIsOpen, setCachedIsOpen] = useState(false)
+  const { incrementOverlaysOpenCount, decrementOverlaysOpenCount } = useOverlayManager()
+
+  const actionBarActive = actionBarProps?.variant === 'edit' ? !actionBarProps.primaryButton?.disabled : true
+  const { ref: actionBarRef, height: _actionBarHeight } = useResizeObserver({ box: 'border-box' })
+  const actionBarHeight = actionBarActive ? _actionBarHeight : 0
+
+  useEffect(() => {
+    if (isOpen === cachedIsOpen) return
+
+    setCachedIsOpen(isOpen)
+
+    if (isOpen) {
+      incrementOverlaysOpenCount()
+    } else {
+      decrementOverlaysOpenCount()
+    }
+  }, [cachedIsOpen, decrementOverlaysOpenCount, incrementOverlaysOpenCount, isOpen])
+
+  return (
+    <>
+      {isOpen ? headTags : null}
+      <CSSTransition
+        in={isOpen}
+        appear
+        mountOnEnter
+        unmountOnExit
+        timeout={{ enter: 0, exit: parseInt(cVar('animationTimingSlow', true)) }}
+        classNames="bottom-drawer-overlay"
+      >
+        <DrawerOverlay />
+      </CSSTransition>
+      <CSSTransition
+        in={isOpen}
+        appear
+        mountOnEnter
+        unmountOnExit
+        timeout={{ enter: 0, exit: parseInt(cVar('animationTimingSlow', true)) }}
+        classNames="bottom-drawer"
+      >
+        <Container role="dialog">
+          <DrawerHeader title={title} label={titleLabel} onCloseClick={onClose} />
+          <ScrollContainer actionBarHeight={actionBarHeight}>{children}</ScrollContainer>
+          {actionBarProps ? <StyledActionBar ref={actionBarRef} {...actionBarProps} /> : null}
+        </Container>
+      </CSSTransition>
+    </>
+  )
+}

--- a/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.tsx
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/BottomDrawer.tsx
@@ -16,6 +16,7 @@ export type BottomDrawerProps = {
   title?: string
   titleLabel?: string
   actionBar?: ActionBarProps
+  coverTopbar?: boolean
 }
 
 export const BottomDrawer: React.FC<BottomDrawerProps> = ({
@@ -25,6 +26,7 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
   titleLabel,
   children,
   actionBar: actionBarProps,
+  coverTopbar,
 }) => {
   const headTags = useHeadTags(title)
 
@@ -68,7 +70,7 @@ export const BottomDrawer: React.FC<BottomDrawerProps> = ({
         timeout={{ enter: 0, exit: parseInt(cVar('animationTimingSlow', true)) }}
         classNames="bottom-drawer"
       >
-        <Container role="dialog">
+        <Container role="dialog" coverTopbar={!!coverTopbar}>
           <DrawerHeader title={title} label={titleLabel} onCloseClick={onClose} />
           <ScrollContainer actionBarHeight={actionBarHeight}>{children}</ScrollContainer>
           {actionBarProps ? <StyledActionBar ref={actionBarRef} {...actionBarProps} /> : null}

--- a/packages/atlas/src/components/_overlays/BottomDrawer/index.ts
+++ b/packages/atlas/src/components/_overlays/BottomDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from './BottomDrawer'


### PR DESCRIPTION
This adds a reusable `BottomDrawer` component that can be used for any kind of action overlay that slides from the bottom. This will include:
- Video workspace
- NFT workspace
- NFT purchase view
- Settling an auction
- Anything similar

The code is mostly copied from the video workspace, with some adjustments. The component includes support for:
- Entering/exiting the screen with animation and background overlay
- Managing scroll lock
- Drawer header
- Optional action bar
- Scrollable content inside the overlay, with space reserved for action bar (no need to measure manually)
- Updated tab title when the overlay is opened

You can test it out with the `BottomDrawer` story. I haven't used it in the video workspace yet, since it needs to be slightly rebuilt first, will do that later