### PR TITLE
fix unsubscribing balance

### DIFF
--- a/packages/atlas/src/hooks/useSubsribeAccountBalance.ts
+++ b/packages/atlas/src/hooks/useSubsribeAccountBalance.ts
@@ -13,7 +13,7 @@ export const useSubsribeAccountBalance = () => {
       return
     }
 
-    let unsubscribe
+    let unsubscribe: () => void
     const init = async () => {
       unsubscribe = await joystream.subscribeAccountBalance(
         activeMembership.controllerAccount,
@@ -22,7 +22,9 @@ export const useSubsribeAccountBalance = () => {
     }
     init()
 
-    return unsubscribe
+    return () => {
+      unsubscribe()
+    }
   }, [activeMembership, joystream, proxyCallback])
 
   return accountBalance


### PR DESCRIPTION
Closes #2620 

Task is a bit poorly described. The problem was that when you switch member and make a purchase, sometimes the balance of the wrong member would appear. The problem was an incorrect unsubscribe.