### PR TITLE
fix sidenav scroll hiding

### DIFF
--- a/packages/atlas/src/providers/overlayManager.tsx
+++ b/packages/atlas/src/providers/overlayManager.tsx
@@ -78,7 +78,11 @@ export const useOverlayManager = () => {
 
   const decrementOverlaysOpenCount = useCallback(() => {
     setOverlaysSet((prevSet) => {
-      prevSet.delete(overlayId)
+      if (prevSet.size === 1) {
+        prevSet.clear()
+      } else {
+        prevSet.delete(overlayId)
+      }
       return new Set(prevSet)
     })
   }, [overlayId, setOverlaysSet])


### PR DESCRIPTION
Closes #2572

The problem was in `useOverlayManager`. When you change page, `overlayId` ref is changing and `prevSet.delete(overlayId)` is no longer working.