### PR TITLE
Set correct avatar on comment input

### DIFF
--- a/packages/atlas/src/components/_comments/CommentInput/CommentInput.styles.ts
+++ b/packages/atlas/src/components/_comments/CommentInput/CommentInput.styles.ts
@@ -26,7 +26,7 @@ export const CustomPlaceholder = styled(Text)`
   opacity: 0;
   top: 0;
   color: ${cVar('colorTextMuted')};
-  user-select: none;
+  pointer-events: none;
   transition: all ${cVar('animationTransitionMedium')};
 `
 export const CustomPlaceholderHandle = styled(Text)`

--- a/packages/atlas/src/components/_comments/CommentInput/CommentInput.tsx
+++ b/packages/atlas/src/components/_comments/CommentInput/CommentInput.tsx
@@ -72,7 +72,7 @@ export const CommentInput: React.FC<CommentInputProps> = ({
   const show = !!value || active || processing
 
   return (
-    <StyledCommentRow {...rest} processing={processing} show={show}>
+    <StyledCommentRow {...rest} processing={processing} show={show} isMemberAvatarClickable={false}>
       <Container
         ref={containerRef}
         onFocus={() => {

--- a/packages/atlas/src/components/_comments/CommentRow/CommentRow.tsx
+++ b/packages/atlas/src/components/_comments/CommentRow/CommentRow.tsx
@@ -10,7 +10,8 @@ export type CommentRowProps = {
   indented?: boolean
   highlighted?: boolean
   isMemberAvatarLoading?: boolean
-  memberAvatarUrl?: string
+  isMemberAvatarClickable?: boolean
+  memberAvatarUrl?: string | null
   memberUrl?: string
   className?: string
   withoutOutlineBox?: boolean
@@ -22,6 +23,7 @@ export const CommentRow: React.FC<CommentRowProps> = ({
   children,
   memberAvatarUrl,
   isMemberAvatarLoading,
+  isMemberAvatarClickable = true,
   memberUrl = '',
   className,
   withoutOutlineBox = false,
@@ -47,7 +49,12 @@ export const CommentRow: React.FC<CommentRowProps> = ({
     <OutlineBox highlighted={!!highlighted} withoutOutlineBox={withoutOutlineBox}>
       <ContentWrapper indented={!!indented}>
         <Link to={memberUrl}>
-          <Avatar assetUrl={memberAvatarUrl} size={avatarSize} loading={isMemberAvatarLoading} clickable />
+          <Avatar
+            assetUrl={memberAvatarUrl}
+            size={avatarSize}
+            loading={isMemberAvatarLoading}
+            clickable={isMemberAvatarClickable}
+          />
         </Link>
         <div className={className}>{children}</div>
       </ContentWrapper>

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -203,7 +203,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
       </CommentsSectionHeader>
       <CommentInput
         memberAvatarUrl={memberAvatarUrl}
-        isMemberAvatarLoading={isMemberAvatarLoading}
+        isMemberAvatarLoading={authorized ? isMemberAvatarLoading : false}
         processing={commentInputProcessing}
         readOnly={!activeMemberId}
         memberHandle={activeMembership?.handle}

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -22,6 +22,7 @@ import { COMMENTS_SORT_OPTIONS } from '@/config/sorting'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useReactionTransactions } from '@/hooks/useReactionTransactions'
+import { useMemberAvatar } from '@/providers/assets'
 import { usePersonalDataStore } from '@/providers/personalData'
 import { useUser } from '@/providers/user'
 
@@ -49,6 +50,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
   const reactionPopoverDismissed = usePersonalDataStore((state) => state.reactionPopoverDismissed)
   const { activeMemberId, activeAccountId, signIn, activeMembership } = useUser()
   const { openSignInDialog } = useDisplaySignInDialog()
+  const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
   const [highlightedComment, setHighlightedComment] = useState<string | null>(null)
 
   useEffect(() => {
@@ -200,6 +202,8 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
         />
       </CommentsSectionHeader>
       <CommentInput
+        memberAvatarUrl={memberAvatarUrl}
+        isMemberAvatarLoading={isMemberAvatarLoading}
         processing={commentInputProcessing}
         readOnly={!activeMemberId}
         memberHandle={activeMembership?.handle}


### PR DESCRIPTION
This is just a minor fix. We were missing the member avatar on comment input.

![image](https://user-images.githubusercontent.com/51168865/167789313-dc7f1530-7b4b-4c45-9cef-f678ccfea4ae.png)
