### PR TITLE
set channel owner as reward account

### DIFF
--- a/packages/atlas/src/joystream-lib/extrinsics.ts
+++ b/packages/atlas/src/joystream-lib/extrinsics.ts
@@ -121,9 +121,9 @@ export class JoystreamLibExtrinsics {
     const creationParameters = new ChannelCreationParameters(this.api.registry, {
       meta: channelMetadata,
       assets: channelAssets,
-      collaborators: new BTreeSet(this.api.registry, RuntimeMemberId),
-      moderators: new BTreeSet(this.api.registry, RuntimeMemberId),
-      reward_account: new Option<RuntimeAccountId>(this.api.registry, RuntimeAccountId),
+      collaborators: new BTreeSet(this.api.registry, RuntimeMemberId, [memberId]),
+      moderators: new BTreeSet(this.api.registry, RuntimeMemberId, [memberId]),
+      reward_account: new Option<RuntimeAccountId>(this.api.registry, RuntimeAccountId, inputMetadata.ownerAccount),
     })
 
     const contentActor = new ContentActor(this.api.registry, {

--- a/packages/atlas/src/joystream-lib/types.ts
+++ b/packages/atlas/src/joystream-lib/types.ts
@@ -51,7 +51,9 @@ export type VideoInputMetadata = Omit<
   category?: number
   nft?: NftIssuanceInputMetadata
 }
-export type ChannelInputMetadata = Omit<IChannelMetadata, 'coverPhoto' | 'avatarPhoto' | 'category'>
+export type ChannelInputMetadata = Omit<IChannelMetadata, 'coverPhoto' | 'avatarPhoto' | 'category'> & {
+  ownerAccount: AccountId
+}
 export type MemberInputMetadata = Omit<IMembershipMetadata, 'avatarObject'>
 
 type NftBuyNowInputMetadata = {

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -80,7 +80,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
   const [avatarHashPromise, setAvatarHashPromise] = useState<Promise<string> | null>(null)
   const [coverHashPromise, setCoverHashPromise] = useState<Promise<string> | null>(null)
 
-  const { activeMemberId, activeChannelId, setActiveUser, refetchActiveMembership } = useUser()
+  const { activeMemberId, activeAccountId, activeChannelId, setActiveUser, refetchActiveMembership } = useUser()
   const { joystream, proxyCallback } = useJoystream()
   const handleTransaction = useTransaction()
   const { displaySnackbar } = useSnackbar()
@@ -222,7 +222,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
   }
 
   const submit = async (data: Inputs) => {
-    if (!joystream || !activeMemberId) {
+    if (!joystream || !activeMemberId || !activeAccountId) {
       return
     }
 
@@ -233,6 +233,7 @@ export const CreateEditChannelView: React.FC<CreateEditChannelViewProps> = ({ ne
       ...(dirtyFields.description ? { description: data.description?.trim() ?? '' } : {}),
       ...(dirtyFields.language || newChannel ? { language: data.language } : {}),
       ...(dirtyFields.isPublic || newChannel ? { isPublic: data.isPublic } : {}),
+      ownerAccount: activeAccountId,
     }
 
     const assets: ChannelInputAssets = {}


### PR DESCRIPTION
This PR sets `reward_account` of newly created channel to owner's account. Also it adds the owner to list of channel collaborators and moderators.
