### PR TITLE
Update empty fallback copies

### DIFF
--- a/packages/atlas/src/views/viewer/ChannelView/ChannelView.tsx
+++ b/packages/atlas/src/views/viewer/ChannelView/ChannelView.tsx
@@ -170,6 +170,7 @@ export const ChannelView: React.FC = () => {
       case 'NFTs':
         return (
           <ChannelNfts
+            isFiltersApplied={canClearAllFilters}
             tilesPerPage={tilesPerPage}
             orderBy={sortNftsBy}
             ownedNftWhereInput={ownedNftWhereInput}

--- a/packages/atlas/src/views/viewer/ChannelView/ChannelViewTabs/ChannelNfts.tsx
+++ b/packages/atlas/src/views/viewer/ChannelView/ChannelViewTabs/ChannelNfts.tsx
@@ -18,6 +18,7 @@ type ChannelNftsProps = {
   tilesPerPage: number
   ownedNftWhereInput?: OwnedNftWhereInput
   orderBy?: OwnedNftOrderByInput
+  isFiltersApplied?: boolean
 }
 
 export const ChannelNfts: React.FC<ChannelNftsProps> = ({
@@ -26,6 +27,7 @@ export const ChannelNfts: React.FC<ChannelNftsProps> = ({
   onResize,
   ownedNftWhereInput,
   orderBy,
+  isFiltersApplied,
 }) => {
   const { currentPage, setCurrentPage } = usePagination(0)
 
@@ -70,7 +72,14 @@ export const ChannelNfts: React.FC<ChannelNftsProps> = ({
     <>
       <VideoSection className={transitions.names.slide}>
         {!nftsWithPlaceholders.length && (
-          <EmptyFallback title="This channel does not have any NFTs issued yet" variant="small" />
+          <EmptyFallback
+            title={
+              isFiltersApplied
+                ? 'No NFTs found that match filter criteria'
+                : 'This channel does not have any NFTs issued yet'
+            }
+            variant="small"
+          />
         )}
         <Grid maxColumns={null} onResize={onResize}>
           {nftsWithPlaceholders?.map((nft, idx) => (

--- a/packages/atlas/src/views/viewer/MemberView/MemberNFTs.tsx
+++ b/packages/atlas/src/views/viewer/MemberView/MemberNFTs.tsx
@@ -10,11 +10,12 @@ type MemberNFTsProps = {
   nfts?: AllNftFieldsFragment[]
   loading?: boolean
   owner?: boolean
+  isFiltersApplied?: boolean
 }
 
 const INITIAL_TILES_PER_ROW = 4
 
-export const MemberNFTs: React.FC<MemberNFTsProps> = ({ nfts, loading, owner }) => {
+export const MemberNFTs: React.FC<MemberNFTsProps> = ({ nfts, loading, owner, isFiltersApplied }) => {
   const [tilesPerRow, setTilesPerRow] = useState(INITIAL_TILES_PER_ROW)
   const nftRows = useVideoGridRows('main')
   const tilesPerPage = nftRows * tilesPerRow
@@ -35,11 +36,21 @@ export const MemberNFTs: React.FC<MemberNFTsProps> = ({ nfts, loading, owner }) 
       </Grid>
       {nfts && !nfts.length && (
         <EmptyFallback
-          title={owner ? 'Start your collection' : 'No NFTs collected'}
-          subtitle={
-            owner ? "This member hadn't started the collection yet." : "This member hasn't started the collection yet."
+          title={
+            isFiltersApplied
+              ? 'No NFTs found that match filter criteria'
+              : owner
+              ? 'Start your collection'
+              : 'No NFTs collected'
           }
-          variant="small"
+          subtitle={
+            isFiltersApplied
+              ? 'Try changing the filter criteria'
+              : owner
+              ? 'Buy NFTs across the platform or create your own.'
+              : "This member hasn't started the collection yet."
+          }
+          variant="large"
         />
       )}
     </section>

--- a/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
+++ b/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
@@ -91,13 +91,20 @@ export const MemberView: React.FC = () => {
   const tabContent = React.useMemo(() => {
     switch (currentTab) {
       case 'NFTs owned':
-        return <MemberNFTs nfts={nfts} loading={loading} owner={activeMembership?.handle === handle} />
+        return (
+          <MemberNFTs
+            isFiltersApplied={canClearAllFilters}
+            nfts={nfts}
+            loading={loading}
+            owner={activeMembership?.handle === handle}
+          />
+        )
       case 'Activity':
         return <MemberActivity memberId={member?.id} sort={sortBy as 'createdAt_ASC' | 'createdAt_DESC'} />
       case 'About':
         return <MemberAbout />
     }
-  }, [activeMembership?.handle, currentTab, handle, loading, member?.id, nfts, sortBy])
+  }, [activeMembership?.handle, canClearAllFilters, currentTab, handle, loading, member?.id, nfts, sortBy])
 
   // At mount set the tab from the search params
   const initialRender = useRef(true)


### PR DESCRIPTION
Fix #2536 

Summary of changes: 
 - Member view
   -  Changed empty fallback variant to large. https://www.figma.com/file/yhZpTHdf1sxJx13uRZ71GV/Membership-profile?node-id=848%3A130385
   - Keep the previous copy for the owner:  `Start your collection`  and corresponding `subtitle`
   - Keep the previous copy  for non-owner `No NFTs collected` and corresponding `subtitle`
   - Added copy when there is a filter applied and no nfts found 'No NFTs found that match filter criteria`
 - Channel view 
   -  Added copy when there is a filter applied and no nfts found 'No NFTs found that match filter criteria' 