### PR TITLE
remove Olympia endpoint, use development

### DIFF
--- a/packages/atlas/.env
+++ b/packages/atlas/.env
@@ -3,17 +3,11 @@
 VITE_ENV=development
 
 # default target env is development
-VITE_DEVELOPMENT_ORION_URL=https://atlas-dev.joystream.app/orion/graphql
-VITE_DEVELOPMENT_QUERY_NODE_SUBSCRIPTION_URL=wss://atlas-dev.joystream.app/query-node/server/graphql
-VITE_DEVELOPMENT_NODE_URL=wss://atlas-dev.joystream.app/ws-rpc
-VITE_DEVELOPMENT_FAUCET_URL=https://atlas-dev.joystream.app/member-faucet/register
+VITE_DEVELOPMENT_ORION_URL=https://54.196.132.14.nip.io/orion/graphql
+VITE_DEVELOPMENT_QUERY_NODE_SUBSCRIPTION_URL=wss://54.196.132.14.nip.io/query-node/server/graphql
+VITE_DEVELOPMENT_NODE_URL=wss://54.196.132.14.nip.io/ws-rpc
+VITE_DEVELOPMENT_FAUCET_URL=https://54.196.132.14.nip.io/member-faucet/register
 VITE_DEVELOPMENT_OFFICIAL_JOYSTREAM_CHANNEL_ID=12
-
-VITE_OLYMPIA_ORION_URL=https://54.196.132.14.nip.io/orion/graphql
-VITE_OLYMPIA_QUERY_NODE_SUBSCRIPTION_URL=wss://54.196.132.14.nip.io/query-node/server/graphql
-VITE_OLYMPIA_NODE_URL=wss://54.196.132.14.nip.io/ws-rpc
-VITE_OLYMPIA_FAUCET_URL=https://54.196.132.14.nip.io/member-faucet/register
-VITE_OLYMPIA_OFFICIAL_JOYSTREAM_CHANNEL_ID=12
 
 VITE_PRODUCTION_ORION_URL=https://orion.joystream.org/graphql
 VITE_PRODUCTION_QUERY_NODE_SUBSCRIPTION_URL=wss://hydra.joystream.org/graphql

--- a/packages/atlas/codegen.config.yml
+++ b/packages/atlas/codegen.config.yml
@@ -1,6 +1,6 @@
 overwrite: true
 
-schema: ${VITE_OLYMPIA_ORION_URL}
+schema: ${VITE_DEVELOPMENT_ORION_URL}
 
 documents:
   - './src/api/queries/**/*.graphql'

--- a/packages/atlas/src/components/_overlays/AdminOverlay/AdminOverlay.tsx
+++ b/packages/atlas/src/components/_overlays/AdminOverlay/AdminOverlay.tsx
@@ -29,7 +29,6 @@ import {
 const ENVIRONMENT_NAMES: Record<string, string> = {
   production: 'Main Testnet',
   development: 'Atlas Dev Testnet',
-  olympia: 'Olympia Playground',
 }
 const environmentsItems = availableEnvs().map((item) => ({ name: ENVIRONMENT_NAMES[item] || item, value: item }))
 

--- a/packages/atlas/src/providers/environment/store.ts
+++ b/packages/atlas/src/providers/environment/store.ts
@@ -8,7 +8,7 @@ export type EnvironmentState = {
 }
 
 const INITIAL_STATE: EnvironmentState = {
-  targetDevEnv: 'olympia',
+  targetDevEnv: 'development',
   nodeOverride: null,
 }
 


### PR DESCRIPTION
Now that Olympia has been released and is the main testnet, I think it doesn't make sense to keep a separate endpoint set in available environments. This PR removes `olympia` environment and goes back to using `development` as default, which points to our Rhodes playground.