### PR TITLE
add Olympia banner

### DIFF
--- a/packages/atlas/src/MainLayout.tsx
+++ b/packages/atlas/src/MainLayout.tsx
@@ -2,6 +2,7 @@ import loadable from '@loadable/component'
 import React, { useEffect, useRef, useState } from 'react'
 import { Route, Routes, useLocation, useNavigationType } from 'react-router-dom'
 
+import { OlympiaBanner } from '@/components/OlympiaBanner'
 import { SvgJoystreamLogoStudio } from '@/components/_illustrations'
 import { StudioLoading } from '@/components/_loaders/StudioLoading'
 import { AdminOverlay } from '@/components/_overlays/AdminOverlay'
@@ -86,6 +87,7 @@ export const MainLayout: React.FC = () => {
         <Route path={BASE_PATHS.playground + '/*'} element={<LoadablePlaygroundLayout />} />
       </Routes>
       <AdminOverlay />
+      <OlympiaBanner />
     </>
   )
 }

--- a/packages/atlas/src/components/OlympiaBanner/OlympiaBanner.tsx
+++ b/packages/atlas/src/components/OlympiaBanner/OlympiaBanner.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled'
+import React, { useEffect } from 'react'
+import { useLocation } from 'react-router'
+import useResizeObserver from 'use-resize-observer'
+
+import { Text } from '@/components/Text'
+import { SvgAlertsWarning24 } from '@/components/_icons'
+import { JOYSTREAM_DISCORD_URL } from '@/config/urls'
+import { cVar, sizes } from '@/styles'
+
+export const OlympiaBanner: React.FC = () => {
+  const { ref, height } = useResizeObserver({ box: 'border-box' })
+  const { pathname, search } = useLocation()
+  const isVisible = pathname.includes('studio') || pathname.includes('member/edit') || search.includes('loginStep')
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (isVisible) {
+      root.style.setProperty('--size-banner-height', `${height || 0}px`)
+    } else {
+      root.style.setProperty('--size-banner-height', '0px')
+    }
+  }, [isVisible, height])
+
+  return (
+    <Banner isVisible={isVisible} ref={ref}>
+      <Icon />
+      <Info variant="t100">
+        On March 23rd the Olympia testnet was launched. We expect the full migration process to take up to 7 days. Until
+        then, Atlas will continue using the old Giza testnet. This means that any{' '}
+        <b>new membership/content created in this app will be lost</b>. Head over to our{' '}
+        <a href={JOYSTREAM_DISCORD_URL}>Discord</a> for support.
+      </Info>
+    </Banner>
+  )
+}
+
+const Banner = styled.div<{ isVisible: boolean }>`
+  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  padding: ${sizes(3)};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: ${cVar('colorCoreYellow200')};
+  z-index: 999999;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+`
+
+const Icon = styled(SvgAlertsWarning24)`
+  min-width: 24px;
+
+  path {
+    fill: ${cVar('colorCoreRed500')};
+  }
+`
+
+const Info = styled(Text)`
+  color: ${cVar('colorCoreNeutral700')};
+  margin-left: ${sizes(2)};
+
+  b {
+    color: ${cVar('colorCoreRed500')};
+    word-break: keep-all;
+  }
+
+  a {
+    color: ${cVar('colorCoreBlue500')};
+    font-weight: 700;
+    text-decoration: none;
+  }
+`

--- a/packages/atlas/src/components/OlympiaBanner/index.ts
+++ b/packages/atlas/src/components/OlympiaBanner/index.ts
@@ -1,0 +1,1 @@
+export * from './OlympiaBanner'

--- a/packages/atlas/src/components/_navigation/SidenavBase/SidenavBase.styles.ts
+++ b/packages/atlas/src/components/_navigation/SidenavBase/SidenavBase.styles.ts
@@ -12,7 +12,7 @@ export const NAVBAR_LEFT_PADDING = 24
 
 export const SidebarNav = styled.nav<ExpandableElementProps>`
   position: fixed;
-  top: 0;
+  top: var(--size-banner-height);
   bottom: 0;
   height: 100%;
   z-index: ${zIndex.sideNav};
@@ -105,11 +105,11 @@ export const LegalLink = styled(Link)`
 
 export const StyledHamburgerButton = styled(HamburgerButton)`
   position: fixed;
-  top: ${sizes(2)};
+  top: calc(${sizes(2)} + var(--size-banner-height));
   left: ${sizes(3)};
   z-index: ${zIndex.sideNav};
   ${media.md} {
-    top: ${sizes(4)};
+    top: calc(${sizes(4)} + var(--size-banner-height));
   }
 `
 

--- a/packages/atlas/src/components/_navigation/SidenavBase/SidenavBase.styles.ts
+++ b/packages/atlas/src/components/_navigation/SidenavBase/SidenavBase.styles.ts
@@ -14,7 +14,7 @@ export const SidebarNav = styled.nav<ExpandableElementProps>`
   position: fixed;
   top: var(--size-banner-height);
   bottom: 0;
-  height: 100%;
+  height: calc(100% - var(--size-banner-height));
   z-index: ${zIndex.sideNav};
 
   --size-sidenav-width-expanded: 320px;

--- a/packages/atlas/src/components/_navigation/TopbarBase/TopbarBase.styles.ts
+++ b/packages/atlas/src/components/_navigation/TopbarBase/TopbarBase.styles.ts
@@ -5,7 +5,7 @@ import { media, oldColors, sizes, zIndex } from '@/styles'
 
 export const Header = styled.header`
   position: fixed;
-  top: 0;
+  top: var(--size-banner-height);
   left: 0;
   right: 0;
   z-index: ${zIndex.header};

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.styles.ts
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.styles.ts
@@ -13,7 +13,7 @@ const paddingStyles = css`
 export const Container = styled.div`
   position: fixed;
   right: ${sizes(4)};
-  top: 0;
+  top: var(--size-banner-height);
   width: 280px;
   height: 0;
   z-index: ${zIndex.nearTransactionBar};

--- a/packages/atlas/src/components/_overlays/Modal/Modal.styles.ts
+++ b/packages/atlas/src/components/_overlays/Modal/Modal.styles.ts
@@ -23,7 +23,7 @@ export const ModalContent = styled.div<ModalContentProps>`
   z-index: ${zIndex.globalOverlay};
   position: fixed;
   left: 50%;
-  top: 50%;
+  top: calc(50% + calc(var(--size-banner-height) / 2));
   transform: translate(-50%, -50%);
   max-height: 90vh;
   max-width: 90vw;

--- a/packages/atlas/src/views/studio/StudioLayout.tsx
+++ b/packages/atlas/src/views/studio/StudioLayout.tsx
@@ -152,7 +152,7 @@ const MainContainer = styled.main<{ hasSidebar: boolean }>`
 
   position: relative;
   height: 100%;
-  padding: var(--size-topbar-height) var(--size-global-horizontal-padding) 0;
+  padding: calc(var(--size-topbar-height) + var(--size-banner-height)) var(--size-global-horizontal-padding) 0;
   margin-left: var(--size-sidenav-width);
 `
 

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.style.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.style.ts
@@ -31,7 +31,7 @@ export const Container = styled.div`
   opacity: 0;
   position: fixed;
   z-index: ${zIndex.videoWorkspaceOverlay};
-  top: var(--size-topbar-height);
+  top: calc(var(--size-topbar-height) + var(--size-banner-height));
   left: 0;
   right: 0;
   height: calc(100vh - var(--size-topbar-height));

--- a/packages/atlas/src/views/viewer/ViewerLayout.tsx
+++ b/packages/atlas/src/views/viewer/ViewerLayout.tsx
@@ -102,6 +102,6 @@ export const ViewerLayout: React.FC = () => {
 
 const MainContainer = styled.main`
   position: relative;
-  padding: var(--size-topbar-height) var(--size-global-horizontal-padding) 0;
+  padding: calc(var(--size-topbar-height) + var(--size-banner-height)) var(--size-global-horizontal-padding) 0;
   margin-left: var(--size-sidenav-width-collapsed);
 `


### PR DESCRIPTION
This PR adds a banner informing users that Atlas will keep using Giza network for a couple of days and changes they are making will be lost until full migration. The banner is visible in Studio or when creating/editing a membership.

**It's hacky.** I don't want to do a proper layout with this banner on top so added a quick hack, once we migrate to Olympia, we can revert this commit

<img width="1131" alt="Screenshot 2022-03-23 at 18 52 49" src="https://user-images.githubusercontent.com/12646744/159764501-8f0e84ab-7979-44bb-a7a1-6ccde0c303cd.png">

