### PR TITLE
Update show more functionality on video page

### DIFF
--- a/packages/atlas/src/views/viewer/VideoView/VideoView.styles.ts
+++ b/packages/atlas/src/views/viewer/VideoView/VideoView.styles.ts
@@ -116,15 +116,21 @@ export const DetailsWrapper = styled.div`
 `
 
 export const DescriptionContainer = styled.div`
-  margin-top: ${sizes(6)};
-  margin-bottom: ${sizes(8)};
-
-  ${media.md} {
-    margin: ${sizes(8)} 0;
-  }
+  margin: ${sizes(6)} 0;
 `
 export const DescriptionTitle = styled(Text)`
   margin-bottom: ${sizes(2)};
+`
+
+export const DescriptionBody = styled.div<{ detailsExpanded?: boolean }>`
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: ${({ detailsExpanded }) => (detailsExpanded ? 'unset' : 3)};
+  line-clamp: ${({ detailsExpanded }) => (detailsExpanded ? 'unset' : 3)};
+  -webkit-box-orient: vertical;
 `
 
 export const DescriptionCopy = styled(Text)`
@@ -147,10 +153,11 @@ export const LicenceCategoryWrapper = styled.div<{ detailsExpanded: boolean }>`
   grid-template-rows: 1fr;
   gap: ${sizes(6)};
   visibility: ${({ detailsExpanded }) => (detailsExpanded ? 'visible' : 'hidden')};
-  max-height: ${({ detailsExpanded }) => (detailsExpanded ? 'auto' : '0')};
+  max-height: ${({ detailsExpanded }) => (detailsExpanded ? '400px' : '0')};
   overflow: ${({ detailsExpanded }) => (detailsExpanded ? 'unset' : 'hidden')};
   opacity: ${({ detailsExpanded }) => (detailsExpanded ? 1 : 0)};
-  transition: opacity 150ms ease-out;
+  margin-bottom: ${({ detailsExpanded }) => (detailsExpanded ? sizes(6) : 0)};
+  transition: opacity ${cVar('animationTransitionFast')};
 `
 
 export const LicenseCustomText = styled(Text)`
@@ -159,7 +166,7 @@ export const LicenseCustomText = styled(Text)`
 
 export const ExpandButton = styled(Button)`
   display: block;
-  margin-top: ${sizes(2)};
+  margin-bottom: ${sizes(8)};
 `
 
 export const CategoryWrapper = styled.div`

--- a/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
@@ -1,6 +1,6 @@
 import { generateVideoMetaTags } from '@joystream/atlas-meta-server/src/tags'
 import { throttle } from 'lodash-es'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useAddVideoView, useVideo } from '@/api/hooks'
@@ -34,6 +34,7 @@ import {
   Category,
   CategoryWrapper,
   ChannelContainer,
+  DescriptionBody,
   DescriptionContainer,
   DescriptionCopy,
   DescriptionLink,
@@ -57,6 +58,7 @@ import {
 
 export const VideoView: React.FC = () => {
   const [detailsExpanded, setDetailsExpanded] = useState(false)
+  const descriptionBodyRef = useRef<HTMLDivElement>(null)
   useRedirectMigratedContent({ type: 'video' })
   const { id } = useParams()
   const { loading, video, error } = useVideo(id ?? '', {
@@ -226,11 +228,13 @@ export const VideoView: React.FC = () => {
             video?.description && (
               <>
                 <DescriptionTitle variant="h100">Description</DescriptionTitle>
-                {video.description?.split('\n').map((line, idx) => (
-                  <DescriptionCopy variant={mdMatch ? 't300' : 't200'} secondary key={idx}>
-                    {replaceUrls(line)}
-                  </DescriptionCopy>
-                ))}
+                <DescriptionBody ref={descriptionBodyRef} detailsExpanded={detailsExpanded}>
+                  {video.description?.split('\n').map((line, idx) => (
+                    <DescriptionCopy variant={mdMatch ? 't300' : 't200'} secondary key={idx}>
+                      {replaceUrls(line)}
+                    </DescriptionCopy>
+                  ))}
+                </DescriptionBody>
               </>
             )
           ) : (
@@ -241,20 +245,8 @@ export const VideoView: React.FC = () => {
               <DescriptionSkeletonLoader width="30%" />
             </>
           )}
-          {!mdMatch && (
-            <ExpandButton
-              onClick={toggleDetailsExpand}
-              iconPlacement="right"
-              size="small"
-              variant="tertiary"
-              textOnly
-              icon={detailsExpanded ? <SvgActionChevronT /> : <SvgActionChevronB />}
-            >
-              Show {!detailsExpanded ? 'more' : 'less'}
-            </ExpandButton>
-          )}
         </DescriptionContainer>
-        <LicenceCategoryWrapper detailsExpanded={!mdMatch ? detailsExpanded : true}>
+        <LicenceCategoryWrapper detailsExpanded={detailsExpanded}>
           <GridItem>
             {video ? (
               <>
@@ -288,6 +280,16 @@ export const VideoView: React.FC = () => {
             )}
           </CategoryWrapper>
         </LicenceCategoryWrapper>
+        <ExpandButton
+          onClick={toggleDetailsExpand}
+          iconPlacement="right"
+          size="medium"
+          variant="tertiary"
+          textOnly
+          icon={detailsExpanded ? <SvgActionChevronT /> : <SvgActionChevronB />}
+        >
+          Show {!detailsExpanded ? 'more' : 'less'}
+        </ExpandButton>
       </DetailsWrapper>
     </>
   )

--- a/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/VideoView.tsx
@@ -246,7 +246,7 @@ export const VideoView: React.FC = () => {
             </>
           )}
         </DescriptionContainer>
-        <LicenceCategoryWrapper detailsExpanded={detailsExpanded}>
+        <LicenceCategoryWrapper detailsExpanded={detailsExpanded || !video?.description}>
           <GridItem>
             {video ? (
               <>
@@ -280,16 +280,18 @@ export const VideoView: React.FC = () => {
             )}
           </CategoryWrapper>
         </LicenceCategoryWrapper>
-        <ExpandButton
-          onClick={toggleDetailsExpand}
-          iconPlacement="right"
-          size="medium"
-          variant="tertiary"
-          textOnly
-          icon={detailsExpanded ? <SvgActionChevronT /> : <SvgActionChevronB />}
-        >
-          Show {!detailsExpanded ? 'more' : 'less'}
-        </ExpandButton>
+        {video?.description && (
+          <ExpandButton
+            onClick={toggleDetailsExpand}
+            iconPlacement="right"
+            size="medium"
+            variant="tertiary"
+            textOnly
+            icon={detailsExpanded ? <SvgActionChevronT /> : <SvgActionChevronB />}
+          >
+            Show {!detailsExpanded ? 'more' : 'less'}
+          </ExpandButton>
+        )}
       </DetailsWrapper>
     </>
   )


### PR DESCRIPTION
Fix #2315
Design: https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2528%3A332971

Ignore the look of the `Show more button`. We need to revisit our button variants - the issue is already created  https://github.com/Joystream/atlas/issues/2463. 