### PR TITLE
View history of comment edits

### DIFF
--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -234,6 +234,11 @@ const cache = new InMemoryCache({
         createdAt: createDateHandler(),
       },
     },
+    CommentCreatedEvent: {
+      fields: {
+        createdAt: createDateHandler(),
+      },
+    },
     StorageDataObject: {
       fields: {
         size: {

--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -229,6 +229,11 @@ const cache = new InMemoryCache({
         createdAt: createDateHandler(),
       },
     },
+    CommentTextUpdatedEvent: {
+      fields: {
+        createdAt: createDateHandler(),
+      },
+    },
     StorageDataObject: {
       fields: {
         size: {

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -1,6 +1,13 @@
 import { QueryHookOptions } from '@apollo/client'
 
-import { GetCommentsQuery, GetCommentsQueryVariables, useGetCommentsQuery } from '@/api/queries'
+import {
+  GetCommentEditsQuery,
+  GetCommentEditsQueryVariables,
+  GetCommentsQuery,
+  GetCommentsQueryVariables,
+  useGetCommentEditsQuery,
+  useGetCommentsQuery,
+} from '@/api/queries'
 
 export const useComments = (
   variables?: GetCommentsQueryVariables,
@@ -10,6 +17,18 @@ export const useComments = (
 
   return {
     comments: data?.comments,
+    ...rest,
+  }
+}
+
+export const useCommentEdits = (
+  commentId?: string,
+  opts?: QueryHookOptions<GetCommentEditsQuery, GetCommentEditsQueryVariables>
+) => {
+  const { data, ...rest } = useGetCommentEditsQuery({ ...opts, variables: { commentId: commentId || '' } })
+
+  return {
+    commentEdits: data?.commentTextUpdatedEvents,
     ...rest,
   }
 }

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -7,6 +7,7 @@ import {
   GetCommentsQueryVariables,
   useGetCommentEditsQuery,
   useGetCommentsQuery,
+  useGetOriginalCommentQuery,
 } from '@/api/queries'
 
 export const useComments = (
@@ -25,10 +26,24 @@ export const useCommentEdits = (
   commentId?: string,
   opts?: QueryHookOptions<GetCommentEditsQuery, GetCommentEditsQueryVariables>
 ) => {
-  const { data, ...rest } = useGetCommentEditsQuery({ ...opts, variables: { commentId: commentId || '' } })
+  const { data: editedCommentsData, ...rest } = useGetCommentEditsQuery({
+    ...opts,
+    variables: { commentId: commentId || '' },
+  })
+  // we need to fetch the original comment separately.
+  const { data: originalCommentData, loading: originalCommentLoading } = useGetOriginalCommentQuery({
+    variables: { commentId: commentId || '' },
+  })
+
+  const originalComment = originalCommentData?.commentCreatedEvents.map((comment) => ({
+    ...comment,
+    newText: comment.text,
+  }))[0]
 
   return {
-    commentEdits: data?.commentTextUpdatedEvents,
+    commentEdits: editedCommentsData?.commentTextUpdatedEvents &&
+      originalComment && [originalComment, ...editedCommentsData.commentTextUpdatedEvents],
     ...rest,
+    loading: rest.loading || originalCommentLoading,
   }
 }

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -118,6 +118,20 @@ export type GetCommentsConnectionQuery = {
   }
 }
 
+export type GetCommentEditsQueryVariables = Types.Exact<{
+  commentId: Types.Scalars['ID']
+}>
+
+export type GetCommentEditsQuery = {
+  __typename?: 'Query'
+  commentTextUpdatedEvents: Array<{
+    __typename?: 'CommentTextUpdatedEvent'
+    id: string
+    createdAt: Date
+    newText: string
+  }>
+}
+
 export const GetCommentsDocument = gql`
   query GetComments(
     $limit: Int
@@ -233,3 +247,44 @@ export type GetCommentsConnectionQueryResult = Apollo.QueryResult<
   GetCommentsConnectionQuery,
   GetCommentsConnectionQueryVariables
 >
+export const GetCommentEditsDocument = gql`
+  query GetCommentEdits($commentId: ID!) {
+    commentTextUpdatedEvents(where: { comment: { id_eq: $commentId } }) {
+      id
+      createdAt
+      newText
+    }
+  }
+`
+
+/**
+ * __useGetCommentEditsQuery__
+ *
+ * To run a query within a React component, call `useGetCommentEditsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCommentEditsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCommentEditsQuery({
+ *   variables: {
+ *      commentId: // value for 'commentId'
+ *   },
+ * });
+ */
+export function useGetCommentEditsQuery(
+  baseOptions: Apollo.QueryHookOptions<GetCommentEditsQuery, GetCommentEditsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetCommentEditsQuery, GetCommentEditsQueryVariables>(GetCommentEditsDocument, options)
+}
+export function useGetCommentEditsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetCommentEditsQuery, GetCommentEditsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetCommentEditsQuery, GetCommentEditsQueryVariables>(GetCommentEditsDocument, options)
+}
+export type GetCommentEditsQueryHookResult = ReturnType<typeof useGetCommentEditsQuery>
+export type GetCommentEditsLazyQueryHookResult = ReturnType<typeof useGetCommentEditsLazyQuery>
+export type GetCommentEditsQueryResult = Apollo.QueryResult<GetCommentEditsQuery, GetCommentEditsQueryVariables>

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -132,6 +132,15 @@ export type GetCommentEditsQuery = {
   }>
 }
 
+export type GetOriginalCommentQueryVariables = Types.Exact<{
+  commentId: Types.Scalars['ID']
+}>
+
+export type GetOriginalCommentQuery = {
+  __typename?: 'Query'
+  commentCreatedEvents: Array<{ __typename?: 'CommentCreatedEvent'; id: string; createdAt: Date; text: string }>
+}
+
 export const GetCommentsDocument = gql`
   query GetComments(
     $limit: Int
@@ -288,3 +297,50 @@ export function useGetCommentEditsLazyQuery(
 export type GetCommentEditsQueryHookResult = ReturnType<typeof useGetCommentEditsQuery>
 export type GetCommentEditsLazyQueryHookResult = ReturnType<typeof useGetCommentEditsLazyQuery>
 export type GetCommentEditsQueryResult = Apollo.QueryResult<GetCommentEditsQuery, GetCommentEditsQueryVariables>
+export const GetOriginalCommentDocument = gql`
+  query GetOriginalComment($commentId: ID!) {
+    commentCreatedEvents(where: { comment: { id_eq: $commentId } }) {
+      id
+      createdAt
+      text
+    }
+  }
+`
+
+/**
+ * __useGetOriginalCommentQuery__
+ *
+ * To run a query within a React component, call `useGetOriginalCommentQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetOriginalCommentQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetOriginalCommentQuery({
+ *   variables: {
+ *      commentId: // value for 'commentId'
+ *   },
+ * });
+ */
+export function useGetOriginalCommentQuery(
+  baseOptions: Apollo.QueryHookOptions<GetOriginalCommentQuery, GetOriginalCommentQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetOriginalCommentQuery, GetOriginalCommentQueryVariables>(GetOriginalCommentDocument, options)
+}
+export function useGetOriginalCommentLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetOriginalCommentQuery, GetOriginalCommentQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetOriginalCommentQuery, GetOriginalCommentQueryVariables>(
+    GetOriginalCommentDocument,
+    options
+  )
+}
+export type GetOriginalCommentQueryHookResult = ReturnType<typeof useGetOriginalCommentQuery>
+export type GetOriginalCommentLazyQueryHookResult = ReturnType<typeof useGetOriginalCommentLazyQuery>
+export type GetOriginalCommentQueryResult = Apollo.QueryResult<
+  GetOriginalCommentQuery,
+  GetOriginalCommentQueryVariables
+>

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -37,3 +37,11 @@ query GetCommentEdits($commentId: ID!) {
     newText
   }
 }
+
+query GetOriginalComment($commentId: ID!) {
+  commentCreatedEvents(where: { comment: { id_eq: $commentId } }) {
+    id
+    createdAt
+    text
+  }
+}

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -29,3 +29,11 @@ query GetCommentsConnection(
     totalCount
   }
 }
+
+query GetCommentEdits($commentId: ID!) {
+  commentTextUpdatedEvents(where: { comment: { id_eq: $commentId } }) {
+    id
+    createdAt
+    newText
+  }
+}

--- a/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
+++ b/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
 
 import { useCommentEdits } from '@/api/hooks'
 import { CommentFieldsFragment } from '@/api/queries'
 import { absoluteRoutes } from '@/config/routes'
 import { useMemberAvatar } from '@/providers/assets'
+import { cVar, transitions } from '@/styles'
 
 import { CommentSnapshot } from '../CommentSnapshot'
 import { GAP_BETWEEN_COMMENT_SNAPSHOTS } from '../CommentSnapshot/CommentSnaphsot.styles'
@@ -17,22 +19,43 @@ export const CommentEditHistory: React.FC<CommentEditHistoryProps> = ({ original
   const { commentEdits, loading } = useCommentEdits(originalComment?.id)
   const { url: memberAvatarUrl, isLoadingAsset } = useMemberAvatar(originalComment?.author)
 
-  return commentEdits ? (
-    <Container>
-      {commentEdits?.map(({ id, newText, createdAt }) => (
-        <CommentSnapshot
-          key={id}
-          createdAt={createdAt}
-          memberHandle={originalComment?.author?.handle}
-          memberUrl={absoluteRoutes.viewer.member(originalComment?.author?.handle)}
-          text={newText}
-          loading={loading}
-          memberAvatarUrl={memberAvatarUrl || ''}
-          isMemberAvatarLoading={isLoadingAsset}
-        />
-      ))}
-    </Container>
-  ) : null
+  const placeholderItems = Array.from({ length: 3 }, () => ({ id: undefined }))
+
+  return (
+    <SwitchTransition>
+      <CSSTransition
+        timeout={parseInt(cVar('animationTimingFast', true))}
+        key={loading?.toString()}
+        classNames={transitions.names.fade}
+      >
+        {loading ? (
+          <Container>
+            {placeholderItems.map((_, idx) => (
+              <CommentSnapshot key={idx} loading={loading} last={placeholderItems?.length === idx + 1} />
+            ))}
+          </Container>
+        ) : (
+          <Container>
+            {commentEdits?.map(({ id, newText, createdAt }, idx) => {
+              return (
+                <CommentSnapshot
+                  key={id}
+                  last={commentEdits?.length === idx + 1}
+                  createdAt={createdAt}
+                  memberHandle={originalComment?.author?.handle}
+                  memberUrl={absoluteRoutes.viewer.member(originalComment?.author?.handle)}
+                  text={newText}
+                  loading={loading}
+                  memberAvatarUrl={memberAvatarUrl || ''}
+                  isMemberAvatarLoading={isLoadingAsset}
+                />
+              )
+            })}
+          </Container>
+        )}
+      </CSSTransition>
+    </SwitchTransition>
+  )
 }
 
 const Container = styled.div`

--- a/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
+++ b/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled'
+import React from 'react'
+
+import { useCommentEdits } from '@/api/hooks'
+import { CommentFieldsFragment } from '@/api/queries'
+import { absoluteRoutes } from '@/config/routes'
+import { useMemberAvatar } from '@/providers/assets'
+
+import { CommentSnapshot } from '../CommentSnapshot'
+import { GAP_BETWEEN_COMMENT_SNAPSHOTS } from '../CommentSnapshot/CommentSnaphsot.styles'
+
+type CommentEditHistoryProps = {
+  originalComment?: CommentFieldsFragment | null
+}
+
+export const CommentEditHistory: React.FC<CommentEditHistoryProps> = ({ originalComment }) => {
+  const { commentEdits, loading } = useCommentEdits(originalComment?.id)
+  const { url: memberAvatarUrl, isLoadingAsset } = useMemberAvatar(originalComment?.author)
+
+  return commentEdits ? (
+    <Container>
+      {commentEdits?.map(({ id, newText, createdAt }) => (
+        <CommentSnapshot
+          key={id}
+          createdAt={createdAt}
+          memberHandle={originalComment?.author?.handle}
+          memberUrl={absoluteRoutes.viewer.member(originalComment?.author?.handle)}
+          text={newText}
+          loading={loading}
+          memberAvatarUrl={memberAvatarUrl || ''}
+          isMemberAvatarLoading={isLoadingAsset}
+        />
+      ))}
+    </Container>
+  ) : null
+}
+
+const Container = styled.div`
+  display: grid;
+  gap: ${GAP_BETWEEN_COMMENT_SNAPSHOTS}px;
+`

--- a/packages/atlas/src/components/_comments/CommentEditHistory/index.ts
+++ b/packages/atlas/src/components/_comments/CommentEditHistory/index.ts
@@ -1,0 +1,1 @@
+export * from './CommentEditHistory'

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.stories.tsx
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta, Story } from '@storybook/react'
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+
+import { CommentSnapshot, CommentSnapshotProps } from './CommentSnaphsot'
+
+export default {
+  title: 'comments/CommentSnapshot',
+  component: CommentSnapshot,
+  args: {
+    memberAvatarUrl: 'https://placedog.net/100/100?random=2',
+    text: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Ea, a suscipit? Quaerat veniam rerum voluptatem quasi similique quo corporis aspernatur excepturi porro vitae expedita, aliquam amet quisquam velit quod in?',
+    loading: false,
+    memberHandle: 'johndoe',
+    createdAt: new Date(1649761429792),
+  },
+  argTypes: {
+    memberAvatarUrl: {
+      description: 'The URL to the member profile',
+      table: { disable: true },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} as Meta<CommentSnapshotProps>
+
+const Template: Story<CommentSnapshotProps> = (args) => {
+  return (
+    <div style={{ display: 'grid', gap: 32 }}>
+      <CommentSnapshot {...args} />
+      <CommentSnapshot {...args} />
+    </div>
+  )
+}
+
+export const Default = Template.bind({})

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.stories.tsx
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.stories.tsx
@@ -15,10 +15,8 @@ export default {
     createdAt: new Date(1649761429792),
   },
   argTypes: {
-    memberAvatarUrl: {
-      description: 'The URL to the member profile',
-      table: { disable: true },
-    },
+    createdAt: { control: 'date' },
+    memberUrl: { table: { disable: true } },
   },
   decorators: [
     (Story) => (
@@ -29,13 +27,19 @@ export default {
   ],
 } as Meta<CommentSnapshotProps>
 
-const Template: Story<CommentSnapshotProps> = (args) => {
+const SingleTemplate: Story<CommentSnapshotProps> = (args) => {
+  return <CommentSnapshot {...args} />
+}
+
+const ManyTemplate: Story<CommentSnapshotProps> = (args) => {
   return (
     <div style={{ display: 'grid', gap: 32 }}>
       <CommentSnapshot {...args} />
       <CommentSnapshot {...args} />
+      <CommentSnapshot {...args} />
+      <CommentSnapshot {...args} last={true} />
     </div>
   )
 }
-
-export const Default = Template.bind({})
+export const Single = SingleTemplate.bind({})
+export const Many = ManyTemplate.bind({})

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.styles.ts
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.styles.ts
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled'
 import { Link } from 'react-router-dom'
 
+import { Text } from '@/components/Text'
 import { cVar, sizes, square } from '@/styles'
 
 export const GAP_BETWEEN_COMMENT_SNAPSHOTS = sizes(8, true)
+const AVATAR_HEIGHT = sizes(10, true)
 
 export const AvatarWrapper = styled.div`
   position: relative;
@@ -13,11 +15,11 @@ export const AvatarWrapper = styled.div`
 `
 
 export const Line = styled.div`
-  top: ${GAP_BETWEEN_COMMENT_SNAPSHOTS}px;
-  background-color: ${cVar('colorBorderMutedAlpha')};
   position: absolute;
+  top: ${AVATAR_HEIGHT}px;
+  background-color: ${cVar('colorBorderMutedAlpha')};
   width: 1px;
-  height: 100%;
+  height: calc(100% - (${AVATAR_HEIGHT}px - ${GAP_BETWEEN_COMMENT_SNAPSHOTS}px));
 `
 
 export const ContentWrapper = styled.div`
@@ -33,6 +35,9 @@ export const CommentHeader = styled.header`
 
   /* author, dot, date */
   grid-template-columns: repeat(3, auto);
+`
+export const CommentBody = styled(Text)`
+  white-space: pre;
 `
 
 export const CommentHeaderDot = styled.div`

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.styles.ts
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.styles.ts
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled'
+import { Link } from 'react-router-dom'
+
+import { cVar, sizes, square } from '@/styles'
+
+export const GAP_BETWEEN_COMMENT_SNAPSHOTS = sizes(8, true)
+
+export const AvatarWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+export const Line = styled.div`
+  top: ${GAP_BETWEEN_COMMENT_SNAPSHOTS}px;
+  background-color: ${cVar('colorBorderMutedAlpha')};
+  position: absolute;
+  width: 1px;
+  height: 100%;
+`
+
+export const ContentWrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: ${sizes(4)};
+`
+
+export const CommentHeader = styled.header`
+  display: inline-grid;
+  gap: ${sizes(2)};
+  align-items: center;
+
+  /* author, dot, date */
+  grid-template-columns: repeat(3, auto);
+`
+
+export const CommentHeaderDot = styled.div`
+  background-color: ${cVar('colorBackgroundAlpha')};
+  border-radius: 100%;
+
+  ${square(4)};
+`
+
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+`

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.tsx
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
+
+import { Avatar } from '@/components/Avatar'
+import { Text } from '@/components/Text'
+import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
+import { cVar, transitions } from '@/styles'
+import { formatDateTime } from '@/utils/time'
+
+import {
+  AvatarWrapper,
+  CommentHeader,
+  CommentHeaderDot,
+  ContentWrapper,
+  Line,
+  StyledLink,
+} from './CommentSnaphsot.styles'
+
+export type CommentSnapshotProps = {
+  isMemberAvatarLoading?: boolean
+  memberAvatarUrl?: string
+  memberUrl?: string
+  memberHandle?: string
+  loading?: boolean
+  createdAt?: Date
+  text?: string
+  last?: boolean
+}
+
+export const CommentSnapshot: React.FC<CommentSnapshotProps> = ({
+  memberAvatarUrl,
+  isMemberAvatarLoading,
+  memberHandle,
+  loading,
+  memberUrl = '',
+  text,
+  last,
+  createdAt,
+}) => {
+  return (
+    <ContentWrapper>
+      <AvatarWrapper>
+        {!last && <Line />}
+        <Link to={memberUrl}>
+          <Avatar assetUrl={memberAvatarUrl} size="small" loading={isMemberAvatarLoading} clickable />
+        </Link>
+      </AvatarWrapper>
+      <SwitchTransition>
+        <CSSTransition
+          timeout={parseInt(cVar('animationTimingFast', true))}
+          key={loading?.toString()}
+          classNames={transitions.names.fade}
+        >
+          {loading ? (
+            <div>
+              <SkeletonLoader width={128} height={20} bottomSpace={8} />
+              <SkeletonLoader width="100%" height={16} bottomSpace={8} />
+              <SkeletonLoader width="70%" height={16} />
+            </div>
+          ) : (
+            <section>
+              <CommentHeader>
+                <StyledLink to={memberUrl}>
+                  <Text variant="h200">{memberHandle}</Text>
+                </StyledLink>
+                <CommentHeaderDot />
+                <Text variant="t100" secondary>
+                  {createdAt && formatDateTime(createdAt)}
+                </Text>
+              </CommentHeader>
+              <Text variant="t200" as="p" margin={{ top: 2 }}>
+                {text}
+              </Text>
+            </section>
+          )}
+        </CSSTransition>
+      </SwitchTransition>
+    </ContentWrapper>
+  )
+}

--- a/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.tsx
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/CommentSnaphsot.tsx
@@ -10,6 +10,7 @@ import { formatDateTime } from '@/utils/time'
 
 import {
   AvatarWrapper,
+  CommentBody,
   CommentHeader,
   CommentHeaderDot,
   ContentWrapper,
@@ -41,10 +42,10 @@ export const CommentSnapshot: React.FC<CommentSnapshotProps> = ({
   return (
     <ContentWrapper>
       <AvatarWrapper>
-        {!last && <Line />}
         <Link to={memberUrl}>
           <Avatar assetUrl={memberAvatarUrl} size="small" loading={isMemberAvatarLoading} clickable />
         </Link>
+        {!last && <Line />}
       </AvatarWrapper>
       <SwitchTransition>
         <CSSTransition
@@ -69,9 +70,9 @@ export const CommentSnapshot: React.FC<CommentSnapshotProps> = ({
                   {createdAt && formatDateTime(createdAt)}
                 </Text>
               </CommentHeader>
-              <Text variant="t200" as="p" margin={{ top: 2 }}>
+              <CommentBody variant="t200" as="p" margin={{ top: 2 }}>
                 {text}
-              </Text>
+              </CommentBody>
             </section>
           )}
         </CSSTransition>

--- a/packages/atlas/src/components/_comments/CommentSnapshot/index.ts
+++ b/packages/atlas/src/components/_comments/CommentSnapshot/index.ts
@@ -1,0 +1,1 @@
+export * from './CommentSnaphsot'

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -97,7 +97,13 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
               />
             ))}
       </CommentWrapper>
-      <DialogModal title="Edit history" show={!!originalComment} dividers onExitClick={() => setOriginalComment(null)}>
+      <DialogModal
+        size="medium"
+        title="Edit history"
+        show={!!originalComment}
+        dividers
+        onExitClick={() => setOriginalComment(null)}
+      >
         <CommentEditHistory originalComment={originalComment} />
       </DialogModal>
     </CommentsSectionWrapper>

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useComments } from '@/api/hooks'
-import { CommentOrderByInput } from '@/api/queries'
+import { CommentFieldsFragment, CommentOrderByInput } from '@/api/queries'
 import { EmptyFallback } from '@/components/EmptyFallback'
 import { Text } from '@/components/Text'
 import { Comment } from '@/components/_comments/Comment'
+import { CommentEditHistory } from '@/components/_comments/CommentEditHistory'
 import { Select } from '@/components/_inputs/Select'
+import { DialogModal } from '@/components/_overlays/DialogModal'
 import { absoluteRoutes } from '@/config/routes'
 import { COMMENTS_SORT_OPTIONS } from '@/config/sorting'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
@@ -21,6 +23,7 @@ type CommentsSectionProps = {
 
 export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, videoAuthorId }) => {
   const [sortCommentsBy, setSortCommentsBy] = useState(CommentOrderByInput.ReactionsCountDesc)
+  const [originalComment, setOriginalComment] = useState<CommentFieldsFragment | null>(null)
   const { id } = useParams()
   const { activeMemberId } = useUser()
   const { comments, loading } = useComments(
@@ -73,6 +76,9 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
                 createdAt={new Date(comment.createdAt)}
                 comment={comment.text}
                 isEdited={comment.isEdited}
+                onEditLabelClick={() => {
+                  setOriginalComment(comment)
+                }}
                 isAbleToEdit={comment.author.id === activeMemberId}
                 memberHandle={comment.author.handle}
                 memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
@@ -91,6 +97,9 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
               />
             ))}
       </CommentWrapper>
+      <DialogModal title="Edit history" show={!!originalComment} dividers onExitClick={() => setOriginalComment(null)}>
+        <CommentEditHistory originalComment={originalComment} />
+      </DialogModal>
     </CommentsSectionWrapper>
   )
 }


### PR DESCRIPTION
Fix #2441 
~This is created based on https://github.com/Joystream/atlas/pull/2526~
~I'll rebase once it's merged.~ 

Be aware, that I didn't add any styling to the edit history dialog, I think after the [Dialog update](https://github.com/Joystream/atlas/pull/2462) this won't be needed. 

You can test the full flow on the video with id "1" and you can check the CommentSnaphsot component in the storybook.

Designs
Flow: https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2213%3A140609
Component: 
https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2429%3A220249