### PR TITLE
Fix issue with not loading sections on IOS devices

### DIFF
--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -29,13 +29,15 @@ const getVideoKeyArgs = (args: GetVideosConnectionQueryVariables | null) => {
   const createdAtGte = args?.where?.createdAt_gte ? JSON.stringify(args.where.createdAt_gte) : ''
   const sorting = args?.orderBy?.[0] ? args.orderBy[0] : ''
   const isFeatured = args?.where?.isFeatured_eq ?? ''
+  const durationGte = args?.where?.duration_gte || null
+  const durationLte = args?.where?.duration_gte || null
 
   // only for counting videos in HomeView
   if (args?.where?.channel?.id_in && !args?.first) {
     return `${createdAtGte}:${channel}`
   }
 
-  return `${onlyCount}:${channel}:${category}:${nft}:${language}:${createdAtGte}:${isPublic}:${idEq}:${idIn}:${sorting}:${isFeatured}`
+  return `${onlyCount}:${channel}:${category}:${nft}:${language}:${createdAtGte}:${isPublic}:${idEq}:${idIn}:${sorting}:${isFeatured}:${durationGte}:${durationLte}`
 }
 
 const getChannelKeyArgs = (args: GetChannelsConnectionQueryVariables | null) => {

--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -29,8 +29,8 @@ const getVideoKeyArgs = (args: GetVideosConnectionQueryVariables | null) => {
   const createdAtGte = args?.where?.createdAt_gte ? JSON.stringify(args.where.createdAt_gte) : ''
   const sorting = args?.orderBy?.[0] ? args.orderBy[0] : ''
   const isFeatured = args?.where?.isFeatured_eq ?? ''
-  const durationGte = args?.where?.duration_gte || null
-  const durationLte = args?.where?.duration_gte || null
+  const durationGte = args?.where?.duration_gte || ''
+  const durationLte = args?.where?.duration_gte || ''
 
   // only for counting videos in HomeView
   if (args?.where?.channel?.id_in && !args?.first) {

--- a/packages/atlas/src/components/Grid/Grid.tsx
+++ b/packages/atlas/src/components/Grid/Grid.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import React, { useRef } from 'react'
-import useResizeObserver from 'use-resize-observer'
+// we use pollyfiled version because "border-box" option seems to be not working on iPhone
+import useResizeObserver from 'use-resize-observer/polyfilled'
 
 import { media, sizes } from '@/styles'
-import { isIphone } from '@/utils/browser'
 import { toPx } from '@/utils/styles'
 
 type GridProps = {
@@ -28,9 +28,7 @@ export const Grid: React.FC<GridProps> = ({
   const gridRef = useRef<HTMLImageElement>(null)
   useResizeObserver<HTMLDivElement>({
     ref: gridRef,
-    // border box seems to be not working on iPhone
-    // setting border-box is causing a bug on ios with videos loading infinetely See: https://github.com/Joystream/atlas/issues/2561
-    box: isIphone ? 'content-box' : 'border-box',
+    box: 'border-box',
     onResize: () => {
       if (onResize && gridRef.current) {
         const computedStyles = window.getComputedStyle(gridRef.current)

--- a/packages/atlas/src/components/Grid/Grid.tsx
+++ b/packages/atlas/src/components/Grid/Grid.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react'
 import useResizeObserver from 'use-resize-observer'
 
 import { media, sizes } from '@/styles'
+import { isIphone } from '@/utils/browser'
 import { toPx } from '@/utils/styles'
 
 type GridProps = {
@@ -27,7 +28,9 @@ export const Grid: React.FC<GridProps> = ({
   const gridRef = useRef<HTMLImageElement>(null)
   useResizeObserver<HTMLDivElement>({
     ref: gridRef,
-    box: 'border-box',
+    // border box seems to be not working on iPhone
+    // setting border-box is causing a bug on ios with videos loading infinetely See: https://github.com/Joystream/atlas/issues/2561
+    box: isIphone ? 'content-box' : 'border-box',
     onResize: () => {
       if (onResize && gridRef.current) {
         const computedStyles = window.getComputedStyle(gridRef.current)

--- a/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
+++ b/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
@@ -94,7 +94,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
         media: {
           isAccepted_eq: true,
         },
-        ...videoWhereInput,
+        ...(videoWhereInput ? videoWhereInput : {}),
       },
     }
 

--- a/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
+++ b/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
@@ -78,6 +78,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
     const [videosPerRow, setVideosPerRow] = useState(INITIAL_VIDEOS_PER_ROW)
     const rowsToLoad = useVideoGridRows()
     const [_targetRowsCount, setTargetRowsCount] = useState(rowsToLoad)
+    const [initialGridResizeDone, setInitialGridResizeDone] = useState(false)
     const targetRowsCount = Math.max(_targetRowsCount, rowsToLoad)
 
     const queryVariables: GetVideosConnectionQueryVariables & GetMostViewedVideosConnectionQueryVariables = {
@@ -107,7 +108,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
       GetVideosConnectionQueryVariables
     >({
       query: query || GetVideosConnectionDocument,
-      isReady: ready,
+      isReady: ready && initialGridResizeDone,
       skipCount,
       queryVariables,
       targetRowsCount,
@@ -133,7 +134,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
       return null
     }
 
-    const hasNoItems = ready && !loading && totalCount === 0
+    const hasNoItems = ready && initialGridResizeDone && !loading && totalCount === 0
     if (hasNoItems && !emptyFallback) {
       return null
     }
@@ -172,6 +173,9 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
             <Grid
               onResize={(sizes) => {
                 setVideosPerRow(sizes.length)
+                if (!initialGridResizeDone) {
+                  setInitialGridResizeDone(true)
+                }
               }}
             >
               {gridContent}

--- a/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
+++ b/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
@@ -78,7 +78,6 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
     const [videosPerRow, setVideosPerRow] = useState(INITIAL_VIDEOS_PER_ROW)
     const rowsToLoad = useVideoGridRows()
     const [_targetRowsCount, setTargetRowsCount] = useState(rowsToLoad)
-    const [initialGridResizeDone, setInitialGridResizeDone] = useState(false)
     const targetRowsCount = Math.max(_targetRowsCount, rowsToLoad)
 
     const queryVariables: GetVideosConnectionQueryVariables & GetMostViewedVideosConnectionQueryVariables = {
@@ -108,7 +107,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
       GetVideosConnectionQueryVariables
     >({
       query: query || GetVideosConnectionDocument,
-      isReady: ready && initialGridResizeDone,
+      isReady: ready,
       skipCount,
       queryVariables,
       targetRowsCount,
@@ -134,7 +133,7 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
       return null
     }
 
-    const hasNoItems = ready && initialGridResizeDone && !loading && totalCount === 0
+    const hasNoItems = ready && !loading && totalCount === 0
     if (hasNoItems && !emptyFallback) {
       return null
     }
@@ -173,9 +172,6 @@ export const InfiniteVideoGrid = React.forwardRef<HTMLElement, InfiniteVideoGrid
             <Grid
               onResize={(sizes) => {
                 setVideosPerRow(sizes.length)
-                if (!initialGridResizeDone) {
-                  setInitialGridResizeDone(true)
-                }
               }}
             >
               {gridContent}

--- a/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
+++ b/packages/atlas/src/components/InfiniteGrids/InfiniteVideoGrid.tsx
@@ -49,7 +49,7 @@ type InfiniteVideoGridProps = {
   }
 }
 
-const INITIAL_VIDEOS_PER_ROW = 4
+const INITIAL_VIDEOS_PER_ROW = 1
 
 type VideoQuery = GetVideosConnectionQuery | GetMostViewedVideosConnectionQuery
 

--- a/packages/atlas/src/components/_video/VideoPlayer/utils.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/utils.ts
@@ -1,5 +1,7 @@
 import { VideoJsPlayer } from 'video.js'
 
+import { isIphone } from '@/utils/browser'
+
 export type PlayerState = 'loading' | 'ended' | 'error' | 'playingOrPaused' | 'pending'
 
 export const VOLUME_STEP = 0.1
@@ -16,8 +18,6 @@ export enum CustomVideojsEvents {
   PlayControl = 'PLAY_CONTROL',
   PauseControl = 'PAUSE_CONTROL',
 }
-
-const isIphone = /iPhone/.test(window.navigator.userAgent)
 
 export const isFullScreenEnabled =
   document.fullscreenEnabled ||

--- a/packages/atlas/src/utils/browser.ts
+++ b/packages/atlas/src/utils/browser.ts
@@ -28,3 +28,5 @@ export const isMobile = () => {
   }
   return false
 }
+
+export const isIphone = /iPhone/.test(window.navigator.userAgent)

--- a/packages/atlas/src/views/viewer/CategoryView/CategoryVideos.tsx
+++ b/packages/atlas/src/views/viewer/CategoryView/CategoryVideos.tsx
@@ -46,15 +46,9 @@ export const CategoryVideos: React.FC<{ categoryId: string }> = ({ categoryId })
 
   const [sortVideosBy, setSortVideosBy] = useState<VideoOrderByInput>(VideoOrderByInput.CreatedAtDesc)
 
-  const { videoCount } = useVideoCount({ where: videoWhereInput })
-
-  useEffect(() => {
-    setVideoWhereInput({
-      category: {
-        id_eq: categoryId,
-      },
-    })
-  }, [categoryId, setVideoWhereInput])
+  const { videoCount } = useVideoCount({
+    where: { ...videoWhereInput, category: { id_eq: categoryId } },
+  })
 
   useEffect(() => {
     if (scrollWhenFilterChange.current) {
@@ -155,7 +149,7 @@ export const CategoryVideos: React.FC<{ categoryId: string }> = ({ categoryId })
               />
             </FallbackWrapper>
           }
-          videoWhereInput={videoWhereInput}
+          videoWhereInput={{ ...videoWhereInput, category: { id_eq: categoryId } }}
           orderBy={sortVideosBy}
           onDemandInfinite
         />


### PR DESCRIPTION
Fix #2561
To be honest, It turned out that for some reason `initialGridResizeDone` was never set on iPhones.  I'm not sure what `setInitialGridResizeDone` actually did, but it looked pretty useless to me, so I removed this.