### PR TITLE
fix search input styling for iOS

### DIFF
--- a/packages/atlas/src/views/viewer/ChannelView/ChannelView.styles.ts
+++ b/packages/atlas/src/views/viewer/ChannelView/ChannelView.styles.ts
@@ -194,6 +194,7 @@ export const StyledTextField = styled(TextField)<TextFieldProps>`
     font: ${cVar('typographyDesktopT200')};
     letter-spacing: ${cVar('typographyDesktopT200LetterSpacing')};
     text-transform: ${cVar('typographyDesktopT200TextTransform')};
+    border-radius: 0;
 
     ${media.sm} {
       ${({ isOpen }) => isOpen === false && 'border: none !important'};
@@ -203,7 +204,8 @@ export const StyledTextField = styled(TextField)<TextFieldProps>`
       border: 1px solid ${oldColors.white};
     }
 
-    ::-webkit-search-cancel-button {
+    ::-webkit-search-cancel-button,
+    &[type='search'] {
       /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-appearance: none;
     }


### PR DESCRIPTION
Fixes #2093 

It doesn't have white background anymore (not sure if this is our fix or iOS), but it still has unnecessary border radius.
![IMG-2617](https://user-images.githubusercontent.com/13706246/159321438-10dcd92d-375d-4ace-9d7e-36308d5bda84.PNG)

