### PR TITLE
Empty state for notification widget and view

### DIFF
--- a/packages/atlas/src/components/_notifications/NotificationsWidget/NotificationsWidget.styles.ts
+++ b/packages/atlas/src/components/_notifications/NotificationsWidget/NotificationsWidget.styles.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 
+import { Button } from '@/components/_buttons/Button'
 import { cVar, media, sizes } from '@/styles'
 
 export const Wrapper = styled.div`
@@ -7,7 +8,6 @@ export const Wrapper = styled.div`
   left: -5px;
   width: 100vw;
   background-color: ${cVar('colorBackgroundStrong')};
-
   ${media.sm} {
     left: 0;
     width: 516px;
@@ -19,6 +19,7 @@ export const Header = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: ${sizes(4)};
+  box-shadow: ${cVar('effectDividersBottom')};
 `
 
 export const Content = styled.div`
@@ -27,4 +28,8 @@ export const Content = styled.div`
   ${media.sm} {
     max-height: 336px;
   }
+`
+
+export const StyledButton = styled(Button)`
+  box-shadow: ${cVar('effectDividersTop')};
 `

--- a/packages/atlas/src/components/_notifications/NotificationsWidget/NotificationsWidget.tsx
+++ b/packages/atlas/src/components/_notifications/NotificationsWidget/NotificationsWidget.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react'
 
+import { EmptyFallback } from '@/components/EmptyFallback'
 import { Text } from '@/components/Text'
 import { Button } from '@/components/_buttons/Button'
 import { SvgActionNotifications } from '@/components/_icons'
@@ -7,7 +8,7 @@ import { Popover, PopoverImperativeHandle, PopoverProps } from '@/components/_ov
 import { absoluteRoutes } from '@/config/routes'
 import { useNotifications } from '@/providers/notifications'
 
-import { Content, Header, Wrapper } from './NotificationsWidget.styles'
+import { Content, Header, StyledButton, Wrapper } from './NotificationsWidget.styles'
 
 import { NotificationTile } from '../NotificationTile'
 
@@ -27,19 +28,23 @@ export const NotificationsWidget: React.FC<NotificationsWidgetProps> = ({ ...res
           </Button>
         </Header>
         <Content>
-          {notifications.map((notification, idx) => (
-            <NotificationTile
-              variant="compact"
-              key={`notification-${notification.id}-${idx}`}
-              notification={notification}
-              onClick={() => {
-                popoverRef.current?.hide()
-                markNotificationAsRead(notification.id)
-              }}
-            />
-          ))}
+          {notifications.length > 0 ? (
+            notifications.map((notification, idx) => (
+              <NotificationTile
+                variant="compact"
+                key={`notification-${notification.id}-${idx}`}
+                notification={notification}
+                onClick={() => {
+                  popoverRef.current?.hide()
+                  markNotificationAsRead(notification.id)
+                }}
+              />
+            ))
+          ) : (
+            <EmptyFallback variant="small" title="You don’t have any notifications" />
+          )}
         </Content>
-        <Button
+        <StyledButton
           variant="tertiary"
           size="large"
           icon={<SvgActionNotifications />}
@@ -48,7 +53,7 @@ export const NotificationsWidget: React.FC<NotificationsWidgetProps> = ({ ...res
           onClick={popoverRef.current?.hide}
         >
           <Text variant="t100">Go to notification center</Text>
-        </Button>
+        </StyledButton>
       </Wrapper>
     </Popover>
   )

--- a/packages/atlas/src/views/notifications/Notifications.styles.ts
+++ b/packages/atlas/src/views/notifications/Notifications.styles.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { LayoutGrid } from '@/components/LayoutGrid'
 import { Pill } from '@/components/Pill'
 import { NotificationTile } from '@/components/_notifications/NotificationTile'
-import { media, sizes } from '@/styles'
+import { cVar, media, sizes } from '@/styles'
 
 export const StyledLayoutGrid = styled(LayoutGrid)`
   padding-top: ${sizes(12)};
@@ -39,4 +39,27 @@ export const StyledNotificationTile = styled(NotificationTile)`
   :not(:last-of-type) {
     margin-bottom: ${sizes(2)};
   }
+`
+
+const TILE_HEIGHT = 78
+
+export const NotificationEmptyRectangle = styled.div<{ opacity?: number; absolute?: boolean }>`
+  position: ${({ absolute }) => (absolute ? 'absolute' : 'static')};
+  z-index: -1;
+  top: 0;
+  width: 100%;
+  background-color: ${cVar('colorBackgroundMuted')};
+  height: ${TILE_HEIGHT}px;
+  opacity: ${({ opacity = 1 }) => opacity};
+  margin-bottom: ${sizes(2)};
+`
+
+export const NotificationEmptyRectangleWithText = styled.div`
+  display: flex;
+  text-align: center;
+  height: ${TILE_HEIGHT}px;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin-bottom: ${sizes(2)};
 `

--- a/packages/atlas/src/views/notifications/Notifications.tsx
+++ b/packages/atlas/src/views/notifications/Notifications.tsx
@@ -10,6 +10,8 @@ import { useSelectedNotifications } from './Notifications.hooks'
 import {
   Header,
   MarkAllReadWrapper,
+  NotificationEmptyRectangle,
+  NotificationEmptyRectangleWithText,
   StyledLayoutGrid,
   StyledNotificationTile,
   StyledPill,
@@ -39,17 +41,38 @@ export const Notifications = () => {
           )}
         </Header>
         <div>
-          {notifications.map((notification, idx) => (
-            <StyledNotificationTile
-              key={`notification-${notification.id}-${idx}`}
-              notification={notification}
-              selected={selectedNotifications.includes(notification.id)}
-              onCheckboxChange={(selected) => setNotificationSelected(notification.id, selected)}
-              onClick={() => markNotificationAsRead(notification.id)}
-            />
-          ))}
+          {notifications.length > 0 ? (
+            notifications.map((notification, idx) => (
+              <StyledNotificationTile
+                key={`notification-${notification.id}-${idx}`}
+                notification={notification}
+                selected={selectedNotifications.includes(notification.id)}
+                onCheckboxChange={(selected) => setNotificationSelected(notification.id, selected)}
+                onClick={() => markNotificationAsRead(notification.id)}
+              />
+            ))
+          ) : (
+            <NotificationsEmptyFallback />
+          )}
         </div>
       </GridItem>
     </StyledLayoutGrid>
+  )
+}
+
+const NotificationsEmptyFallback = () => {
+  return (
+    <>
+      <NotificationEmptyRectangle />
+      <NotificationEmptyRectangle opacity={0.8} />
+      <NotificationEmptyRectangleWithText>
+        <NotificationEmptyRectangle opacity={0.5} absolute />
+        <Text variant="h500" secondary>
+          You don’t have any notifications
+        </Text>
+      </NotificationEmptyRectangleWithText>
+      <NotificationEmptyRectangle opacity={0.3} />
+      <NotificationEmptyRectangle opacity={0.1} />
+    </>
   )
 }


### PR DESCRIPTION
Fix #2478
Design: https://www.figma.com/file/Goequb9eZDL6WxK7T74oxS/Notifications?node-id=839%3A97662

Updating empty fallback is not in the scope of this task. We will deal with it in #2278 