### PR TITLE
fix dialog buttons

### DIFF
--- a/packages/atlas/src/components/_overlays/Dialog/Dialog.styles.ts
+++ b/packages/atlas/src/components/_overlays/Dialog/Dialog.styles.ts
@@ -105,7 +105,7 @@ export const Footer = styled.div<FooterProps>`
   ${({ dividers }) => dividers && footerDividersStyles};
 
   ${media.sm} {
-    flex-direction: row;
+    flex-direction: row-reverse;
     align-items: center;
   }
 `


### PR DESCRIPTION
Dialog buttons were on the left but should have been on the right, this PR fixes this.
@drillprop this is your code so please make sure I didn't destroy your work.