### PR TITLE
improve nft sale validation

### DIFF
--- a/packages/atlas/src/joystream-lib/lib.ts
+++ b/packages/atlas/src/joystream-lib/lib.ts
@@ -102,4 +102,18 @@ export class JoystreamLib {
     })
     return proxy(unsubscribe)
   }
+
+  async getNftChainState() {
+    await this.ensureApi()
+
+    const [maxAuctionDuration, minStartingPrice] = await Promise.all([
+      this.api.query.content.maxAuctionDuration(),
+      this.api.query.content.minStartingPrice(),
+    ])
+
+    return {
+      maxAuctionDuration: maxAuctionDuration.toNumber(),
+      minStartingPrice: minStartingPrice.toNumber(),
+    }
+  }
 }

--- a/packages/atlas/src/providers/joystream/provider.tsx
+++ b/packages/atlas/src/providers/joystream/provider.tsx
@@ -18,7 +18,9 @@ type ProxyCallbackFn = <T extends object>(callback: T) => T & ProxyMarked
 export type JoystreamContextValue = {
   joystream: Remote<JoystreamLib> | undefined
   proxyCallback: ProxyCallbackFn
+  chainState: ReturnType<typeof useJoystreamChainState>
 } & ReturnType<typeof useJoystreamUtilFns>
+
 export const JoystreamContext = React.createContext<JoystreamContextValue | undefined>(undefined)
 JoystreamContext.displayName = 'JoystreamContext'
 const worker = new JoystreamJsWorker()
@@ -40,6 +42,7 @@ export const JoystreamProvider: React.FC = ({ children }) => {
   const proxyCallback = useCallback(<T extends object>(callback: T) => proxy(callback), [])
 
   const utilFns = useJoystreamUtilFns(joystream.current, proxyCallback)
+  const chainState = useJoystreamChainState(joystream.current)
 
   // initialize Joystream Lib
   useEffect(() => {
@@ -96,7 +99,7 @@ export const JoystreamProvider: React.FC = ({ children }) => {
 
   return (
     <JoystreamContext.Provider
-      value={{ joystream: initialized ? joystream.current : undefined, proxyCallback, ...utilFns }}
+      value={{ joystream: initialized ? joystream.current : undefined, proxyCallback, chainState, ...utilFns }}
     >
       {children}
     </JoystreamContext.Provider>
@@ -108,7 +111,7 @@ const useJoystreamUtilFns = (joystream: Remote<JoystreamLib> | undefined, proxyC
   const currentBlockRef = useRef(0)
   const currentBlockMsTimestampRef = useRef(0)
 
-  // fetch JOY token price from the status server
+  // fetch tJOY token price from the status server
   useEffect(() => {
     const getPrice = async () => {
       try {
@@ -150,4 +153,28 @@ const useJoystreamUtilFns = (joystream: Remote<JoystreamLib> | undefined, proxyC
     getCurrentBlock,
     getCurrentBlockMsTimestamp,
   }
+}
+
+type JoystreamChainState = {
+  nftMinStartingPrice: number
+  nftMaxAuctionDuration: number
+}
+const useJoystreamChainState = (joystream: Remote<JoystreamLib> | undefined) => {
+  const [chainState, setChainState] = useState<JoystreamChainState>({
+    nftMinStartingPrice: 1,
+    nftMaxAuctionDuration: 1_296_000,
+  })
+
+  useEffect(() => {
+    if (!joystream) return
+
+    joystream.getNftChainState().then((nftChainState) =>
+      setChainState({
+        nftMaxAuctionDuration: nftChainState.maxAuctionDuration,
+        nftMinStartingPrice: nftChainState.minStartingPrice,
+      })
+    )
+  }, [joystream])
+
+  return chainState
 }

--- a/packages/atlas/src/providers/joystream/useJoystream.ts
+++ b/packages/atlas/src/providers/joystream/useJoystream.ts
@@ -11,12 +11,7 @@ export const useJoystream = (): JoystreamContextValue => {
 }
 
 export const useTokenPrice = () => {
-  const ctx = useContext(JoystreamContext)
-  if (!ctx) {
-    throw new Error('useJoystream must be used within JoystreamProvider')
-  }
-
-  const { tokenPrice } = ctx
+  const { tokenPrice } = useJoystream()
 
   const convertToUSD = useCallback(
     (tokens: number) => {

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.hooks.ts
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.hooks.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react'
 
 import { AuctionDatePickerValue } from '@/components/_inputs/AuctionDatePicker'
 import { useBlockTimeEstimation } from '@/hooks/useBlockTimeEstimation'
+import { useJoystream } from '@/providers/joystream'
 import { daysToMilliseconds } from '@/utils/time'
 
 import { Listing } from './NftForm.types'
@@ -13,10 +14,27 @@ export const useNftForm = () => {
   const [listingType, setListingType] = useState<Listing>('Auction')
   const [currentStep, setCurrentStep] = useState(0)
 
-  const { convertDurationToBlocks } = useBlockTimeEstimation()
-
   const nextStep = useCallback(() => setCurrentStep((step) => step + 1), [])
   const previousStep = useCallback(() => setCurrentStep((step) => step - 1), [])
+
+  return {
+    state: {
+      activeInputs,
+      setActiveInputs,
+      termsAccepted,
+      setTermsAccepted,
+      listingType,
+      setListingType,
+      currentStep,
+      nextStep,
+      previousStep,
+    },
+  }
+}
+
+export const useNftFormUtils = () => {
+  const { convertDurationToBlocks } = useBlockTimeEstimation()
+  const { chainState } = useJoystream()
 
   const getNumberOfBlocks = (startDate: AuctionDatePickerValue, endDate: AuctionDatePickerValue) => {
     const start = (startDate?.type === 'date' && startDate.date) || new Date()
@@ -31,18 +49,5 @@ export const useNftForm = () => {
     }
   }
 
-  return {
-    getNumberOfBlocks,
-    state: {
-      activeInputs,
-      setActiveInputs,
-      termsAccepted,
-      setTermsAccepted,
-      listingType,
-      setListingType,
-      currentStep,
-      nextStep,
-      previousStep,
-    },
-  }
+  return { getNumberOfBlocks, chainState }
 }

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.tsx
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import React, { useCallback, useEffect, useMemo } from 'react'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 
 import { useVideo } from '@/api/hooks'
 import { NftTile, NftTileProps } from '@/components/NftTile'
@@ -17,7 +17,7 @@ import { formatDateTime } from '@/utils/time'
 
 import { AcceptTerms } from './AcceptTerms'
 import { ListingType } from './ListingType'
-import { useNftForm } from './NftForm.hooks'
+import { useNftForm, useNftFormUtils } from './NftForm.hooks'
 import {
   NftFormScrolling,
   NftFormWrapper,
@@ -68,31 +68,32 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
       nextStep,
     },
   } = useNftForm()
+  const { chainState } = useNftFormUtils()
 
   const isOnFirstStep = currentStep === 0
   const isOnLastStep = currentStep === 2
 
-  const {
-    handleSubmit: createSubmitHandler,
-    register,
-    reset,
-    getValues,
-    setValue,
-    control,
-    watch,
-    formState: { isValid, errors },
-  } = useForm<NftFormFields>({
+  const formMethods = useForm<NftFormFields>({
     mode: 'onChange',
     resolver: (data, ctx, options) => {
-      const resolver = zodResolver(createValidationSchema(data))
+      const resolver = zodResolver(createValidationSchema(data, listingType, chainState.nftMinStartingPrice))
       return resolver(data, ctx, options)
     },
     reValidateMode: 'onChange',
     defaultValues: {
       startDate: null,
       endDate: null,
+      startingPrice: chainState.nftMinStartingPrice || undefined,
     },
   })
+  const {
+    handleSubmit: createSubmitHandler,
+    reset,
+    getValues,
+    setValue,
+    watch,
+    formState: { isValid },
+  } = formMethods
 
   const { video, loading: loadingVideo } = useVideo(videoId, { fetchPolicy: 'cache-only' })
 
@@ -154,7 +155,7 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
         })
       } else if (listingType === 'Auction') {
         const startsAtBlock = startDate ? convertMsTimestampToBlock(startDate.getTime()) : undefined
-        const startingPrice = data.startingPrice || 1 // TODO: this should use a chain constant for minimum bid
+        const startingPrice = data.startingPrice || chainState.nftMinStartingPrice
         const minimalBidStep = Math.ceil(startingPrice * NFT_MIN_BID_STEP_MULTIPLIER)
 
         if (data.auctionDurationBlocks) {
@@ -185,6 +186,7 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
     })
     return handler()
   }, [
+    chainState.nftMinStartingPrice,
     closeModal,
     convertMsTimestampToBlock,
     createSubmitHandler,
@@ -239,11 +241,14 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
 
   // Clear form on listing type change
   useEffect(() => {
-    if (listingType) {
-      reset()
-      setActiveInputs([])
+    reset()
+    if (listingType === 'Fixed price') {
+      setTimeout(() => {
+        setValue('buyNowPrice', 1)
+      })
     }
-  }, [listingType, reset, setActiveInputs])
+    setActiveInputs([])
+  }, [listingType, reset, setActiveInputs, setValue])
 
   const getNftStatus = () => {
     switch (listingType) {
@@ -273,16 +278,9 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
     <ListingType key="step-content-1" selectedType={listingType} onSelectType={setListingType} />,
     <SetUp
       key="step-content-2"
-      watch={watch}
-      control={control}
-      errors={errors}
-      register={register}
       selectedType={listingType}
-      setValue={setValue}
       activeInputs={activeInputs}
       setActiveInputs={setActiveInputs}
-      reset={reset}
-      formData={getValues()}
     />,
     <AcceptTerms
       key="step-content-3"
@@ -303,23 +301,25 @@ export const NftForm: React.FC<NftFormProps> = ({ setFormStatus, onSubmit, video
           </Text>
         </NftPreview>
         <NftFormScrolling>
-          <NftFormWrapper lastStep={currentStep === 2}>
-            <StepperWrapper>
-              <StepperInnerWrapper>
-                {issueNftSteps.map((step, idx) => {
-                  const stepVariant = getStepVariant(currentStep, idx)
-                  const isLast = idx === issueNftSteps.length - 1
-                  return (
-                    <StepWrapper key={idx}>
-                      <Step showOtherStepsOnMobile number={idx + 1} variant={stepVariant} title={step.title} />
-                      {!isLast && <SvgActionChevronR />}
-                    </StepWrapper>
-                  )
-                })}
-              </StepperInnerWrapper>
-            </StepperWrapper>
-            {stepsContent[currentStep]}
-          </NftFormWrapper>
+          <FormProvider {...formMethods}>
+            <NftFormWrapper lastStep={currentStep === 2}>
+              <StepperWrapper>
+                <StepperInnerWrapper>
+                  {issueNftSteps.map((step, idx) => {
+                    const stepVariant = getStepVariant(currentStep, idx)
+                    const isLast = idx === issueNftSteps.length - 1
+                    return (
+                      <StepWrapper key={idx}>
+                        <Step showOtherStepsOnMobile number={idx + 1} variant={stepVariant} title={step.title} />
+                        {!isLast && <SvgActionChevronR />}
+                      </StepWrapper>
+                    )
+                  })}
+                </StepperInnerWrapper>
+              </StepperWrapper>
+              {stepsContent[currentStep]}
+            </NftFormWrapper>
+          </FormProvider>
         </NftFormScrolling>
       </NftWorkspaceFormWrapper>
     </ScrollableWrapper>

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.utils.ts
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.utils.ts
@@ -4,9 +4,9 @@ import { z } from 'zod'
 import { AuctionDatePickerValue } from '@/components/_inputs/AuctionDatePicker'
 import { pluralizeNoun } from '@/utils/misc'
 
-import { NftFormFields } from './NftForm.types'
+import { Listing, NftFormFields } from './NftForm.types'
 
-export const createValidationSchema = (data: NftFormFields) => {
+export const createValidationSchema = (data: NftFormFields, listingType: Listing, minStartingPrice: number) => {
   const auctionDateType = z
     .union([
       z.object({
@@ -20,6 +20,10 @@ export const createValidationSchema = (data: NftFormFields) => {
     ])
     .nullable()
     .optional()
+
+  const buyNowPrice = z
+    .number({ required_error: 'Buy now price must be provided', invalid_type_error: 'Buy now price must be a number' })
+    .min(1, 'Buy now price cannot be lower than 1')
 
   return z.object({
     startDate: auctionDateType
@@ -63,8 +67,11 @@ export const createValidationSchema = (data: NftFormFields) => {
         { message: 'Expiration date cannot be earlier than starting date' }
       ),
     royalty: z.number().nullable().optional(),
-    startingPrice: z.number().nullable().optional(),
-    buyNowPrice: z.number().nullable().optional(),
+    startingPrice: z
+      .number({ invalid_type_error: 'Minimum bid must be a number' })
+      .min(minStartingPrice, `Minimum bid cannot be lower than ${minStartingPrice}`)
+      .optional(),
+    buyNowPrice: listingType === 'Auction' ? buyNowPrice.nullable().optional() : buyNowPrice,
     auctionDurationBlocks: z.number().nullable().optional(),
     whitelistedMembersIds: z.array(z.string()).nullable().optional(),
   })

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.utils.ts
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.utils.ts
@@ -25,6 +25,10 @@ export const createValidationSchema = (data: NftFormFields, listingType: Listing
     .number({ required_error: 'Buy now price must be provided', invalid_type_error: 'Buy now price must be a number' })
     .min(1, 'Buy now price cannot be lower than 1')
 
+  const startingPriceBase = z
+    .number({ invalid_type_error: 'Minimum bid must be a number' })
+    .min(minStartingPrice, `Minimum bid cannot be lower than ${minStartingPrice}`)
+
   return z.object({
     startDate: auctionDateType
       .refine(
@@ -67,10 +71,12 @@ export const createValidationSchema = (data: NftFormFields, listingType: Listing
         { message: 'Expiration date cannot be earlier than starting date' }
       ),
     royalty: z.number().nullable().optional(),
-    startingPrice: z
-      .number({ invalid_type_error: 'Minimum bid must be a number' })
-      .min(minStartingPrice, `Minimum bid cannot be lower than ${minStartingPrice}`)
-      .optional(),
+    startingPrice:
+      data.buyNowPrice && listingType === 'Auction'
+        ? startingPriceBase
+            .max(data.buyNowPrice - 1, 'Starting price needs to be lower than the buy now price.')
+            .optional()
+        : startingPriceBase.optional(),
     buyNowPrice: listingType === 'Auction' ? buyNowPrice.nullable().optional() : buyNowPrice,
     auctionDurationBlocks: z.number().nullable().optional(),
     whitelistedMembersIds: z.array(z.string()).nullable().optional(),

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/SetUp/SetUp.tsx
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/SetUp/SetUp.tsx
@@ -34,6 +34,7 @@ export const SetUp: React.FC<SetUpProps> = ({ selectedType, activeInputs, setAct
     getValues,
     watch,
     control,
+    trigger,
     formState: { errors },
   } = useFormContext<NftFormFields>()
 
@@ -62,6 +63,7 @@ export const SetUp: React.FC<SetUpProps> = ({ selectedType, activeInputs, setAct
       if (!prevState.includes(name)) {
         if (name === 'buyNowPrice') {
           setValue('buyNowPrice', 1)
+          trigger() // trigger form validation to make sure starting price is valid
         }
         return [...prevState, name]
       }
@@ -163,6 +165,7 @@ export const SetUp: React.FC<SetUpProps> = ({ selectedType, activeInputs, setAct
                 disabled={!activeInputs.includes('buyNowPrice')}
                 error={!!errors.buyNowPrice}
                 helperText={errors.buyNowPrice?.message}
+                onBlur={() => trigger()} // trigger form validation to make sure starting price is valid
               />
             </FormField>
             <FormField

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/SetUp/SetUp.tsx
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/SetUp/SetUp.tsx
@@ -1,15 +1,6 @@
 import { addMonths } from 'date-fns'
 import React, { useEffect } from 'react'
-import {
-  Control,
-  Controller,
-  DeepMap,
-  FieldError,
-  UseFormRegister,
-  UseFormReset,
-  UseFormSetValue,
-  UseFormWatch,
-} from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 
 import { Pill } from '@/components/Pill'
 import { Text } from '@/components/Text'
@@ -22,41 +13,34 @@ import { formatNumber } from '@/utils/number'
 
 import { AuctionDatePickerWrapper, DaysSummary, DaysSummaryInfo, Header, StyledFormField } from './SetUp.styles'
 
-import { useNftForm } from '../NftForm.hooks'
+import { useNftFormUtils } from '../NftForm.hooks'
 import { AuctionDurationTooltipFooter } from '../NftForm.styles'
 import { Listing, NftFormFields } from '../NftForm.types'
 import { getTotalDaysAndHours } from '../NftForm.utils'
 
 type SetUpProps = {
-  register: UseFormRegister<NftFormFields>
   selectedType: Listing
-  setValue: UseFormSetValue<NftFormFields>
   activeInputs: string[]
   setActiveInputs: React.Dispatch<React.SetStateAction<string[]>>
-  reset: UseFormReset<NftFormFields>
-  formData: NftFormFields
-  watch: UseFormWatch<NftFormFields>
-  control: Control<NftFormFields>
-  errors: DeepMap<NftFormFields, FieldError>
 }
 
 const MAX_DATE = addMonths(new Date(), 5) // TODO: should use chain constant for max auction duration
 
-export const SetUp: React.FC<SetUpProps> = ({
-  register,
-  selectedType,
-  setValue,
-  activeInputs,
-  setActiveInputs,
-  reset,
-  formData,
-  watch,
-  control,
-}) => {
+export const SetUp: React.FC<SetUpProps> = ({ selectedType, activeInputs, setActiveInputs }) => {
+  const {
+    register,
+    setValue,
+    reset,
+    getValues,
+    watch,
+    control,
+    formState: { errors },
+  } = useFormContext<NftFormFields>()
+
   const startDate = watch('startDate')
   const endDate = watch('endDate')
 
-  const { getNumberOfBlocks } = useNftForm()
+  const { getNumberOfBlocks, chainState } = useNftFormUtils()
 
   const numberOfBlocks = getNumberOfBlocks(startDate, endDate) || 0
 
@@ -76,13 +60,18 @@ export const SetUp: React.FC<SetUpProps> = ({
     const { name } = event.target
     setActiveInputs((prevState) => {
       if (!prevState.includes(name)) {
+        if (name === 'buyNowPrice') {
+          setValue('buyNowPrice', 1)
+        }
         return [...prevState, name]
       }
       if (name === 'auctionDuration') {
         setValue('startDate', null)
         setValue('endDate', null)
+      } else if (name === 'startingPrice') {
+        setValue('startingPrice', chainState.nftMinStartingPrice || undefined)
       } else {
-        reset({ ...formData, [name]: undefined })
+        reset({ ...getValues(), [name]: undefined })
       }
       return prevState.filter((inputName) => inputName !== name)
     })
@@ -126,9 +115,11 @@ export const SetUp: React.FC<SetUpProps> = ({
         {selectedType === 'Fixed price' && (
           <StyledFormField title="">
             <TextField
-              {...register('buyNowPrice', { required: true, valueAsNumber: true })}
+              {...register('buyNowPrice', { valueAsNumber: true })}
               type="number"
               nodeEnd={<Pill label="tJoy" />}
+              error={!!errors.buyNowPrice}
+              helperText={errors.buyNowPrice?.message}
             />
           </StyledFormField>
         )}
@@ -146,8 +137,11 @@ export const SetUp: React.FC<SetUpProps> = ({
               <TextField
                 {...register('startingPrice', { valueAsNumber: true })}
                 type="number"
+                defaultValue={chainState.nftMinStartingPrice?.toString()}
                 nodeEnd={<Pill label="tJOY" />}
                 disabled={!activeInputs.includes('startingPrice')}
+                error={!!errors.startingPrice}
+                helperText={errors.startingPrice?.message}
               />
             </FormField>
             <FormField
@@ -163,9 +157,12 @@ export const SetUp: React.FC<SetUpProps> = ({
             >
               <TextField
                 {...register('buyNowPrice', { valueAsNumber: true })}
+                placeholder="—"
                 type="number"
                 nodeEnd={<Pill label="tJOY" />}
                 disabled={!activeInputs.includes('buyNowPrice')}
+                error={!!errors.buyNowPrice}
+                helperText={errors.buyNowPrice?.message}
               />
             </FormField>
             <FormField


### PR DESCRIPTION
This PR:
- Adds fetching of chain constants
- Validates the NFT minimum bid to be higher than chain variable
- Provides default values for "starting price" and "buy now" fields, depending on listing type
- Adds error messages if incorrect values (like negative number) are provided