### PR TITLE
fix video tile publisher context menu

### DIFF
--- a/packages/atlas/src/components/_video/VideoTilePublisher/VideoTilePublisher.tsx
+++ b/packages/atlas/src/components/_video/VideoTilePublisher/VideoTilePublisher.tsx
@@ -194,12 +194,16 @@ export const VideoTilePublisher: React.FC<VideoTilePublisherProps> = React.memo(
           onClick: onReuploadVideoClick,
           title: 'Reupload file',
         },
-        {
-          icon: <SvgActionTrash />,
-          onClick: onDeleteVideoClick,
-          title: 'Delete video',
-          destructive: true,
-        },
+        ...(!hasNft
+          ? [
+              {
+                icon: <SvgActionTrash />,
+                onClick: onDeleteVideoClick,
+                title: 'Delete video',
+                destructive: true,
+              },
+            ]
+          : []),
       ]
 
       const onOpenInTabClick = () => {


### PR DESCRIPTION
When failed video has minted NFT, shouldn't have `Delete video` in context menu