### PR TITLE
Change CategoryLink to `More in <Category>`

### DIFF
--- a/packages/atlas/src/components/CategoryLink/CategoryLink.tsx
+++ b/packages/atlas/src/components/CategoryLink/CategoryLink.tsx
@@ -59,7 +59,7 @@ export const CategoryLink: React.FC<CategoryLinkProps> = ({
           >
             {id ? (
               <Text variant={_textVariant} secondary={!!textSecondary}>
-                More from {name}
+                More in {name}
               </Text>
             ) : (
               <SkeletonLoader height={16} width={150} />


### PR DESCRIPTION
## What's this?

Minor last-minute design improvement to change `More from` to `More in` indicating that it links a category not a member.

## Rationale

Currently headline for videos in the same category is `More from People & Blogs` or `More from Education`.