### PR TITLE
Comment components refactor, performance improvements

### DIFF
--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -22,6 +22,29 @@ import {
 } from '@/api/queries'
 import { createLookup } from '@/utils/data'
 
+export const useComment = (commentId: string, opts?: QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) => {
+  const { data, ...rest } = useGetCommentQuery({ ...opts, variables: { commentId: commentId } })
+
+  const userCommentReactionsLookup =
+    data?.commentReactions &&
+    data.commentReactions.reduce<Record<string, number[]>>((acc, item) => {
+      if (item) {
+        acc[item.commentId] = [...(acc[item.commentId] ? acc[item.commentId] : []), item.reactionId]
+      }
+      return acc
+    }, {})
+
+  const comment = data?.comments.map((comment) => ({
+    ...comment,
+    userReactions: userCommentReactionsLookup?.[comment.id],
+  }))[0]
+
+  return {
+    comment,
+    ...rest,
+  }
+}
+
 type CommentReaction = {
   commentId: string
   reactionId: number

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -24,19 +24,17 @@ import { createLookup } from '@/utils/data'
 
 export const useComment = (commentId: string, opts?: QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) => {
   const { data, ...rest } = useGetCommentQuery({ ...opts, variables: { commentId: commentId } })
+  const { comments: replies } = useComments({
+    where: { parentComment: { id_eq: commentId } },
+    orderBy: CommentOrderByInput.CreatedAtAsc,
+  })
 
-  const userCommentReactionsLookup =
-    data?.commentReactions &&
-    data.commentReactions.reduce<Record<string, number[]>>((acc, item) => {
-      if (item) {
-        acc[item.commentId] = [...(acc[item.commentId] ? acc[item.commentId] : []), item.reactionId]
-      }
-      return acc
-    }, {})
+  const userCommentReactionsLookup = data?.commentReactions && getUserCommentReactionsLookup(data.commentReactions)
 
   const comment = data?.comments.map((comment) => ({
     ...comment,
     userReactions: userCommentReactionsLookup?.[comment.id],
+    replies,
   }))[0]
 
   return {

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -30,12 +30,10 @@ export const useComment = (commentId: string, opts?: QueryHookOptions<GetComment
     orderBy: CommentOrderByInput.CreatedAtAsc,
   })
 
-  const userCommentReactionsLookup = data?.commentReactions && getUserCommentReactionsLookup(data.commentReactions)
-
   const comment = data?.commentByUniqueInput
     ? {
         ...data.commentByUniqueInput,
-        userReactions: userCommentReactionsLookup?.[commentId],
+        reactions: data.commentReactions,
         replies,
       }
     : undefined

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -23,7 +23,7 @@ import {
 import { createLookup } from '@/utils/data'
 
 export const useComment = (
-  variables: { commentId: string; memberId?: string },
+  variables: GetCommentQueryVariables,
   opts?: QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>
 ) => {
   const { data, ...rest } = useGetCommentQuery({ ...opts, variables })
@@ -31,12 +31,15 @@ export const useComment = (
   const { comments: replies } = useComments({
     where: { parentComment: { id_eq: variables.commentId } },
     orderBy: CommentOrderByInput.CreatedAtAsc,
+    ...opts,
   })
+
+  const userCommentReactionsLookup = data?.commentReactions && getUserCommentReactionsLookup(data.commentReactions)
 
   const comment = data?.commentByUniqueInput
     ? {
         ...data.commentByUniqueInput,
-        userReactions: data.commentReactions,
+        userReactions: userCommentReactionsLookup?.[variables.commentId],
         replies,
       }
     : undefined

--- a/packages/atlas/src/api/hooks/comments.ts
+++ b/packages/atlas/src/api/hooks/comments.ts
@@ -22,18 +22,21 @@ import {
 } from '@/api/queries'
 import { createLookup } from '@/utils/data'
 
-export const useComment = (commentId: string, opts?: QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) => {
-  const { data, ...rest } = useGetCommentQuery({ ...opts, variables: { commentId } })
+export const useComment = (
+  variables: { commentId: string; memberId?: string },
+  opts?: QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>
+) => {
+  const { data, ...rest } = useGetCommentQuery({ ...opts, variables })
 
   const { comments: replies } = useComments({
-    where: { parentComment: { id_eq: commentId } },
+    where: { parentComment: { id_eq: variables.commentId } },
     orderBy: CommentOrderByInput.CreatedAtAsc,
   })
 
   const comment = data?.commentByUniqueInput
     ? {
         ...data.commentByUniqueInput,
-        reactions: data.commentReactions,
+        userReactions: data.commentReactions,
         replies,
       }
     : undefined

--- a/packages/atlas/src/api/queries/__generated__/baseTypes.generated.ts
+++ b/packages/atlas/src/api/queries/__generated__/baseTypes.generated.ts
@@ -7809,140 +7809,6 @@ export type CommentReactionsCountByReactionIdWhereUniqueInput = {
   id: Scalars['ID']
 }
 
-export type CommentSectionPreferenceEvent = BaseGraphQlObject &
-  Event & {
-    __typename?: 'CommentSectionPreferenceEvent'
-    /** Is comment section enabled (true if enabled) */
-    commentSectionStatus: Scalars['Boolean']
-    createdAt: Scalars['DateTime']
-    createdById: Scalars['String']
-    deletedAt?: Maybe<Scalars['DateTime']>
-    deletedById?: Maybe<Scalars['String']>
-    id: Scalars['ID']
-    /** Blocknumber of the block in which the event was emitted. */
-    inBlock: Scalars['Int']
-    /** Hash of the extrinsic which caused the event to be emitted */
-    inExtrinsic?: Maybe<Scalars['String']>
-    /** Index of event in block from which it was emitted. */
-    indexInBlock: Scalars['Int']
-    /** Network the block was produced in */
-    network: Network
-    /** Filtering options for interface implementers */
-    type?: Maybe<EventTypeOptions>
-    updatedAt?: Maybe<Scalars['DateTime']>
-    updatedById?: Maybe<Scalars['String']>
-    version: Scalars['Int']
-    video: Video
-    videoId: Scalars['String']
-  }
-
-export type CommentSectionPreferenceEventConnection = {
-  __typename?: 'CommentSectionPreferenceEventConnection'
-  edges: Array<CommentSectionPreferenceEventEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']
-}
-
-export type CommentSectionPreferenceEventCreateInput = {
-  commentSectionStatus: Scalars['Boolean']
-  inBlock: Scalars['Float']
-  inExtrinsic?: InputMaybe<Scalars['String']>
-  indexInBlock: Scalars['Float']
-  network: Network
-  video: Scalars['ID']
-}
-
-export type CommentSectionPreferenceEventEdge = {
-  __typename?: 'CommentSectionPreferenceEventEdge'
-  cursor: Scalars['String']
-  node: CommentSectionPreferenceEvent
-}
-
-export enum CommentSectionPreferenceEventOrderByInput {
-  CommentSectionStatusAsc = 'commentSectionStatus_ASC',
-  CommentSectionStatusDesc = 'commentSectionStatus_DESC',
-  CreatedAtAsc = 'createdAt_ASC',
-  CreatedAtDesc = 'createdAt_DESC',
-  DeletedAtAsc = 'deletedAt_ASC',
-  DeletedAtDesc = 'deletedAt_DESC',
-  InBlockAsc = 'inBlock_ASC',
-  InBlockDesc = 'inBlock_DESC',
-  InExtrinsicAsc = 'inExtrinsic_ASC',
-  InExtrinsicDesc = 'inExtrinsic_DESC',
-  IndexInBlockAsc = 'indexInBlock_ASC',
-  IndexInBlockDesc = 'indexInBlock_DESC',
-  NetworkAsc = 'network_ASC',
-  NetworkDesc = 'network_DESC',
-  UpdatedAtAsc = 'updatedAt_ASC',
-  UpdatedAtDesc = 'updatedAt_DESC',
-  VideoAsc = 'video_ASC',
-  VideoDesc = 'video_DESC',
-}
-
-export type CommentSectionPreferenceEventUpdateInput = {
-  commentSectionStatus?: InputMaybe<Scalars['Boolean']>
-  inBlock?: InputMaybe<Scalars['Float']>
-  inExtrinsic?: InputMaybe<Scalars['String']>
-  indexInBlock?: InputMaybe<Scalars['Float']>
-  network?: InputMaybe<Network>
-  video?: InputMaybe<Scalars['ID']>
-}
-
-export type CommentSectionPreferenceEventWhereInput = {
-  AND?: InputMaybe<Array<CommentSectionPreferenceEventWhereInput>>
-  OR?: InputMaybe<Array<CommentSectionPreferenceEventWhereInput>>
-  commentSectionStatus_eq?: InputMaybe<Scalars['Boolean']>
-  commentSectionStatus_in?: InputMaybe<Array<Scalars['Boolean']>>
-  createdAt_eq?: InputMaybe<Scalars['DateTime']>
-  createdAt_gt?: InputMaybe<Scalars['DateTime']>
-  createdAt_gte?: InputMaybe<Scalars['DateTime']>
-  createdAt_lt?: InputMaybe<Scalars['DateTime']>
-  createdAt_lte?: InputMaybe<Scalars['DateTime']>
-  createdById_eq?: InputMaybe<Scalars['ID']>
-  createdById_in?: InputMaybe<Array<Scalars['ID']>>
-  deletedAt_all?: InputMaybe<Scalars['Boolean']>
-  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
-  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
-  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
-  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
-  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
-  deletedById_eq?: InputMaybe<Scalars['ID']>
-  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
-  id_eq?: InputMaybe<Scalars['ID']>
-  id_in?: InputMaybe<Array<Scalars['ID']>>
-  inBlock_eq?: InputMaybe<Scalars['Int']>
-  inBlock_gt?: InputMaybe<Scalars['Int']>
-  inBlock_gte?: InputMaybe<Scalars['Int']>
-  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
-  inBlock_lt?: InputMaybe<Scalars['Int']>
-  inBlock_lte?: InputMaybe<Scalars['Int']>
-  inExtrinsic_contains?: InputMaybe<Scalars['String']>
-  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
-  inExtrinsic_eq?: InputMaybe<Scalars['String']>
-  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
-  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
-  indexInBlock_eq?: InputMaybe<Scalars['Int']>
-  indexInBlock_gt?: InputMaybe<Scalars['Int']>
-  indexInBlock_gte?: InputMaybe<Scalars['Int']>
-  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
-  indexInBlock_lt?: InputMaybe<Scalars['Int']>
-  indexInBlock_lte?: InputMaybe<Scalars['Int']>
-  network_eq?: InputMaybe<Network>
-  network_in?: InputMaybe<Array<Network>>
-  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
-  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
-  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
-  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
-  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
-  updatedById_eq?: InputMaybe<Scalars['ID']>
-  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
-  video?: InputMaybe<VideoWhereInput>
-}
-
-export type CommentSectionPreferenceEventWhereUniqueInput = {
-  id: Scalars['ID']
-}
-
 export enum CommentStatus {
   Deleted = 'DELETED',
   Moderated = 'MODERATED',
@@ -10326,7 +10192,6 @@ export enum EventTypeOptions {
   CommentModeratedEvent = 'CommentModeratedEvent',
   CommentPinnedEvent = 'CommentPinnedEvent',
   CommentReactedEvent = 'CommentReactedEvent',
-  CommentSectionPreferenceEvent = 'CommentSectionPreferenceEvent',
   CommentTextUpdatedEvent = 'CommentTextUpdatedEvent',
   CouncilorRewardUpdatedEvent = 'CouncilorRewardUpdatedEvent',
   EnglishAuctionSettledEvent = 'EnglishAuctionSettledEvent',
@@ -20735,9 +20600,6 @@ export type Query = {
   commentReactionsCountByReactionIdByUniqueInput?: Maybe<CommentReactionsCountByReactionId>
   commentReactionsCountByReactionIds: Array<CommentReactionsCountByReactionId>
   commentReactionsCountByReactionIdsConnection: CommentReactionsCountByReactionIdConnection
-  commentSectionPreferenceEventByUniqueInput?: Maybe<CommentSectionPreferenceEvent>
-  commentSectionPreferenceEvents: Array<CommentSectionPreferenceEvent>
-  commentSectionPreferenceEventsConnection: CommentSectionPreferenceEventConnection
   commentText: Array<CommentTextFtsOutput>
   commentTextUpdatedEventByUniqueInput?: Maybe<CommentTextUpdatedEvent>
   commentTextUpdatedEvents: Array<CommentTextUpdatedEvent>
@@ -22286,26 +22148,6 @@ export type QueryCommentReactionsCountByReactionIdsConnectionArgs = {
   last?: InputMaybe<Scalars['Int']>
   orderBy?: InputMaybe<Array<CommentReactionsCountByReactionIdOrderByInput>>
   where?: InputMaybe<CommentReactionsCountByReactionIdWhereInput>
-}
-
-export type QueryCommentSectionPreferenceEventByUniqueInputArgs = {
-  where: CommentSectionPreferenceEventWhereUniqueInput
-}
-
-export type QueryCommentSectionPreferenceEventsArgs = {
-  limit?: InputMaybe<Scalars['Int']>
-  offset?: InputMaybe<Scalars['Int']>
-  orderBy?: InputMaybe<Array<CommentSectionPreferenceEventOrderByInput>>
-  where?: InputMaybe<CommentSectionPreferenceEventWhereInput>
-}
-
-export type QueryCommentSectionPreferenceEventsConnectionArgs = {
-  after?: InputMaybe<Scalars['String']>
-  before?: InputMaybe<Scalars['String']>
-  first?: InputMaybe<Scalars['Int']>
-  last?: InputMaybe<Scalars['Int']>
-  orderBy?: InputMaybe<Array<CommentSectionPreferenceEventOrderByInput>>
-  where?: InputMaybe<CommentSectionPreferenceEventWhereInput>
 }
 
 export type QueryCommentTextArgs = {
@@ -30060,7 +29902,6 @@ export type Video = BaseGraphQlObject & {
   comments: Array<Comment>
   /** Comments count */
   commentsCount: Scalars['Int']
-  commentsectionpreferenceeventvideo?: Maybe<Array<CommentSectionPreferenceEvent>>
   commenttextupdatedeventvideo?: Maybe<Array<CommentTextUpdatedEvent>>
   createdAt: Scalars['DateTime']
   createdById: Scalars['String']
@@ -31165,9 +31006,6 @@ export type VideoWhereInput = {
   comments_every?: InputMaybe<CommentWhereInput>
   comments_none?: InputMaybe<CommentWhereInput>
   comments_some?: InputMaybe<CommentWhereInput>
-  commentsectionpreferenceeventvideo_every?: InputMaybe<CommentSectionPreferenceEventWhereInput>
-  commentsectionpreferenceeventvideo_none?: InputMaybe<CommentSectionPreferenceEventWhereInput>
-  commentsectionpreferenceeventvideo_some?: InputMaybe<CommentSectionPreferenceEventWhereInput>
   commenttextupdatedeventvideo_every?: InputMaybe<CommentTextUpdatedEventWhereInput>
   commenttextupdatedeventvideo_none?: InputMaybe<CommentTextUpdatedEventWhereInput>
   commenttextupdatedeventvideo_some?: InputMaybe<CommentTextUpdatedEventWhereInput>

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -69,6 +69,7 @@ export type GetCommentsQuery = {
 export type GetCommentQueryVariables = Types.Exact<{
   commentId: Types.Scalars['ID']
   memberId?: Types.InputMaybe<Types.Scalars['ID']>
+  videoId?: Types.InputMaybe<Types.Scalars['ID']>
 }>
 
 export type GetCommentQuery = {
@@ -386,8 +387,8 @@ export type GetCommentsQueryHookResult = ReturnType<typeof useGetCommentsQuery>
 export type GetCommentsLazyQueryHookResult = ReturnType<typeof useGetCommentsLazyQuery>
 export type GetCommentsQueryResult = Apollo.QueryResult<GetCommentsQuery, GetCommentsQueryVariables>
 export const GetCommentDocument = gql`
-  query GetComment($commentId: ID!, $memberId: ID) {
-    commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
+  query GetComment($commentId: ID!, $memberId: ID, $videoId: ID) {
+    commentReactions(where: { member: { id_eq: $memberId }, video: { id_eq: $videoId } }, limit: 1000) {
       reactionId
       commentId
     }
@@ -412,6 +413,7 @@ export const GetCommentDocument = gql`
  *   variables: {
  *      commentId: // value for 'commentId'
  *      memberId: // value for 'memberId'
+ *      videoId: // value for 'videoId'
  *   },
  * });
  */

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -67,13 +67,13 @@ export type GetCommentsQuery = {
 }
 
 export type GetCommentQueryVariables = Types.Exact<{
-  commentId?: Types.InputMaybe<Types.Scalars['ID']>
+  commentId: Types.Scalars['ID']
 }>
 
 export type GetCommentQuery = {
   __typename?: 'Query'
   commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string }>
-  comments: Array<{
+  commentByUniqueInput?: {
     __typename?: 'Comment'
     id: string
     createdAt: Date
@@ -119,7 +119,7 @@ export type GetCommentQuery = {
       reactionId: number
     }>
     commentcreatedeventcomment?: Array<{ __typename?: 'CommentCreatedEvent'; inBlock: number }> | null
-  }>
+  } | null
 }
 
 export type GetCommentsConnectionQueryVariables = Types.Exact<{
@@ -385,12 +385,12 @@ export type GetCommentsQueryHookResult = ReturnType<typeof useGetCommentsQuery>
 export type GetCommentsLazyQueryHookResult = ReturnType<typeof useGetCommentsLazyQuery>
 export type GetCommentsQueryResult = Apollo.QueryResult<GetCommentsQuery, GetCommentsQueryVariables>
 export const GetCommentDocument = gql`
-  query GetComment($commentId: ID) {
+  query GetComment($commentId: ID!) {
     commentReactions(where: { comment: { id_eq: $commentId } }, limit: 1000) {
       reactionId
       commentId
     }
-    comments(limit: 1, offset: 0, where: { id_eq: $commentId }, orderBy: createdAt_DESC) {
+    commentByUniqueInput(where: { id: $commentId }) {
       ...CommentFields
     }
   }
@@ -413,7 +413,7 @@ export const GetCommentDocument = gql`
  *   },
  * });
  */
-export function useGetCommentQuery(baseOptions?: Apollo.QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) {
+export function useGetCommentQuery(baseOptions: Apollo.QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) {
   const options = { ...defaultOptions, ...baseOptions }
   return Apollo.useQuery<GetCommentQuery, GetCommentQueryVariables>(GetCommentDocument, options)
 }

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -67,15 +67,13 @@ export type GetCommentsQuery = {
 }
 
 export type GetCommentQueryVariables = Types.Exact<{
-  where: Types.CommentWhereUniqueInput
-  memberId?: Types.InputMaybe<Types.Scalars['ID']>
-  videoId?: Types.InputMaybe<Types.Scalars['ID']>
+  commentId?: Types.InputMaybe<Types.Scalars['ID']>
 }>
 
 export type GetCommentQuery = {
   __typename?: 'Query'
   commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string }>
-  commentByUniqueInput?: {
+  comments: Array<{
     __typename?: 'Comment'
     id: string
     createdAt: Date
@@ -121,7 +119,7 @@ export type GetCommentQuery = {
       reactionId: number
     }>
     commentcreatedeventcomment?: Array<{ __typename?: 'CommentCreatedEvent'; inBlock: number }> | null
-  } | null
+  }>
 }
 
 export type GetCommentsConnectionQueryVariables = Types.Exact<{
@@ -387,12 +385,12 @@ export type GetCommentsQueryHookResult = ReturnType<typeof useGetCommentsQuery>
 export type GetCommentsLazyQueryHookResult = ReturnType<typeof useGetCommentsLazyQuery>
 export type GetCommentsQueryResult = Apollo.QueryResult<GetCommentsQuery, GetCommentsQueryVariables>
 export const GetCommentDocument = gql`
-  query GetComment($where: CommentWhereUniqueInput!, $memberId: ID, $videoId: ID) {
-    commentReactions(where: { member: { id_eq: $memberId }, video: { id_eq: $videoId } }, limit: 1000) {
+  query GetComment($commentId: ID) {
+    commentReactions(where: { comment: { id_eq: $commentId } }, limit: 1000) {
       reactionId
       commentId
     }
-    commentByUniqueInput(where: $where) {
+    comments(limit: 1, offset: 0, where: { id_eq: $commentId }, orderBy: createdAt_DESC) {
       ...CommentFields
     }
   }
@@ -411,13 +409,11 @@ export const GetCommentDocument = gql`
  * @example
  * const { data, loading, error } = useGetCommentQuery({
  *   variables: {
- *      where: // value for 'where'
- *      memberId: // value for 'memberId'
- *      videoId: // value for 'videoId'
+ *      commentId: // value for 'commentId'
  *   },
  * });
  */
-export function useGetCommentQuery(baseOptions: Apollo.QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) {
+export function useGetCommentQuery(baseOptions?: Apollo.QueryHookOptions<GetCommentQuery, GetCommentQueryVariables>) {
   const options = { ...defaultOptions, ...baseOptions }
   return Apollo.useQuery<GetCommentQuery, GetCommentQueryVariables>(GetCommentDocument, options)
 }

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -68,11 +68,12 @@ export type GetCommentsQuery = {
 
 export type GetCommentQueryVariables = Types.Exact<{
   commentId: Types.Scalars['ID']
+  memberId?: Types.InputMaybe<Types.Scalars['ID']>
 }>
 
 export type GetCommentQuery = {
   __typename?: 'Query'
-  commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string }>
+  commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string; memberId: string }>
   commentByUniqueInput?: {
     __typename?: 'Comment'
     id: string
@@ -118,7 +119,7 @@ export type GetCommentQuery = {
       count: number
       reactionId: number
     }>
-    commentcreatedeventcomment?: Array<{ __typename?: 'CommentCreatedEvent'; inBlock: number }> | null
+    commentcreatedeventcomment?: Array<{ __typename?: 'CommentCreatedEvent'; inExtrinsic?: string | null }> | null
   } | null
 }
 
@@ -385,10 +386,11 @@ export type GetCommentsQueryHookResult = ReturnType<typeof useGetCommentsQuery>
 export type GetCommentsLazyQueryHookResult = ReturnType<typeof useGetCommentsLazyQuery>
 export type GetCommentsQueryResult = Apollo.QueryResult<GetCommentsQuery, GetCommentsQueryVariables>
 export const GetCommentDocument = gql`
-  query GetComment($commentId: ID!) {
-    commentReactions(where: { comment: { id_eq: $commentId } }, limit: 1000) {
+  query GetComment($commentId: ID!, $memberId: ID) {
+    commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
       reactionId
       commentId
+      memberId
     }
     commentByUniqueInput(where: { id: $commentId }) {
       ...CommentFields
@@ -410,6 +412,7 @@ export const GetCommentDocument = gql`
  * const { data, loading, error } = useGetCommentQuery({
  *   variables: {
  *      commentId: // value for 'commentId'
+ *      memberId: // value for 'memberId'
  *   },
  * });
  */

--- a/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/comments.generated.tsx
@@ -73,7 +73,7 @@ export type GetCommentQueryVariables = Types.Exact<{
 
 export type GetCommentQuery = {
   __typename?: 'Query'
-  commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string; memberId: string }>
+  commentReactions: Array<{ __typename?: 'CommentReaction'; reactionId: number; commentId: string }>
   commentByUniqueInput?: {
     __typename?: 'Comment'
     id: string
@@ -390,7 +390,6 @@ export const GetCommentDocument = gql`
     commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
       reactionId
       commentId
-      memberId
     }
     commentByUniqueInput(where: { id: $commentId }) {
       ...CommentFields

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -15,8 +15,8 @@ query GetComments(
   }
 }
 
-query GetComment($commentId: ID!, $memberId: ID) {
-  commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
+query GetComment($commentId: ID!, $memberId: ID, $videoId: ID) {
+  commentReactions(where: { member: { id_eq: $memberId }, video: { id_eq: $videoId } }, limit: 1000) {
     reactionId
     commentId
   }

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -15,12 +15,12 @@ query GetComments(
   }
 }
 
-query GetComment($where: CommentWhereUniqueInput!, $memberId: ID, $videoId: ID) {
-  commentReactions(where: { member: { id_eq: $memberId }, video: { id_eq: $videoId } }, limit: 1000) {
+query GetComment($commentID: ID!) {
+  commentReactions(where: { comment: { id_eq: $commentID } }, limit: 1000) {
     reactionId
     commentId
   }
-  commentByUniqueInput(where: $where) {
+  commentByUniqueInput(where: { id: $commentID }) {
     ...CommentFields
   }
 }

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -19,7 +19,6 @@ query GetComment($commentId: ID!, $memberId: ID) {
   commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
     reactionId
     commentId
-    memberId
   }
   commentByUniqueInput(where: { id: $commentId }) {
     ...CommentFields

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -15,10 +15,11 @@ query GetComments(
   }
 }
 
-query GetComment($commentId: ID!) {
-  commentReactions(where: { comment: { id_eq: $commentId } }, limit: 1000) {
+query GetComment($commentId: ID!, $memberId: ID) {
+  commentReactions(where: { member: { id_eq: $memberId }, comment: { id_eq: $commentId } }, limit: 1000) {
     reactionId
     commentId
+    memberId
   }
   commentByUniqueInput(where: { id: $commentId }) {
     ...CommentFields

--- a/packages/atlas/src/api/queries/comments.graphql
+++ b/packages/atlas/src/api/queries/comments.graphql
@@ -15,12 +15,12 @@ query GetComments(
   }
 }
 
-query GetComment($commentID: ID!) {
-  commentReactions(where: { comment: { id_eq: $commentID } }, limit: 1000) {
+query GetComment($commentId: ID!) {
+  commentReactions(where: { comment: { id_eq: $commentId } }, limit: 1000) {
     reactionId
     commentId
   }
-  commentByUniqueInput(where: { id: $commentID }) {
+  commentByUniqueInput(where: { id: $commentId }) {
     ...CommentFields
   }
 }

--- a/packages/atlas/src/components/_comments/Comment/Comment.stories.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.stories.tsx
@@ -2,11 +2,11 @@ import { Meta, Story } from '@storybook/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
-import { Comment, CommentProps } from './Comment'
+import { InternalComment, InternalCommentProps } from './InternalComment'
 
 export default {
   title: 'comments/Comment',
-  component: Comment,
+  component: InternalComment,
   args: {
     memberAvatarUrl: 'https://placedog.net/100/100?random=2',
     memberHandle: 'johndoe',
@@ -35,9 +35,9 @@ export default {
     onReactionClick: { table: { disable: true } },
     reactions: { table: { disable: true } },
   },
-} as Meta<CommentProps>
+} as Meta<InternalCommentProps>
 
-const Template: Story<CommentProps> = (args) => <Comment {...args} />
+const Template: Story<InternalCommentProps> = (args) => <InternalComment {...args} />
 
 export const Default = Template.bind({})
 export const NoReactions = Template.bind({})

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -43,10 +43,11 @@ export const Comment: React.FC<CommentProps> = React.memo(
     const [processingCommentReactionId, setProcessingCommentReactionId] = useState<string | null>(null)
 
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
-    const { comment, loading: loadingQuery } = useComment(
+    const { comment } = useComment(
       { commentId: commentId ?? '', memberId: activeMemberId ?? undefined },
       {
         skip: !commentId,
+        fetchPolicy: 'cache-only',
       }
     )
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
@@ -196,15 +197,13 @@ export const Comment: React.FC<CommentProps> = React.memo(
       handle: comment.author.handle,
     }))
 
-    const loading = !commentId || loadingQuery
-
-    const userReactionsIds = comment?.userReactions?.map((reaction) => reaction.reactionId)
+    const loading = !commentId
 
     const reactions =
       comment &&
       getCommentReactions({
         commentId: comment?.id,
-        userReactionsIds,
+        userReactionsIds: comment?.userReactions,
         reactionsCount: comment?.reactionsCountByReactionId,
         activeMemberId,
         processingCommentReactionId,

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -145,24 +145,25 @@ export const Comment: React.FC<CommentProps> = React.memo(
         openSignInDialog({ onConfirm: signIn })
       }
     }
-    const handleComment = async (parentCommentId?: string) => {
-      if (!video || !replyCommentInputText) {
+    const handleComment = async () => {
+      if (!video || !replyCommentInputText || !comment) {
         return
       }
 
       setReplyCommentInputIsProcessing(true)
-      const commentId = await addComment({
+      const newCommentId = await addComment({
         videoId: video.id,
         commentBody: replyCommentInputText,
-        parentCommentId,
+        parentCommentId: comment.id,
       })
       setReplyCommentInputIsProcessing(false)
 
-      if (commentId) {
-        setReplyCommentInputText('')
-        setHighlightedCommentId?.(commentId || null)
-        setReplyInputOpen(false)
-      }
+      // TODO: uncomment code once posted replies return an Id
+      // if (newCommentId) {
+      setReplyCommentInputText('')
+      setHighlightedCommentId?.(newCommentId || null)
+      setReplyInputOpen(false)
+      // }
     }
 
     const handleReplyClick = () => {
@@ -282,7 +283,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
               readOnly={!activeMemberId}
               memberHandle={activeMembership?.handle}
               onFocus={handleOpenSignInDialog}
-              onComment={() => handleComment(comment?.id)}
+              onComment={handleComment}
               hasInitialValueChanged={!!replyCommentInputText}
               value={replyCommentInputText}
               withoutOutlineBox

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -22,6 +22,7 @@ export type CommentProps = {
   commentId?: string
   video?: VideoFieldsFragment | null
   isReplyable?: boolean
+  isAReply?: boolean
   setOriginalComment?: React.Dispatch<React.SetStateAction<CommentFieldsFragment | null>>
   setShowEditHistory?: React.Dispatch<React.SetStateAction<boolean>>
   setHighlightedCommentId?: React.Dispatch<React.SetStateAction<string | null>>
@@ -39,6 +40,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
     setRepliesOpen,
     isRepliesOpen,
     isReplyable,
+    isAReply,
     ...rest
   }) => {
     const replyCommentInputRef = useRef<HTMLTextAreaElement>(null)
@@ -218,6 +220,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
       return (
         <>
           <InternalComment
+            indented={isAReply}
             isCommentFromUrl={commentId === commentIdQueryParam}
             videoId={video?.id}
             commentId={commentId}

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -43,9 +43,11 @@ export const Comment: React.FC<CommentProps> = React.memo(
     const [processingCommentReactionId, setProcessingCommentReactionId] = useState<string | null>(null)
 
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
-    const { comment } = useComment(
+    const { comment, loading: loadingQuery } = useComment(
       { commentId: commentId ?? '', memberId: activeMemberId ?? undefined },
-      { skip: !commentId, fetchPolicy: 'cache-only' }
+      {
+        skip: !commentId,
+      }
     )
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
 
@@ -194,7 +196,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
       handle: comment.author.handle,
     }))
 
-    const loading = !commentId
+    const loading = !commentId || loadingQuery
 
     const userReactionsIds = comment?.userReactions?.map((reaction) => reaction.reactionId)
 

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -43,9 +43,9 @@ export const Comment: React.FC<CommentProps> = React.memo(
     const [processingCommentReactionId, setProcessingCommentReactionId] = useState<string | null>(null)
 
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
-    const { comment, loading: loadingQuery } = useComment(
+    const { comment } = useComment(
       { commentId: commentId ?? '', memberId: activeMemberId ?? undefined },
-      { skip: !commentId }
+      { skip: !commentId, fetchPolicy: 'cache-only' }
     )
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
 
@@ -194,9 +194,9 @@ export const Comment: React.FC<CommentProps> = React.memo(
       handle: comment.author.handle,
     }))
 
-    const loading = loadingQuery || !commentId
+    const loading = !commentId
 
-    const userReactionsIds = comment?.userReactions.map((reaction) => reaction.reactionId)
+    const userReactionsIds = comment?.userReactions?.map((reaction) => reaction.reactionId)
 
     const reactions =
       comment &&

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -29,7 +29,6 @@ export type CommentProps = {
   isRepliesOpen?: boolean
 } & Exclude<CommentRowProps, 'memberAvatarUrl' | 'isMemberAvatarLoading'>
 
-// TODO: comment replies don't return an ID on handleComment; investigate
 export const Comment: React.FC<CommentProps> = React.memo(
   ({
     commentId,
@@ -51,7 +50,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
     const [isEditingComment, setIsEditingComment] = useState(false)
     const [processingCommentReactionId, setProcessingCommentReactionId] = useState<string | null>(null)
 
-    const { comment, loading } = useComment(commentId ?? '', { skip: !commentId })
+    const { comment, loading: loadingQuery } = useComment(commentId ?? '', { skip: !commentId })
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
     const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
@@ -185,6 +184,8 @@ export const Comment: React.FC<CommentProps> = React.memo(
         comment?.author.metadata.avatar?.__typename === 'AvatarUri' ? comment?.author.metadata.avatar?.avatarUri : '',
       handle: comment.author.handle,
     }))
+
+    const loading = loadingQuery || !commentId
 
     if (isEditingComment) {
       return (

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -3,9 +3,11 @@ import React, { useRef, useState } from 'react'
 import { useComment } from '@/api/hooks'
 import { CommentFieldsFragment, CommentStatus, VideoFieldsFragment } from '@/api/queries'
 import { ReactionId } from '@/config/reactions'
-import { absoluteRoutes } from '@/config/routes'
+import { QUERY_PARAMS, absoluteRoutes } from '@/config/routes'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useReactionTransactions } from '@/hooks/useReactionTransactions'
+import { useRouterQuery } from '@/hooks/useRouterQuery'
+import { useMemberAvatar } from '@/providers/assets'
 import { useConfirmationModal } from '@/providers/confirmationModal'
 import { usePersonalDataStore } from '@/providers/personalData'
 import { useUser } from '@/providers/user'
@@ -52,7 +54,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
     const { comment, loading } = useComment(commentId ?? '', { skip: !commentId })
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
-
+    const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
     const reactionPopoverDismissed = usePersonalDataStore((state) => state.reactionPopoverDismissed)
     const { openSignInDialog } = useDisplaySignInDialog()
     const [openModal, closeModal] = useConfirmationModal()
@@ -210,6 +212,9 @@ export const Comment: React.FC<CommentProps> = React.memo(
       return (
         <>
           <InternalComment
+            isCommentFromUrl={commentId === commentIdQueryParam}
+            videoId={video?.id}
+            commentId={commentId}
             author={comment?.author}
             onToggleReplies={() => isReplyable && setRepliesOpen?.((value) => !value)}
             repliesOpen={isReplyable && isRepliesOpen}

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -48,9 +48,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
       { skip: !commentId }
     )
     const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
-    const { isLoadingAsset: isCommentMemberAvatarLoading, url: commentMemberAvatarUrl } = useMemberAvatar(
-      comment?.author
-    )
+
     const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
     const reactionPopoverDismissed = usePersonalDataStore((state) => state.reactionPopoverDismissed)
     const { openSignInDialog } = useDisplaySignInDialog()

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -187,6 +187,10 @@ export const Comment: React.FC<CommentProps> = React.memo(
 
     const loading = loadingQuery || !commentId
 
+    const userReactions = comment?.reactions
+      .filter((reaction) => reaction.memberId === activeMemberId)
+      .map((reaction) => reaction.reactionId)
+
     if (isEditingComment) {
       return (
         <CommentInput
@@ -235,7 +239,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
               comment &&
               getCommentReactions({
                 commentId: comment?.id,
-                userReactions: comment?.userReactions,
+                userReactions,
                 reactionsCount: comment?.reactionsCountByReactionId,
                 activeMemberId,
                 processingCommentReactionId,

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -44,7 +44,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
 
     const { activeMemberId, activeMembership, activeAccountId, signIn } = useUser()
     const { comment } = useComment(
-      { commentId: commentId ?? '', memberId: activeMemberId ?? undefined },
+      { commentId: commentId ?? '', memberId: activeMemberId ?? undefined, videoId: video?.id },
       {
         skip: !commentId,
         fetchPolicy: 'cache-only',

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -22,7 +22,6 @@ export type CommentProps = {
   commentId?: string
   video?: VideoFieldsFragment | null
   isReplyable?: boolean
-  isAReply?: boolean
   setOriginalComment?: React.Dispatch<React.SetStateAction<CommentFieldsFragment | null>>
   setShowEditHistory?: React.Dispatch<React.SetStateAction<boolean>>
   setHighlightedCommentId?: React.Dispatch<React.SetStateAction<string | null>>
@@ -40,7 +39,6 @@ export const Comment: React.FC<CommentProps> = React.memo(
     setRepliesOpen,
     isRepliesOpen,
     isReplyable,
-    isAReply,
     ...rest
   }) => {
     const replyCommentInputRef = useRef<HTMLTextAreaElement>(null)
@@ -220,7 +218,7 @@ export const Comment: React.FC<CommentProps> = React.memo(
       return (
         <>
           <InternalComment
-            indented={isAReply}
+            indented={!isReplyable}
             isCommentFromUrl={commentId === commentIdQueryParam}
             videoId={video?.id}
             commentId={commentId}

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -67,7 +67,7 @@ export type InternalCommentProps = {
   onReplyClick: (() => void) | undefined
   onToggleReplies: (() => void) | undefined
   onReactionClick: ((reaction: ReactionId) => void) | undefined
-} & CommentRowProps
+} & Pick<CommentRowProps, 'highlighted' | 'indented' | 'memberUrl'>
 
 export const InternalComment: React.FC<InternalCommentProps> = ({
   indented,

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -12,6 +12,7 @@ import { ContextMenu } from '@/components/_overlays/ContextMenu'
 import { PopoverImperativeHandle } from '@/components/_overlays/Popover'
 import { ReactionsOnboardingPopover } from '@/components/_video/ReactionsOnboardingPopover'
 import { REACTION_TYPE, ReactionId } from '@/config/reactions'
+import { absoluteRoutes } from '@/config/routes'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useMemberAvatar } from '@/providers/assets'
 import { cVar, transitions } from '@/styles'
@@ -42,7 +43,7 @@ import { ReactionChipState } from '../ReactionChip/ReactionChip.styles'
 import { ReactionPopover } from '../ReactionPopover'
 
 export type InternalCommentProps = {
-  author?: BasicMembershipFieldsFragment
+  author: BasicMembershipFieldsFragment | undefined
   memberHandle: string | undefined
   createdAt: Date | undefined
   text: string | undefined
@@ -57,6 +58,9 @@ export type InternalCommentProps = {
   repliesOpen: boolean | undefined
   repliesLoading: boolean | undefined
   repliesCount: number | undefined
+  isCommentFromUrl: boolean | undefined
+  videoId: string | undefined
+  commentId: string | undefined
   onEditedLabelClick: (() => void) | undefined
   onEditClick: (() => void) | undefined
   onDeleteClick: (() => void) | undefined
@@ -90,6 +94,9 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
   repliesOpen,
   repliesLoading,
   repliesCount,
+  isCommentFromUrl,
+  videoId,
+  commentId,
 }) => {
   const [commentHover, setCommentHover] = useState(false)
   const [tempReactionId, setTempReactionId] = useState<ReactionId | null>(null)
@@ -129,11 +136,11 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
 
   // scroll comment into view once the comment gets highlighted
   useEffect(() => {
-    if (highlighted === true && !highlightedPreviously) {
+    if (highlighted === true && !highlightedPreviously && !isCommentFromUrl) {
       domRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     }
     setHighlightedPreviously(highlighted)
-  }, [highlightedPreviously, highlighted])
+  }, [highlightedPreviously, highlighted, isCommentFromUrl])
 
   const reactionIsProcessing = reactions?.some(({ state }) => state === 'processing')
   const allReactionsApplied =
@@ -205,10 +212,11 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
                   </StyledLink>
                   <CommentHeaderDot />
                   <Tooltip text={tooltipDate} placement="top" offsetY={4} delay={[1000, null]}>
-                    {/*  TODO timestamp should be a hyperlink to that comment. */}
-                    <HighlightableText variant="t200" secondary margin={{ left: 2, right: 2 }}>
-                      {formatDateAgo(createdAt || new Date())}
-                    </HighlightableText>
+                    <StyledLink to={absoluteRoutes.viewer.video(videoId, { commentId })}>
+                      <HighlightableText variant="t200" secondary margin={{ left: 2, right: 2 }}>
+                        {formatDateAgo(createdAt || new Date())}
+                      </HighlightableText>
+                    </StyledLink>
                   </Tooltip>
                   {isEdited && !isDeleted && (
                     <>
@@ -284,6 +292,7 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
                       {!!repliesCount && (
                         <StyledAvatarGroup
                           size="small"
+                          avatarStrokeColor={highlighted ? cVar('colorBackground', true) : undefined}
                           avatars={filteredDuplicatedAvatars}
                           clickable={false}
                           loading={repliesLoading}

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -2,14 +2,18 @@ import { format } from 'date-fns'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { CSSTransition, SwitchTransition } from 'react-transition-group'
 
+import { BasicMembershipFieldsFragment } from '@/api/queries'
+import { AvatarGroupUrlAvatar } from '@/components/Avatar/AvatarGroup'
 import { Text } from '@/components/Text'
 import { Tooltip } from '@/components/Tooltip'
-import { SvgActionEdit, SvgActionMore, SvgActionTrash } from '@/components/_icons'
+import { SvgActionEdit, SvgActionMore, SvgActionReply, SvgActionTrash } from '@/components/_icons'
 import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
 import { ContextMenu } from '@/components/_overlays/ContextMenu'
 import { PopoverImperativeHandle } from '@/components/_overlays/Popover'
 import { ReactionsOnboardingPopover } from '@/components/_video/ReactionsOnboardingPopover'
 import { REACTION_TYPE, ReactionId } from '@/config/reactions'
+import { useMediaMatch } from '@/hooks/useMediaMatch'
+import { useMemberAvatar } from '@/providers/assets'
 import { cVar, transitions } from '@/styles'
 import { formatDate, formatDateAgo } from '@/utils/time'
 
@@ -22,8 +26,12 @@ import {
   DeletedComment,
   HighlightableText,
   KebabMenuIconButton,
+  RepliesWrapper,
+  ReplyButton,
+  StyledAvatarGroup,
   StyledFooterSkeletonLoader,
   StyledLink,
+  StyledRepliesSkeleton,
   StyledSvgActionTrash,
 } from './Comment.styles'
 
@@ -34,6 +42,7 @@ import { ReactionChipState } from '../ReactionChip/ReactionChip.styles'
 import { ReactionPopover } from '../ReactionPopover'
 
 export type InternalCommentProps = {
+  author?: BasicMembershipFieldsFragment
   memberHandle: string | undefined
   createdAt: Date | undefined
   text: string | undefined
@@ -44,18 +53,23 @@ export type InternalCommentProps = {
   type: 'default' | 'deleted' | 'options'
   reactions: Omit<ReactionChipProps, 'onReactionClick'>[] | undefined
   reactionPopoverDismissed: boolean | undefined
+  replyAvatars: (AvatarGroupUrlAvatar & { handle: string })[] | undefined
+  repliesOpen: boolean | undefined
+  repliesLoading: boolean | undefined
+  repliesCount: number | undefined
   onEditedLabelClick: (() => void) | undefined
   onEditClick: (() => void) | undefined
   onDeleteClick: (() => void) | undefined
+  onReplyClick: (() => void) | undefined
+  onToggleReplies: (() => void) | undefined
   onReactionClick: ((reaction: ReactionId) => void) | undefined
 } & CommentRowProps
 
 export const InternalComment: React.FC<InternalCommentProps> = ({
   indented,
   highlighted,
-  isMemberAvatarLoading,
+  author,
   memberUrl,
-  memberAvatarUrl,
   memberHandle,
   text,
   createdAt,
@@ -70,11 +84,25 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
   onDeleteClick,
   onReactionClick,
   reactions,
+  onReplyClick,
+  replyAvatars,
+  onToggleReplies,
+  repliesOpen,
+  repliesLoading,
+  repliesCount,
 }) => {
+  const [commentHover, setCommentHover] = useState(false)
+  const [tempReactionId, setTempReactionId] = useState<ReactionId | null>(null)
   const isDeleted = type === 'deleted'
   const shouldShowKebabButton = type === 'options' && !loading && !isDeleted
   const popoverRef = useRef<PopoverImperativeHandle>(null)
-  const [tempReactionId, setTempReactionId] = useState<ReactionId | null>(null)
+  const mdMatch = useMediaMatch('md')
+  const { url: memberAvatarUrl, isLoadingAsset: isMemberAvatarLoading } = useMemberAvatar(author)
+  const filteredDuplicatedAvatars = repliesCount
+    ? replyAvatars
+      ? [...new Map(replyAvatars?.map((item) => [item.handle, item])).values()]
+      : Array.from({ length: repliesCount }, () => ({ url: undefined }))
+    : []
 
   const tooltipDate = createdAt ? `${formatDate(createdAt || new Date())} at ${format(createdAt, 'HH:mm')}` : undefined
 
@@ -151,6 +179,8 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
       isMemberAvatarLoading={loading || isMemberAvatarLoading}
       memberUrl={memberUrl}
       memberAvatarUrl={memberAvatarUrl}
+      onMouseEnter={() => setCommentHover(true)}
+      onMouseLeave={() => setCommentHover(false)}
     >
       <CommentWrapper ref={domRef} shouldShowKebabButton={shouldShowKebabButton}>
         <SwitchTransition>
@@ -250,6 +280,36 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
                     {!allReactionsApplied && !isDeleted && (
                       <ReactionPopover disabled={reactionIsProcessing} onReactionClick={handleCommentReactionClick} />
                     )}
+                    <RepliesWrapper>
+                      {!!repliesCount && (
+                        <StyledAvatarGroup
+                          size="small"
+                          avatars={filteredDuplicatedAvatars}
+                          clickable={false}
+                          loading={repliesLoading}
+                        />
+                      )}
+                      {onToggleReplies &&
+                        !!repliesCount &&
+                        (repliesLoading ? (
+                          <StyledRepliesSkeleton height={17} width={75} />
+                        ) : (
+                          <ReplyButton onClick={onToggleReplies} variant="tertiary" size="small" _textOnly>
+                            {repliesOpen ? 'Hide' : 'Show'} {repliesCount} {repliesCount === 1 ? 'reply' : 'replies'}
+                          </ReplyButton>
+                        ))}
+                      {onReplyClick && !isDeleted && (commentHover || !mdMatch) && (
+                        <ReplyButton
+                          onClick={onReplyClick}
+                          variant="tertiary"
+                          size="small"
+                          _textOnly
+                          icon={<SvgActionReply />}
+                        >
+                          Reply
+                        </ReplyButton>
+                      )}
+                    </RepliesWrapper>
                   </CommentFooterItems>
                 }
               />

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -1,0 +1,262 @@
+import { format } from 'date-fns'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
+
+import { Text } from '@/components/Text'
+import { Tooltip } from '@/components/Tooltip'
+import { SvgActionEdit, SvgActionMore, SvgActionTrash } from '@/components/_icons'
+import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
+import { ContextMenu } from '@/components/_overlays/ContextMenu'
+import { PopoverImperativeHandle } from '@/components/_overlays/Popover'
+import { ReactionsOnboardingPopover } from '@/components/_video/ReactionsOnboardingPopover'
+import { REACTION_TYPE, ReactionId } from '@/config/reactions'
+import { cVar, transitions } from '@/styles'
+import { formatDate, formatDateAgo } from '@/utils/time'
+
+import {
+  CommentFooter,
+  CommentFooterItems,
+  CommentHeader,
+  CommentHeaderDot,
+  CommentWrapper,
+  DeletedComment,
+  HighlightableText,
+  KebabMenuIconButton,
+  StyledFooterSkeletonLoader,
+  StyledLink,
+  StyledSvgActionTrash,
+} from './Comment.styles'
+
+import { CommentBody } from '../CommentBody'
+import { CommentRow, CommentRowProps } from '../CommentRow'
+import { ReactionChip, ReactionChipProps } from '../ReactionChip'
+import { ReactionChipState } from '../ReactionChip/ReactionChip.styles'
+import { ReactionPopover } from '../ReactionPopover'
+
+export type InternalCommentProps = {
+  memberHandle: string | undefined
+  createdAt: Date | undefined
+  text: string | undefined
+  loading: boolean | undefined
+  isEdited: boolean | undefined
+  isAbleToEdit: boolean | undefined
+  isModerated: boolean | undefined
+  type: 'default' | 'deleted' | 'options'
+  reactions: Omit<ReactionChipProps, 'onReactionClick'>[] | undefined
+  reactionPopoverDismissed: boolean | undefined
+  onEditedLabelClick: (() => void) | undefined
+  onEditClick: (() => void) | undefined
+  onDeleteClick: (() => void) | undefined
+  onReactionClick: ((reaction: ReactionId) => void) | undefined
+} & CommentRowProps
+
+export const InternalComment: React.FC<InternalCommentProps> = ({
+  indented,
+  highlighted,
+  isMemberAvatarLoading,
+  memberUrl,
+  memberAvatarUrl,
+  memberHandle,
+  text,
+  createdAt,
+  type,
+  loading,
+  isEdited,
+  isModerated,
+  isAbleToEdit,
+  reactionPopoverDismissed,
+  onEditedLabelClick,
+  onEditClick,
+  onDeleteClick,
+  onReactionClick,
+  reactions,
+}) => {
+  const isDeleted = type === 'deleted'
+  const shouldShowKebabButton = type === 'options' && !loading && !isDeleted
+  const popoverRef = useRef<PopoverImperativeHandle>(null)
+  const [tempReactionId, setTempReactionId] = useState<ReactionId | null>(null)
+
+  const tooltipDate = createdAt ? `${formatDate(createdAt || new Date())} at ${format(createdAt, 'HH:mm')}` : undefined
+
+  const contexMenuItems = [
+    ...(isAbleToEdit
+      ? [
+          {
+            icon: <SvgActionEdit />,
+            onClick: onEditClick,
+            title: 'Edit',
+          },
+        ]
+      : []),
+    {
+      icon: <SvgActionTrash />,
+      onClick: onDeleteClick,
+      title: 'Remove',
+      destructive: true,
+    },
+  ]
+
+  const domRef = useRef<HTMLDivElement>(null)
+  const [highlightedPreviously, setHighlightedPreviously] = useState<boolean | undefined>(false)
+
+  // scroll comment into view once the comment gets highlighted
+  useEffect(() => {
+    if (highlighted === true && !highlightedPreviously) {
+      domRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+    setHighlightedPreviously(highlighted)
+  }, [highlightedPreviously, highlighted])
+
+  const reactionIsProcessing = reactions?.some(({ state }) => state === 'processing')
+  const allReactionsApplied =
+    reactions && reactions.filter((r) => r.count).length >= Object.values(REACTION_TYPE).length
+
+  const getReactionState = useCallback(
+    (state?: ReactionChipState): ReactionChipState | undefined => {
+      if (state === 'processing') {
+        return state
+      }
+      if (isDeleted) {
+        return 'read-only'
+      }
+      if (reactionIsProcessing) {
+        return 'disabled'
+      }
+      return state
+    },
+    [isDeleted, reactionIsProcessing]
+  )
+
+  const handleOnboardingPopoverHide = useCallback(() => {
+    popoverRef.current?.hide()
+    setTempReactionId(null)
+  }, [])
+
+  const handleCommentReactionClick = useCallback(
+    (reactionId: ReactionId) => {
+      if (!reactionPopoverDismissed) {
+        setTempReactionId(reactionId)
+        popoverRef.current?.show()
+      } else {
+        onReactionClick?.(reactionId)
+      }
+    },
+    [onReactionClick, reactionPopoverDismissed]
+  )
+
+  return (
+    <CommentRow
+      indented={indented}
+      highlighted={highlighted}
+      isMemberAvatarLoading={loading || isMemberAvatarLoading}
+      memberUrl={memberUrl}
+      memberAvatarUrl={memberAvatarUrl}
+    >
+      <CommentWrapper ref={domRef} shouldShowKebabButton={shouldShowKebabButton}>
+        <SwitchTransition>
+          <CSSTransition
+            timeout={parseInt(cVar('animationTimingFast', true))}
+            key={loading?.toString()}
+            classNames={transitions.names.fade}
+          >
+            {loading ? (
+              <div>
+                <SkeletonLoader width={128} height={20} bottomSpace={8} />
+                <SkeletonLoader width="100%" height={16} bottomSpace={8} />
+                <SkeletonLoader width="70%" height={16} />
+              </div>
+            ) : (
+              <div>
+                <CommentHeader isDeleted={isDeleted}>
+                  <StyledLink to={memberUrl || ''}>
+                    <Text variant="h200" margin={{ right: 2 }}>
+                      {memberHandle}
+                    </Text>
+                  </StyledLink>
+                  <CommentHeaderDot />
+                  <Tooltip text={tooltipDate} placement="top" offsetY={4} delay={[1000, null]}>
+                    {/*  TODO timestamp should be a hyperlink to that comment. */}
+                    <HighlightableText variant="t200" secondary margin={{ left: 2, right: 2 }}>
+                      {formatDateAgo(createdAt || new Date())}
+                    </HighlightableText>
+                  </Tooltip>
+                  {isEdited && !isDeleted && (
+                    <>
+                      <CommentHeaderDot />
+                      <HighlightableText variant="t200" secondary margin={{ left: 2 }} onClick={onEditedLabelClick}>
+                        edited
+                      </HighlightableText>
+                    </>
+                  )}
+                </CommentHeader>
+                {isDeleted ? (
+                  <DeletedComment variant="t200" color={cVar('colorTextMuted')}>
+                    <StyledSvgActionTrash /> Comment deleted by the {isModerated ? 'channel owner' : 'author'}
+                  </DeletedComment>
+                ) : (
+                  <CommentBody>{text}</CommentBody>
+                )}
+              </div>
+            )}
+          </CSSTransition>
+        </SwitchTransition>
+        <ContextMenu
+          placement="bottom-end"
+          disabled={loading || !shouldShowKebabButton}
+          items={contexMenuItems}
+          trigger={
+            <KebabMenuIconButton
+              icon={<SvgActionMore />}
+              variant="tertiary"
+              size="small"
+              isActive={shouldShowKebabButton}
+            />
+          }
+        />
+      </CommentWrapper>
+      <CommentFooter>
+        <SwitchTransition>
+          <CSSTransition
+            timeout={parseInt(cVar('animationTimingFast', true))}
+            key={loading?.toString()}
+            classNames={transitions.names.fade}
+          >
+            {loading ? (
+              <CommentFooterItems>
+                <StyledFooterSkeletonLoader width={48} height={32} rounded />
+                <StyledFooterSkeletonLoader width={48} height={32} rounded />
+              </CommentFooterItems>
+            ) : (
+              <ReactionsOnboardingPopover
+                ref={popoverRef}
+                onConfirm={() => {
+                  tempReactionId && onReactionClick?.(tempReactionId)
+                  handleOnboardingPopoverHide()
+                }}
+                onDecline={handleOnboardingPopoverHide}
+                trigger={
+                  <CommentFooterItems>
+                    {reactions &&
+                      reactions?.map(({ reactionId, active, count, state }) => (
+                        <ReactionChip
+                          key={reactionId}
+                          reactionId={reactionId}
+                          active={active}
+                          count={count}
+                          state={tempReactionId === reactionId ? 'processing' : getReactionState(state)}
+                          onReactionClick={handleCommentReactionClick}
+                        />
+                      ))}
+                    {!allReactionsApplied && !isDeleted && (
+                      <ReactionPopover disabled={reactionIsProcessing} onReactionClick={handleCommentReactionClick} />
+                    )}
+                  </CommentFooterItems>
+                }
+              />
+            )}
+          </CSSTransition>
+        </SwitchTransition>
+      </CommentFooter>
+    </CommentRow>
+  )
+}

--- a/packages/atlas/src/components/_comments/Comment/utils.ts
+++ b/packages/atlas/src/components/_comments/Comment/utils.ts
@@ -7,7 +7,7 @@ type GetCommentReactionsArgs = {
   userReactions?: number[]
   reactionsCount: CommentReactionsCountByReactionIdFieldsFragment[]
   activeMemberId: string | null
-  processingCommentReactionId: string | null
+  processingCommentReactionId: string | null | undefined
 }
 
 export const getCommentReactions = ({

--- a/packages/atlas/src/components/_comments/Comment/utils.ts
+++ b/packages/atlas/src/components/_comments/Comment/utils.ts
@@ -4,7 +4,7 @@ import { REACTION_TYPE, ReactionId } from '@/config/reactions'
 
 type GetCommentReactionsArgs = {
   commentId: string
-  userReactions?: number[]
+  userReactionsIds?: number[]
   reactionsCount: CommentReactionsCountByReactionIdFieldsFragment[]
   activeMemberId: string | null
   processingCommentReactionId: string | null | undefined
@@ -12,7 +12,7 @@ type GetCommentReactionsArgs = {
 
 export const getCommentReactions = ({
   commentId,
-  userReactions,
+  userReactionsIds,
   reactionsCount,
   processingCommentReactionId,
 }: GetCommentReactionsArgs): ReactionChipProps[] => {
@@ -28,7 +28,7 @@ export const getCommentReactions = ({
       ...reaction,
       state: processingCommentReactionId === reaction.customId ? 'processing' : 'default',
       count: reactionsCount.find((r) => r.reactionId === reaction.reactionId)?.count || 0,
-      active: !!userReactions?.find((r) => r === reaction.reactionId),
+      active: !!userReactionsIds?.find((r) => r === reaction.reactionId),
     }
   })
 }

--- a/packages/atlas/src/config/sorting.ts
+++ b/packages/atlas/src/config/sorting.ts
@@ -11,7 +11,14 @@ export const NFT_SORT_OPTIONS = [
 ]
 
 export const COMMENTS_SORT_OPTIONS = [
-  { name: 'Most popular', value: [CommentOrderByInput.ReactionsCountDesc, CommentOrderByInput.CreatedAtDesc] },
+  {
+    name: 'Most popular',
+    value: [
+      CommentOrderByInput.ReactionsCountDesc,
+      CommentOrderByInput.RepliesCountDesc,
+      CommentOrderByInput.CreatedAtDesc,
+    ],
+  },
   { name: 'Newest', value: [CommentOrderByInput.CreatedAtDesc] },
   { name: 'Oldest', value: [CommentOrderByInput.CreatedAtAsc] },
 ]

--- a/packages/atlas/src/hooks/useReactionTransactions.ts
+++ b/packages/atlas/src/hooks/useReactionTransactions.ts
@@ -2,6 +2,7 @@ import { useApolloClient } from '@apollo/client'
 import { useCallback } from 'react'
 
 import {
+  GetCommentDocument,
   GetCommentsDocument,
   GetUserCommentsAndVideoCommentsConnectionDocument,
   GetUserCommentsAndVideoCommentsConnectionQueryHookResult,
@@ -24,7 +25,7 @@ export const useReactionTransactions = () => {
   const refetchComments = useCallback(
     (): Promise<GetUserCommentsAndVideoCommentsConnectionQueryHookResult[]> =>
       client.refetchQueries({
-        include: [GetUserCommentsAndVideoCommentsConnectionDocument, GetCommentsDocument],
+        include: [GetUserCommentsAndVideoCommentsConnectionDocument, GetCommentsDocument, GetCommentDocument],
       }),
     [client]
   )
@@ -66,6 +67,7 @@ export const useReactionTransactions = () => {
             // update this once QN supports getting ID directly from the status query
             (edge) => edge.node.commentcreatedeventcomment?.[0].inExtrinsic === transactionHash
           )?.node.id
+          console.log({ newCommentId, data })
         },
         minimized: {
           signErrorMessage: 'Failed to post video comment',

--- a/packages/atlas/src/hooks/useReactionTransactions.ts
+++ b/packages/atlas/src/hooks/useReactionTransactions.ts
@@ -67,7 +67,6 @@ export const useReactionTransactions = () => {
             // update this once QN supports getting ID directly from the status query
             (edge) => edge.node.commentcreatedeventcomment?.[0].inExtrinsic === transactionHash
           )?.node.id
-          console.log({ newCommentId, data })
         },
         minimized: {
           signErrorMessage: 'Failed to post video comment',

--- a/packages/atlas/src/hooks/useReactionTransactions.ts
+++ b/packages/atlas/src/hooks/useReactionTransactions.ts
@@ -1,5 +1,5 @@
 import { useApolloClient } from '@apollo/client'
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 
 import {
   GetCommentsDocument,
@@ -17,23 +17,7 @@ import { ConsoleLogger } from '@/utils/logs'
 export const useReactionTransactions = () => {
   const { activeMemberId } = useUser()
   const { joystream, proxyCallback } = useJoystream()
-  // stores the isProcessing state of comment inputs and is indexed by commentId's
-  const [commentInputIsProcessingCollection, setCommentInputIsProcessingCollection] = useState(new Set<string>())
-  const setCommentInputIsProcessing = ({ commentInputId, value }: { commentInputId: string; value: boolean }) => {
-    setCommentInputIsProcessingCollection((processing) => {
-      if (value) {
-        processing.add(commentInputId)
-      } else {
-        processing.delete(commentInputId)
-      }
-      return new Set(processing)
-    })
-  }
-
-  const [videoReactionProcessing, setVideoReactionProcessing] = useState(false)
-
   const handleTransaction = useTransaction()
-  const [processingCommentReactionId, setProcessingCommentReactionId] = useState<string | null>(null)
 
   const client = useApolloClient()
 
@@ -45,46 +29,12 @@ export const useReactionTransactions = () => {
     [client]
   )
 
-  const reactToComment = useCallback(
-    async (commentId: string, reactionId: ReactionId) => {
-      if (!joystream || !activeMemberId) {
-        ConsoleLogger.error('No joystream instance')
-        return
-      }
-
-      setProcessingCommentReactionId(commentId + `-` + reactionId.toString())
-
-      return handleTransaction({
-        txFactory: async (updateStatus) =>
-          (await joystream.extrinsics).reactToVideoComment(
-            activeMemberId,
-            commentId,
-            reactionId,
-            proxyCallback(updateStatus)
-          ),
-        minimized: {
-          signErrorMessage: 'Failed to react to comment',
-        },
-        onTxSync: async () => {
-          await refetchComments()
-          setProcessingCommentReactionId(null)
-        },
-        onError: () => {
-          setProcessingCommentReactionId(null)
-        },
-      })
-    },
-    [activeMemberId, handleTransaction, joystream, proxyCallback, refetchComments]
-  )
-
   const addComment = useCallback(
     async ({
-      commentInputId,
       parentCommentId,
       videoId,
       commentBody,
     }: {
-      commentInputId: string
       parentCommentId?: string
       videoId: string
       commentBody: string
@@ -93,7 +43,6 @@ export const useReactionTransactions = () => {
         ConsoleLogger.error('no joystream or active member')
         return
       }
-      setCommentInputIsProcessing({ commentInputId, value: true })
 
       let newCommentId: string | undefined
 
@@ -110,8 +59,6 @@ export const useReactionTransactions = () => {
           ),
         onTxSync: async ({ transactionHash }) => {
           const refetchResult = await refetchComments()
-          setCommentInputIsProcessing({ commentInputId, value: false })
-
           const { data } = refetchResult[0]
 
           newCommentId = data?.videoCommentsConnection.edges.find(
@@ -119,9 +66,6 @@ export const useReactionTransactions = () => {
             // update this once QN supports getting ID directly from the status query
             (edge) => edge.node.commentcreatedeventcomment?.[0].inExtrinsic === transactionHash
           )?.node.id
-        },
-        onError: () => {
-          setCommentInputIsProcessing({ commentInputId, value: false })
         },
         minimized: {
           signErrorMessage: 'Failed to post video comment',
@@ -132,25 +76,46 @@ export const useReactionTransactions = () => {
     [activeMemberId, handleTransaction, joystream, proxyCallback, refetchComments]
   )
 
+  const reactToComment = useCallback(
+    async (commentId: string, reactionId: ReactionId) => {
+      if (!joystream || !activeMemberId) {
+        ConsoleLogger.error('No joystream instance')
+        return
+      }
+
+      return handleTransaction({
+        txFactory: async (updateStatus) =>
+          (await joystream.extrinsics).reactToVideoComment(
+            activeMemberId,
+            commentId,
+            reactionId,
+            proxyCallback(updateStatus)
+          ),
+        minimized: {
+          signErrorMessage: 'Failed to react to comment',
+        },
+        onTxSync: async () => {
+          await refetchComments()
+        },
+      })
+    },
+    [activeMemberId, handleTransaction, joystream, proxyCallback, refetchComments]
+  )
+
   const updateComment = useCallback(
     async ({ commentId, videoId, commentBody }: { commentId: string; videoId: string; commentBody: string }) => {
       if (!joystream || !activeMemberId || !videoId) {
         ConsoleLogger.error('no joystream or active member')
-        return
+        return false
       }
-      setCommentInputIsProcessing({ commentInputId: commentId, value: true })
 
-      await handleTransaction({
+      return await handleTransaction({
         txFactory: async (updateStatus) =>
           (
             await joystream.extrinsics
           ).editVideoComment(activeMemberId, commentId, commentBody, proxyCallback(updateStatus)),
         onTxSync: async () => {
           await refetchComments()
-          setCommentInputIsProcessing({ commentInputId: commentId, value: false })
-        },
-        onError: () => {
-          setCommentInputIsProcessing({ commentInputId: commentId, value: false })
         },
         minimized: {
           signErrorMessage: 'Failed to udpate video comment',
@@ -226,12 +191,10 @@ export const useReactionTransactions = () => {
     (videoId: string, reaction: VideoReaction) => {
       if (!joystream || !activeMemberId) {
         ConsoleLogger.error('No joystream instance')
-        return
+        return Promise.reject(false)
       }
 
-      setVideoReactionProcessing(true)
-
-      handleTransaction({
+      return handleTransaction({
         txFactory: async (updateStatus) =>
           (await joystream.extrinsics).reactToVideo(activeMemberId, videoId, reaction, proxyCallback(updateStatus)),
         minimized: {
@@ -239,10 +202,6 @@ export const useReactionTransactions = () => {
         },
         onTxSync: async () => {
           await refetchVideo()
-          setVideoReactionProcessing(false)
-        },
-        onError: async () => {
-          setVideoReactionProcessing(false)
         },
       })
     },
@@ -250,14 +209,11 @@ export const useReactionTransactions = () => {
   )
 
   return {
-    reactToComment,
     addComment,
+    reactToComment,
     deleteComment,
     moderateComment,
     updateComment,
     likeOrDislikeVideo,
-    videoReactionProcessing,
-    commentInputIsProcessingCollection,
-    processingCommentReactionId,
   }
 }

--- a/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
@@ -5,7 +5,7 @@ import { Comment, CommentProps } from '@/components/_comments/Comment'
 
 type CommentThreadProps = {
   repliesCount: number
-  replies: (CommentFieldsFragment & { userReactions?: number[] })[] | null
+  replies: (CommentFieldsFragment & { userReactions?: number[] })[] | null | undefined
   highlightedCommentId: string | null
 } & CommentProps
 

--- a/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
@@ -14,10 +14,8 @@ export const CommentThread: React.FC<CommentThreadProps> = ({
   replies,
   commentId,
   video,
-  setOriginalComment,
   setHighlightedCommentId,
   highlightedCommentId,
-  setShowEditHistory,
   ...commentProps
 }) => {
   const [repliesOpen, setRepliesOpen] = useState(false)
@@ -32,9 +30,7 @@ export const CommentThread: React.FC<CommentThreadProps> = ({
         video={video}
         setRepliesOpen={setRepliesOpen}
         isRepliesOpen={repliesOpen}
-        setOriginalComment={setOriginalComment}
         setHighlightedCommentId={setHighlightedCommentId}
-        setShowEditHistory={setShowEditHistory}
         {...commentProps}
         isReplyable={true}
       />
@@ -49,9 +45,7 @@ export const CommentThread: React.FC<CommentThreadProps> = ({
                 commentId={comment.id}
                 video={video}
                 indented
-                setOriginalComment={setOriginalComment}
                 setHighlightedCommentId={setHighlightedCommentId}
-                setShowEditHistory={setShowEditHistory}
                 isReplyable={false}
               />
             )))}

--- a/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentThread.tsx
@@ -1,266 +1,60 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import { CommentFieldsFragment } from '@/api/queries'
 import { Comment, CommentProps } from '@/components/_comments/Comment'
-import { CommentInput } from '@/components/_comments/CommentInput'
-import { ReactionId } from '@/config/reactions'
-import { absoluteRoutes } from '@/config/routes'
-import { useReactionTransactions } from '@/hooks/useReactionTransactions'
-import { useMemberAvatar } from '@/providers/assets'
-import { useConfirmationModal } from '@/providers/confirmationModal'
-import { useUser } from '@/providers/user'
-
-import { getCommentReactions } from './utils'
 
 type CommentThreadProps = {
-  onOpenSignInDialog: () => void
-  commentId: string
-  videoId?: string
-  videoAuthorId?: string
-  onCommentReaction: (commentId: string, reactionId: ReactionId) => void
-  authorized: boolean
-  processingCommentReactionId: string | null
+  repliesCount: number
   replies: (CommentFieldsFragment & { userReactions?: number[] })[] | null
-  channelOwnerMember?: string
-  isEditingCommentCollection: Set<string>
-  commentInputTextCollection: Map<string, string>
-  idx: number
-  parentCommentInputIsProcessingCollection: Set<string>
-  onEditLabelClick: (replyComment?: CommentFieldsFragment) => void
-  onUpdateComment: ({ commentId }: { commentId: string }) => void
-  onEditCommentCancel: (comment: CommentFieldsFragment) => void
-  onSetIsEditingComment: ({ commentId, value }: { commentId: string; value: boolean }) => void
-  onSetCommentInputText: ({ commentId, comment }: { commentId: string; comment: string | undefined }) => void
-  onReplyDeleteClick: (replyComment: CommentFieldsFragment) => void
+  highlightedCommentId: string | null
 } & CommentProps
 
 export const CommentThread: React.FC<CommentThreadProps> = ({
-  onOpenSignInDialog,
-  commentId,
-  videoId,
-  videoAuthorId,
-  onCommentReaction,
-  authorized,
-  processingCommentReactionId,
-  reactionPopoverDismissed,
+  repliesCount,
   replies,
-  channelOwnerMember,
-  isEditingCommentCollection,
-  commentInputTextCollection,
-  idx,
-  parentCommentInputIsProcessingCollection,
-  onEditLabelClick,
-  onUpdateComment,
-  onEditCommentCancel,
-  onSetIsEditingComment,
-  onSetCommentInputText,
-  onReplyDeleteClick,
+  commentId,
+  video,
+  setOriginalComment,
+  setHighlightedCommentId,
+  highlightedCommentId,
+  setShowEditHistory,
   ...commentProps
 }) => {
   const [repliesOpen, setRepliesOpen] = useState(false)
-  const [replyInputOpen, setReplyInputOpen] = useState(false)
-  const [highlightedComment, setHighlightedComment] = useState<string | null>(null)
-  const { activeMemberId, activeMembership } = useUser()
-  const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
-  const { addComment, commentInputIsProcessingCollection } = useReactionTransactions()
-  const commentInputRef = useRef<HTMLTextAreaElement>(null)
-  const [openCancelConfirmationModal, closeCancelConfirmationModal] = useConfirmationModal()
+
   const placeholderItems = !replies ? Array.from({ length: 4 }, () => ({ id: undefined })) : []
-  const replyAvatars = replies?.map((comment) => ({
-    url: comment?.author.metadata.avatar?.__typename === 'AvatarUri' ? comment?.author.metadata.avatar?.avatarUri : '',
-    handle: comment.author.handle,
-  }))
-  const commentBoxId = `reply-comment-box-${idx}`
-
-  const toggleRepliesOpen = () => {
-    setRepliesOpen((prevState) => !prevState)
-  }
-
-  const handleCancel = () => {
-    setReplyInputOpen(false)
-    onSetCommentInputText({ commentId: commentBoxId, comment: undefined })
-  }
-
-  const handleComment = useCallback(
-    async (commentInputId: string, videoId?: string, parentCommentId?: string) => {
-      if (!videoId || !commentInputTextCollection.get(commentInputId)) {
-        return
-      }
-      const commentId = await addComment({
-        videoId,
-        commentBody: commentInputTextCollection.get(commentInputId) ?? '',
-        parentCommentId,
-        commentInputId,
-      })
-      onSetCommentInputText({ commentId: commentBoxId, comment: undefined })
-      setHighlightedComment(commentId || null)
-      setReplyInputOpen(false)
-    },
-    [addComment, commentBoxId, commentInputTextCollection, onSetCommentInputText]
-  )
-
-  const handleReplyClick = () => {
-    if (!authorized) {
-      onOpenSignInDialog()
-      return
-    }
-    if (replyInputOpen) {
-      commentInputRef.current?.focus()
-    }
-    setReplyInputOpen(true)
-    setRepliesOpen(true)
-  }
-
-  const handleCancelConfirmation = useCallback(
-    (cb: () => void) => {
-      openCancelConfirmationModal({
-        type: 'warning',
-        title: 'Discard changes',
-        description: 'Are you sure you want to discard your comment changes?',
-        primaryButton: {
-          text: 'Confirm and discard',
-          onClick: () => {
-            closeCancelConfirmationModal()
-            cb()
-          },
-        },
-        secondaryButton: {
-          text: 'Cancel',
-          onClick: () => {
-            closeCancelConfirmationModal()
-          },
-        },
-      })
-    },
-    [closeCancelConfirmationModal, openCancelConfirmationModal]
-  )
-
-  const memoizedContent = useMemo(
-    () => (
-      <>
-        {replies?.map((comment, idx) =>
-          isEditingCommentCollection.has(comment.id) ? (
-            <CommentInput
-              key={`${comment.id}-${idx}`}
-              processing={parentCommentInputIsProcessingCollection.has(comment.id)}
-              readOnly={!activeMemberId}
-              memberHandle={activeMembership?.handle}
-              onFocus={() => !activeMemberId && onOpenSignInDialog()}
-              onComment={() => onUpdateComment({ commentId: comment.id })}
-              value={commentInputTextCollection.get(comment.id) ?? ''}
-              hasInitialValueChanged={comment.text !== commentInputTextCollection.get(comment.id)}
-              onChange={(e) => onSetCommentInputText({ commentId: comment.id, comment: e.target.value })}
-              onCancel={() => onEditCommentCancel(comment)}
-              withoutOutlineBox
-              memberAvatarUrl={memberAvatarUrl}
-              indented
-            />
-          ) : (
-            <Comment
-              id={comment.id}
-              author={comment.author}
-              highlighted={comment.id === highlightedComment}
-              reactions={getCommentReactions({
-                commentId: comment.id,
-                userReactions: comment.userReactions,
-                reactionsCount: comment.reactionsCountByReactionId,
-                activeMemberId,
-                processingCommentReactionId,
-              })}
-              key={`${comment.id}-${idx}`}
-              loading={!comment.id}
-              createdAt={new Date(comment.createdAt)}
-              text={comment.text}
-              isEdited={comment.isEdited}
-              onReactionClick={(reactionId) => onCommentReaction(comment.id, reactionId)}
-              indented
-              onEditLabelClick={() => onEditLabelClick(comment)}
-              isAbleToEdit={comment.author.id === activeMemberId}
-              memberHandle={comment.author.handle}
-              memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
-              reactionPopoverDismissed={reactionPopoverDismissed}
-              onEditClick={() => {
-                onSetIsEditingComment({ commentId: comment.id, value: true })
-                onSetCommentInputText({ commentId: comment.id, comment: comment.text })
-              }}
-              onDeleteClick={() => onReplyDeleteClick(comment)}
-              videoId={videoId}
-              type={
-                ['DELETED', 'MODERATED'].includes(comment.status)
-                  ? 'deleted'
-                  : channelOwnerMember === activeMemberId || comment.author.id === activeMemberId
-                  ? 'options'
-                  : 'default'
-              }
-            />
-          )
-        )}
-      </>
-    ),
-    [
-      replies,
-      isEditingCommentCollection,
-      parentCommentInputIsProcessingCollection,
-      activeMemberId,
-      activeMembership?.handle,
-      commentInputTextCollection,
-      memberAvatarUrl,
-      highlightedComment,
-      processingCommentReactionId,
-      reactionPopoverDismissed,
-      videoId,
-      channelOwnerMember,
-      onOpenSignInDialog,
-      onUpdateComment,
-      onSetCommentInputText,
-      onEditCommentCancel,
-      onCommentReaction,
-      onEditLabelClick,
-      onSetIsEditingComment,
-      onReplyDeleteClick,
-    ]
-  )
 
   return (
     <>
       <Comment
+        highlighted={commentId === highlightedCommentId}
+        commentId={commentId}
+        video={video}
+        setRepliesOpen={setRepliesOpen}
+        isRepliesOpen={repliesOpen}
+        setOriginalComment={setOriginalComment}
+        setHighlightedCommentId={setHighlightedCommentId}
+        setShowEditHistory={setShowEditHistory}
         {...commentProps}
-        id={commentId}
-        onReplyClick={handleReplyClick}
-        onEditLabelClick={onEditLabelClick}
-        replyAvatars={replyAvatars}
-        onToggleReplies={toggleRepliesOpen}
-        repliesOpen={repliesOpen}
-        reactionPopoverDismissed={reactionPopoverDismissed}
-        videoId={videoId}
+        isReplyable={true}
       />
-      {replyInputOpen && (
-        <CommentInput
-          ref={commentInputRef}
-          memberAvatarUrl={memberAvatarUrl}
-          isMemberAvatarLoading={isMemberAvatarLoading}
-          processing={commentInputIsProcessingCollection.has(commentBoxId)}
-          readOnly={!activeMemberId}
-          memberHandle={activeMembership?.handle}
-          onFocus={onOpenSignInDialog}
-          onComment={() => handleComment(commentBoxId, videoId, commentId)}
-          hasInitialValueChanged={!!commentInputTextCollection.get(commentBoxId)}
-          value={commentInputTextCollection.get(commentBoxId) ?? ''}
-          withoutOutlineBox
-          onChange={(event) => onSetCommentInputText({ commentId: commentBoxId, comment: event.target.value })}
-          indented
-          onCancel={() => {
-            commentInputTextCollection.get(commentBoxId) ? handleCancelConfirmation(handleCancel) : handleCancel()
-          }}
-          initialFocus
-          reply
-        />
-      )}
       {repliesOpen &&
-        !!commentProps.repliesCount &&
+        !!repliesCount &&
         (!replies
-          ? placeholderItems.map((_, idx) => <Comment key={idx} type="default" loading indented />)
-          : memoizedContent)}
+          ? placeholderItems.map((_, idx) => <Comment key={idx} indented />)
+          : replies?.map((comment, idx) => (
+              <Comment
+                key={`${comment.id}-${idx}`}
+                highlighted={comment.id === highlightedCommentId}
+                commentId={comment.id}
+                video={video}
+                indented
+                setOriginalComment={setOriginalComment}
+                setHighlightedCommentId={setHighlightedCommentId}
+                setShowEditHistory={setShowEditHistory}
+                isReplyable={false}
+              />
+            )))}
     </>
   )
 }

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useComment, useCommentSectionComments } from '@/api/hooks'
@@ -18,8 +18,6 @@ import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useReactionTransactions } from '@/hooks/useReactionTransactions'
 import { useRouterQuery } from '@/hooks/useRouterQuery'
 import { useMemberAvatar } from '@/providers/assets'
-import { useConfirmationModal } from '@/providers/confirmationModal'
-import { usePersonalDataStore } from '@/providers/personalData'
 import { useUser } from '@/providers/user'
 
 import { CommentThread } from './CommentThread'
@@ -33,48 +31,42 @@ type CommentsSectionProps = {
   videoAuthorId?: string
 }
 
-const COMMENT_BOX_ID = 'comment-box'
 const SCROLL_TO_COMMENT_TIMEOUT = 300
-const HIGHLIGHTED_COMMENT_TIMEOUT = 3000
 
 export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, video, videoAuthorId, videoLoading }) => {
   const [sortCommentsBy, setSortCommentsBy] = useState(COMMENTS_SORT_OPTIONS[0].value)
-  const [openModal, closeModal] = useConfirmationModal()
-  const [originalComment, setOriginalComment] = useState<CommentFieldsFragment | null>(null)
-  const [showEditHistory, setShowEditHistory] = useState(false)
-  const { id } = useParams()
-  const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
-  const reactionPopoverDismissed = usePersonalDataStore((state) => state.reactionPopoverDismissed)
+  const { id: videoId } = useParams()
   const { activeMemberId, activeAccountId, signIn, activeMembership } = useUser()
   const { openSignInDialog } = useDisplaySignInDialog()
   const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
-  const [highlightedComment, setHighlightedComment] = useState<string | null>(null)
-  const { id: videoId } = useParams()
-  // indexed by commentId's
-  const [commentInputTextCollection, setCommentInputTextCollection] = useState(new Map<string, string>())
-  // indexed by commentId's
-  const [isEditingCommentCollection, setIsEditingCommentCollection] = useState(new Set<string>())
+  const [commentInputText, setCommentInputText] = useState('')
+  const [commentInputIsProcessing, setCommentInputIsProcessing] = useState(false)
+  const [originalComment, setOriginalComment] = useState<CommentFieldsFragment | null>(null)
+  const [showEditHistory, setShowEditHistory] = useState(false)
+  const [highlightedCommentId, setHighlightedCommentId] = useState<string | null>(null)
+  const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
+
+  const authorized = activeMemberId && activeAccountId
   const commentWrapperRef = useRef<HTMLDivElement>(null)
   const { comments, totalCount, loading } = useCommentSectionComments(
     {
       memberId: activeMemberId,
       videoId: videoId,
-      orderBy: sortCommentsBy,
     },
     { skip: disabled || !videoId }
   )
+
+  const { addComment } = useReactionTransactions()
+
   const { comment: commentFromUrl, loading: commentFromUrlLoading } = useComment(
     commentIdQueryParam || '',
-    activeMemberId || '',
-    video?.id || '',
+
     {
       skip: !commentIdQueryParam || (comments && comments.length === 1),
     }
   )
   const { comment: parentCommentFromUrl, loading: parentCommentFromUrlLoading } = useComment(
     commentFromUrl?.parentCommentId || '',
-    activeMemberId || '',
-    video?.id || '',
     {
       skip: !commentFromUrl || !commentFromUrl.parentCommentId,
     }
@@ -85,54 +77,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
     commentWrapperRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'start' })
   }
 
-  useEffect(() => {
-    if (!commentIdQueryParam || !commentWrapperRef.current) {
-      return
-    }
-    const scrollTimeout = setTimeout(() => {
-      scrollToCommentInput(true)
-      setHighlightedComment(commentIdQueryParam)
-    }, SCROLL_TO_COMMENT_TIMEOUT)
-
-    return () => {
-      clearTimeout(scrollTimeout)
-    }
-  }, [commentIdQueryParam])
-
-  useEffect(() => {
-    if (!highlightedComment || commentsLoading) {
-      return
-    }
-    const timeout = setTimeout(() => {
-      setHighlightedComment(null)
-    }, HIGHLIGHTED_COMMENT_TIMEOUT)
-
-    return () => clearTimeout(timeout)
-  })
-
-  const authorized = activeMemberId && activeAccountId
-
-  const {
-    processingCommentReactionId,
-    reactToComment,
-    addComment,
-    commentInputIsProcessingCollection,
-    deleteComment,
-    moderateComment,
-    updateComment,
-  } = useReactionTransactions()
-
   const mdMatch = useMediaMatch('md')
-
-  const setCommentInputText = ({ commentId, comment }: { commentId: string; comment: string | undefined }) =>
-    setCommentInputTextCollection((commentInputTextCollection) => {
-      if (comment !== undefined) {
-        commentInputTextCollection.set(commentId, comment)
-      } else {
-        commentInputTextCollection.delete(commentId)
-      }
-      return new Map(commentInputTextCollection)
-    })
 
   const handleSorting = (value?: CommentOrderByInput[] | null) => {
     if (value) {
@@ -140,275 +85,79 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
     }
   }
 
-  const handleComment = async ({
-    commentInputId,
-    parentCommentId,
-  }: {
-    commentInputId: string
-    parentCommentId?: string
-  }) => {
-    if (!videoId || !commentInputTextCollection.get(commentInputId)) {
+  const handleComment = async (parentCommentId?: string) => {
+    if (!videoId || !commentInputText) {
       return
     }
+    setCommentInputIsProcessing(true)
     const newCommentId = await addComment({
       videoId,
-      commentBody: commentInputTextCollection.get(commentInputId) ?? '',
+      commentBody: commentInputText,
       parentCommentId,
-      commentInputId,
     })
+    setCommentInputIsProcessing(false)
     if (newCommentId) {
-      setCommentInputText({ commentId: commentInputId, comment: undefined })
-      setHighlightedComment(newCommentId || null)
+      setCommentInputText('')
+      setHighlightedCommentId(newCommentId || null)
     }
   }
 
-  // removes highlightedComment effect after timeout passes
-  useEffect(() => {
-    if (!highlightedComment) {
-      return
-    }
-    const timeout = setTimeout(() => {
-      setHighlightedComment(null)
-    }, 3000)
-    return () => clearTimeout(timeout)
-  })
-
   const placeholderItems = commentsLoading ? Array.from({ length: 4 }, () => ({ id: undefined })) : []
 
-  const handleOpenSignInDialog = useCallback(() => {
-    if (activeMemberId) {
+  useEffect(() => {
+    if (!commentIdQueryParam || !commentWrapperRef.current) {
       return
     }
-    openSignInDialog({ onConfirm: signIn })
-  }, [activeMemberId, openSignInDialog, signIn])
+    const scrollTimeout = setTimeout(() => {
+      scrollToCommentInput(true)
+      setHighlightedCommentId(commentIdQueryParam)
+    }, SCROLL_TO_COMMENT_TIMEOUT)
 
-  const handleCommentReaction = useCallback(
-    (commentId: string, reactionId: ReactionId) => {
-      if (authorized) {
-        reactToComment(commentId, reactionId)
-      } else {
-        openSignInDialog({ onConfirm: signIn })
-      }
-    },
-    [authorized, openSignInDialog, reactToComment, signIn]
-  )
-
-  const memoizedComments = useMemo(() => {
-    const setIsEditingComment = ({ commentId, value }: { commentId: string; value: boolean }) => {
-      setIsEditingCommentCollection((isEditing) => {
-        if (value) {
-          isEditing.add(commentId)
-        } else {
-          isEditing.delete(commentId)
-        }
-        return new Set(isEditing)
-      })
+    return () => {
+      clearTimeout(scrollTimeout)
     }
-    const handleUpdateComment = async ({ commentId }: { commentId: string }) => {
-      if (!videoId || !commentInputTextCollection.get(commentId)) {
+  }, [commentIdQueryParam])
+
+  useEffect(
+    function resetHighlightedComment() {
+      if (!highlightedCommentId || commentsLoading) {
         return
       }
-      await updateComment({
-        videoId,
-        commentBody: commentInputTextCollection.get(commentId) ?? '',
-        commentId: commentId,
-      })
-      setCommentInputText({ commentId, comment: undefined })
-      setHighlightedComment(commentId || null)
-      setIsEditingComment({ commentId, value: false })
-    }
-    const handleDeleteComment = (comment: CommentFieldsFragment, video: VideoFieldsFragment) => {
-      const isChannelOwner = video?.channel.ownerMember?.id === activeMemberId && comment.author.id !== activeMemberId
-      openModal({
-        type: 'destructive',
-        title: 'Delete this comment?',
-        description: 'Are you sure you want to delete this comment? This cannot be undone.',
-        primaryButton: {
-          text: 'Delete comment',
-          onClick: () => {
-            isChannelOwner
-              ? moderateComment(comment.id, video?.channel.id, comment.author.handle, video.title || '')
-              : deleteComment(comment.id, video?.title || '')
-            closeModal()
-          },
-        },
-        secondaryButton: {
-          text: 'Cancel',
-          onClick: () => closeModal(),
-        },
-      })
-    }
+      const timeout = setTimeout(() => {
+        setHighlightedCommentId(null)
+      }, 3000)
 
-    const handleEditCommentCancel = (comment: CommentFieldsFragment) => {
-      if (comment.text !== commentInputTextCollection.get(comment.id)) {
-        openModal({
-          title: 'Discard changes?',
-          description: 'Are you sure you want to discard your comment changes?',
-          type: 'warning',
-          primaryButton: {
-            text: 'Confirm and discard',
-            onClick: () => {
-              closeModal()
-              setIsEditingComment({ commentId: comment.id, value: false })
-              setCommentInputText({ commentId: comment.id, comment: undefined })
-            },
-          },
-          secondaryButton: {
-            text: 'Cancel',
-            onClick: () => {
-              closeModal()
-            },
-          },
-          onExitClick: () => {
-            closeModal()
-          },
-        })
-      } else {
-        setIsEditingComment({ commentId: comment.id, value: false })
-        setCommentInputText({ commentId: comment.id, comment: undefined })
+      return () => clearTimeout(timeout)
+    },
+    [commentsLoading, highlightedCommentId, setHighlightedCommentId]
+  )
+
+  // remove highlighted reply taken from url
+  const filteredParentCommentReplies = parentCommentFromUrl
+    ? {
+        ...parentCommentFromUrl,
+        replies: parentCommentFromUrl?.replies?.filter((comment) => comment.id !== commentIdQueryParam) || [],
       }
-    }
+    : null
 
-    // remove highlighted reply taken from url
-    const filteredParentCommentReplies = parentCommentFromUrl
-      ? {
-          ...parentCommentFromUrl,
-          replies: parentCommentFromUrl?.replies?.filter((comment) => comment.id !== commentIdQueryParam) || [],
-        }
-      : null
+  // remove comment taken from url from regular array of comments
+  const filteredCommentsFromCommentUrl =
+    comments?.filter(
+      (comment) => commentFromUrl && ![commentFromUrl.id, commentFromUrl.parentCommentId].includes(comment.id)
+    ) || []
 
-    // remove comment taken from url from regular array of comments
-    const filteredCommentsFromCommentUrl =
-      comments?.filter(
-        (comment) => commentFromUrl && ![commentFromUrl.id, commentFromUrl.parentCommentId].includes(comment.id)
-      ) || []
+  // if comment from url is reply, merge it with parent comment, if not render only parent
+  const preparedHighlightedComment = commentFromUrl
+    ? commentFromUrl?.parentCommentId
+      ? filteredParentCommentReplies
+        ? [filteredParentCommentReplies, commentFromUrl]
+        : []
+      : [commentFromUrl]
+    : []
 
-    // if comment from url is reply, merge it with parent comment, if not render only parent
-    const preparedHighlightedComment = commentFromUrl
-      ? commentFromUrl?.parentCommentId
-        ? filteredParentCommentReplies
-          ? [filteredParentCommentReplies, commentFromUrl]
-          : []
-        : [commentFromUrl]
-      : []
-
-    const filteredComments = commentFromUrl
-      ? [...preparedHighlightedComment, ...filteredCommentsFromCommentUrl]
-      : comments
-
-    return filteredComments?.map((comment, idx) =>
-      isEditingCommentCollection.has(comment.id) ? (
-        <CommentInput
-          key={`${comment.id}-${idx}`}
-          processing={commentInputIsProcessingCollection.has(comment.id)}
-          readOnly={!activeMemberId}
-          memberHandle={activeMembership?.handle}
-          onFocus={() => !activeMemberId && openSignInDialog({ onConfirm: signIn })}
-          onComment={() => handleUpdateComment({ commentId: comment.id })}
-          value={commentInputTextCollection.get(comment.id) ?? ''}
-          hasInitialValueChanged={comment.text !== commentInputTextCollection.get(comment.id)}
-          onChange={(e) => setCommentInputText({ commentId: comment.id, comment: e.target.value })}
-          onCancel={() => handleEditCommentCancel(comment)}
-          memberAvatarUrl={memberAvatarUrl}
-          withoutOutlineBox
-        />
-      ) : (
-        <CommentThread
-          videoId={id}
-          key={`${comment.id}-${idx}`}
-          author={comment.author}
-          idx={idx}
-          highlighted={comment.id === highlightedComment}
-          indented={!!comment.parentCommentId && comment.id === commentIdQueryParam}
-          commentFromUrl={comment.id === commentIdQueryParam}
-          onCommentReaction={handleCommentReaction}
-          reactions={getCommentReactions({
-            commentId: comment.id,
-            userReactions: comment.userReactions,
-            reactionsCount: comment.reactionsCountByReactionId,
-            activeMemberId,
-            processingCommentReactionId,
-          })}
-          authorized={!!authorized}
-          onDeleteClick={() => video && handleDeleteComment(comment, video)}
-          loading={!comment.id}
-          commentId={comment.id}
-          onOpenSignInDialog={handleOpenSignInDialog}
-          createdAt={new Date(comment.createdAt)}
-          text={comment.text}
-          reactionPopoverDismissed={reactionPopoverDismissed || !authorized}
-          isEdited={comment.isEdited}
-          isAbleToEdit={comment.author.id === activeMemberId}
-          isModerated={comment.status === CommentStatus.Moderated}
-          memberHandle={comment.author.handle}
-          memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
-          videoAuthorId={videoAuthorId}
-          memberAvatarUrl={
-            comment.author.metadata.avatar?.__typename === 'AvatarUri'
-              ? comment.author.metadata.avatar?.avatarUri
-              : undefined
-          }
-          type={
-            ['DELETED', 'MODERATED'].includes(comment.status)
-              ? 'deleted'
-              : video?.channel.ownerMember?.id === activeMemberId || comment.author.id === activeMemberId
-              ? 'options'
-              : 'default'
-          }
-          processingCommentReactionId={processingCommentReactionId}
-          replies={comment.replies}
-          repliesCount={comment?.replies ? comment?.replies?.length : 0}
-          repliesLoading={!!comment.repliesCount && !comment.replies}
-          onReactionClick={(reactionId) => handleCommentReaction(comment.id, reactionId)}
-          onEditLabelClick={(replyComment) => {
-            setShowEditHistory(true)
-            setOriginalComment(replyComment || comment)
-          }}
-          onEditClick={() => {
-            setIsEditingComment({ commentId: comment.id, value: true })
-            setCommentInputText({ commentId: comment.id, comment: comment.text })
-          }}
-          parentCommentInputIsProcessingCollection={commentInputIsProcessingCollection}
-          channelOwnerMember={video?.channel.ownerMember?.id}
-          onUpdateComment={handleUpdateComment}
-          onEditCommentCancel={handleEditCommentCancel}
-          onSetIsEditingComment={setIsEditingComment}
-          onSetCommentInputText={setCommentInputText}
-          isEditingCommentCollection={isEditingCommentCollection}
-          commentInputTextCollection={commentInputTextCollection}
-          onReplyDeleteClick={(replyComment) => video && handleDeleteComment(replyComment, video)}
-        />
-      )
-    )
-  }, [
-    parentCommentFromUrl,
-    commentFromUrl,
-    comments,
-    videoId,
-    commentInputTextCollection,
-    updateComment,
-    activeMemberId,
-    openModal,
-    moderateComment,
-    deleteComment,
-    closeModal,
-    commentIdQueryParam,
-    isEditingCommentCollection,
-    commentInputIsProcessingCollection,
-    activeMembership?.handle,
-    memberAvatarUrl,
-    id,
-    highlightedComment,
-    handleCommentReaction,
-    processingCommentReactionId,
-    authorized,
-    handleOpenSignInDialog,
-    reactionPopoverDismissed,
-    videoAuthorId,
-    video,
-    openSignInDialog,
-    signIn,
-  ])
+  const filteredComments = commentFromUrl
+    ? [...preparedHighlightedComment, ...filteredCommentsFromCommentUrl]
+    : comments
 
   if (disabled) {
     return (
@@ -434,23 +183,90 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
       <CommentInput
         memberAvatarUrl={memberAvatarUrl}
         isMemberAvatarLoading={authorized ? isMemberAvatarLoading : false}
-        processing={commentInputIsProcessingCollection.has(COMMENT_BOX_ID)}
+        processing={commentInputIsProcessing}
         readOnly={!activeMemberId}
         memberHandle={activeMembership?.handle}
-        onFocus={() => !activeMemberId && openSignInDialog({ onConfirm: signIn })}
-        onComment={() => handleComment({ commentInputId: COMMENT_BOX_ID })}
-        value={commentInputTextCollection.get(COMMENT_BOX_ID) ?? ''}
-        hasInitialValueChanged={!!commentInputTextCollection.get(COMMENT_BOX_ID)}
+        value={commentInputText}
+        hasInitialValueChanged={!!commentInputText}
         withoutOutlineBox
-        onChange={(e) => setCommentInputText({ commentId: COMMENT_BOX_ID, comment: e.target.value })}
+        onFocus={() => !activeMemberId && openSignInDialog({ onConfirm: signIn })}
+        onComment={() => handleComment()}
+        onChange={(e) => setCommentInputText(e.target.value)}
       />
       {comments && !comments.length && (
         <EmptyFallback title="Be the first to comment" subtitle="Nobody has left a comment under this video yet." />
       )}
       <CommentWrapper>
         {commentsLoading
-          ? placeholderItems.map((_, idx) => <Comment key={idx} type="default" loading />)
-          : memoizedComments}
+          ? placeholderItems.map((_, idx) => <Comment key={idx} />)
+          : filteredComments?.map((comment, idx) => (
+              <Comment
+                key={`${comment.id}-${idx}`}
+                commentId={comment.id}
+                video={video}
+                setOriginalComment={setOriginalComment}
+                setHighlightedCommentId={setHighlightedCommentId}
+                highlighted={highlightedCommentId === comment.id}
+              />
+              //   <CommentThread
+              //   key={`${comment.id}-${idx}`}
+              // indented={!!comment.parentCommentId && comment.id === commentIdQueryParam}
+              //   author={comment.author}
+              //   idx={idx}
+              //   highlighted={comment.id === highlightedComment}
+              //   onCommentReaction={handleCommentReaction}
+              //   reactions={getCommentReactions({
+              //     commentId: comment.id,
+              //     userReactions: comment.userReactions,
+              //     reactionsCount: comment.reactionsCountByReactionId,
+              //     activeMemberId,
+              //     processingCommentReactionId,
+              //   })}
+              //   authorized={!!authorized}
+              //   onDeleteClick={() => video && handleDeleteComment(comment, video)}
+              //   loading={!comment.id}
+              //   commentId={comment.id}
+              //   onOpenSignInDialog={handleOpenSignInDialog}
+              //   createdAt={new Date(comment.createdAt)}
+              //   text={comment.text}
+              //   reactionPopoverDismissed={reactionPopoverDismissed || !authorized}
+              //   isEdited={comment.isEdited}
+              //   isAbleToEdit={comment.author.id === activeMemberId}
+              //   isModerated={comment.status === CommentStatus.Moderated}
+              //   memberHandle={comment.author.handle}
+              //   memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
+              //   videoAuthorId={videoAuthorId}
+              //   type={
+              //     ['DELETED', 'MODERATED'].includes(comment.status)
+              //       ? 'deleted'
+              //       : video?.channel.ownerMember?.id === activeMemberId || comment.author.id === activeMemberId
+              //       ? 'options'
+              //       : 'default'
+              //   }
+              //   videoId={videoId}
+              //   processingCommentReactionId={processingCommentReactionId}
+              //   replies={comment.replies}
+              //   repliesCount={comment.repliesCount}
+              //   repliesLoading={!!comment.repliesCount && !comment.replies}
+              //   onReactionClick={(reactionId) => handleCommentReaction(comment.id, reactionId)}
+              //   onEditLabelClick={(replyComment) => {
+              //     setShowEditHistory(true)
+              //     setOriginalComment(replyComment || comment)
+              //   }}
+              //   onEditClick={() => {
+              //     setIsEditingComment({ commentId: comment.id, value: true })
+              //     setCommentInputText({ commentId: comment.id, comment: comment.text })
+              //   }}
+              //   channelOwnerMember={video?.channel.ownerMember?.id}
+              //   onUpdateComment={handleUpdateComment}
+              //   onEditCommentCancel={handleEditCommentCancel}
+              //   onSetIsEditingComment={setIsEditingComment}
+              //   onSetCommentInputText={setCommentInputText}
+              //   isEditingCommentCollection={isEditingCommentCollection}
+              //   commentInputTextCollection={commentInputTextCollection}
+              //   onReplyDeleteClick={(replyComment) => video && handleDeleteComment(replyComment, video)}
+              // />
+            ))}
       </CommentWrapper>
       <DialogModal
         size="medium"

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useComment, useCommentSectionComments } from '@/api/hooks'
-import { CommentFieldsFragment, CommentOrderByInput, CommentStatus, VideoFieldsFragment } from '@/api/queries'
+import { useCommentSectionComments } from '@/api/hooks'
+import { CommentFieldsFragment, CommentOrderByInput, VideoFieldsFragment } from '@/api/queries'
 import { EmptyFallback } from '@/components/EmptyFallback'
 import { Text } from '@/components/Text'
 import { Comment } from '@/components/_comments/Comment'
@@ -10,8 +10,7 @@ import { CommentEditHistory } from '@/components/_comments/CommentEditHistory'
 import { CommentInput } from '@/components/_comments/CommentInput'
 import { Select } from '@/components/_inputs/Select'
 import { DialogModal } from '@/components/_overlays/DialogModal'
-import { ReactionId } from '@/config/reactions'
-import { QUERY_PARAMS, absoluteRoutes } from '@/config/routes'
+import { absoluteRoutes } from '@/config/routes'
 import { COMMENTS_SORT_OPTIONS } from '@/config/sorting'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
@@ -22,7 +21,6 @@ import { useUser } from '@/providers/user'
 
 import { CommentThread } from './CommentThread'
 import { CommentWrapper, CommentsSectionHeader, CommentsSectionWrapper } from './VideoView.styles'
-import { getCommentReactions } from './utils'
 
 type CommentsSectionProps = {
   disabled?: boolean
@@ -200,72 +198,18 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
         {commentsLoading
           ? placeholderItems.map((_, idx) => <Comment key={idx} />)
           : filteredComments?.map((comment, idx) => (
-              <Comment
+              <CommentThread
                 key={`${comment.id}-${idx}`}
                 commentId={comment.id}
+                memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
                 video={video}
+                replies={comment.replies}
+                repliesCount={comment.repliesCount}
+                highlightedCommentId={highlightedCommentId}
                 setOriginalComment={setOriginalComment}
                 setHighlightedCommentId={setHighlightedCommentId}
-                highlighted={highlightedCommentId === comment.id}
+                setShowEditHistory={setShowEditHistory}
               />
-              //   <CommentThread
-              //   key={`${comment.id}-${idx}`}
-              // indented={!!comment.parentCommentId && comment.id === commentIdQueryParam}
-              //   author={comment.author}
-              //   idx={idx}
-              //   highlighted={comment.id === highlightedComment}
-              //   onCommentReaction={handleCommentReaction}
-              //   reactions={getCommentReactions({
-              //     commentId: comment.id,
-              //     userReactions: comment.userReactions,
-              //     reactionsCount: comment.reactionsCountByReactionId,
-              //     activeMemberId,
-              //     processingCommentReactionId,
-              //   })}
-              //   authorized={!!authorized}
-              //   onDeleteClick={() => video && handleDeleteComment(comment, video)}
-              //   loading={!comment.id}
-              //   commentId={comment.id}
-              //   onOpenSignInDialog={handleOpenSignInDialog}
-              //   createdAt={new Date(comment.createdAt)}
-              //   text={comment.text}
-              //   reactionPopoverDismissed={reactionPopoverDismissed || !authorized}
-              //   isEdited={comment.isEdited}
-              //   isAbleToEdit={comment.author.id === activeMemberId}
-              //   isModerated={comment.status === CommentStatus.Moderated}
-              //   memberHandle={comment.author.handle}
-              //   memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
-              //   videoAuthorId={videoAuthorId}
-              //   type={
-              //     ['DELETED', 'MODERATED'].includes(comment.status)
-              //       ? 'deleted'
-              //       : video?.channel.ownerMember?.id === activeMemberId || comment.author.id === activeMemberId
-              //       ? 'options'
-              //       : 'default'
-              //   }
-              //   videoId={videoId}
-              //   processingCommentReactionId={processingCommentReactionId}
-              //   replies={comment.replies}
-              //   repliesCount={comment.repliesCount}
-              //   repliesLoading={!!comment.repliesCount && !comment.replies}
-              //   onReactionClick={(reactionId) => handleCommentReaction(comment.id, reactionId)}
-              //   onEditLabelClick={(replyComment) => {
-              //     setShowEditHistory(true)
-              //     setOriginalComment(replyComment || comment)
-              //   }}
-              //   onEditClick={() => {
-              //     setIsEditingComment({ commentId: comment.id, value: true })
-              //     setCommentInputText({ commentId: comment.id, comment: comment.text })
-              //   }}
-              //   channelOwnerMember={video?.channel.ownerMember?.id}
-              //   onUpdateComment={handleUpdateComment}
-              //   onEditCommentCancel={handleEditCommentCancel}
-              //   onSetIsEditingComment={setIsEditingComment}
-              //   onSetCommentInputText={setCommentInputText}
-              //   isEditingCommentCollection={isEditingCommentCollection}
-              //   commentInputTextCollection={commentInputTextCollection}
-              //   onReplyDeleteClick={(replyComment) => video && handleDeleteComment(replyComment, video)}
-              // />
             ))}
       </CommentWrapper>
       <DialogModal

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -50,6 +50,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
     {
       memberId: activeMemberId,
       videoId: videoId,
+      orderBy: sortCommentsBy,
     },
     { skip: disabled || !videoId }
   )

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -2,15 +2,13 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useComment, useCommentSectionComments } from '@/api/hooks'
-import { CommentFieldsFragment, CommentOrderByInput, VideoFieldsFragment } from '@/api/queries'
+import { CommentOrderByInput, VideoFieldsFragment } from '@/api/queries'
 import { EmptyFallback } from '@/components/EmptyFallback'
 import { Text } from '@/components/Text'
 import { Comment } from '@/components/_comments/Comment'
-import { CommentEditHistory } from '@/components/_comments/CommentEditHistory'
 import { CommentInput } from '@/components/_comments/CommentInput'
 import { Select } from '@/components/_inputs/Select'
-import { DialogModal } from '@/components/_overlays/DialogModal'
-import { QUERY_PARAMS, absoluteRoutes } from '@/config/routes'
+import { QUERY_PARAMS } from '@/config/routes'
 import { COMMENTS_SORT_OPTIONS } from '@/config/sorting'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
@@ -39,8 +37,6 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
   const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
   const [commentInputText, setCommentInputText] = useState('')
   const [commentInputIsProcessing, setCommentInputIsProcessing] = useState(false)
-  const [originalComment, setOriginalComment] = useState<CommentFieldsFragment | null>(null)
-  const [showEditHistory, setShowEditHistory] = useState(false)
   const [highlightedCommentId, setHighlightedCommentId] = useState<string | null>(null)
   const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
 
@@ -57,11 +53,14 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
 
   const { addComment } = useReactionTransactions()
 
-  const { comment: commentFromUrl, loading: commentFromUrlLoading } = useComment(commentIdQueryParam || '', {
-    skip: !commentIdQueryParam || (comments && comments.length === 1),
-  })
+  const { comment: commentFromUrl, loading: commentFromUrlLoading } = useComment(
+    { commentId: commentIdQueryParam || '' },
+    {
+      skip: !commentIdQueryParam || (comments && comments.length === 1),
+    }
+  )
   const { comment: parentCommentFromUrl, loading: parentCommentFromUrlLoading } = useComment(
-    commentFromUrl?.parentCommentId || '',
+    { commentId: commentFromUrl?.parentCommentId || '' },
     {
       skip: !commentFromUrl || !commentFromUrl.parentCommentId,
     }
@@ -198,27 +197,14 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
               <CommentThread
                 key={`${comment.id}-${idx}`}
                 commentId={comment.id}
-                memberUrl={absoluteRoutes.viewer.member(comment.author.handle)}
                 video={video}
                 replies={comment.replies}
                 repliesCount={comment.repliesCount}
                 highlightedCommentId={highlightedCommentId}
-                indented={!!comment.parentCommentId && comment.id === commentIdQueryParam}
-                setOriginalComment={setOriginalComment}
                 setHighlightedCommentId={setHighlightedCommentId}
-                setShowEditHistory={setShowEditHistory}
               />
             ))}
       </CommentWrapper>
-      <DialogModal
-        size="medium"
-        title="Edit history"
-        show={showEditHistory}
-        onExitClick={() => setShowEditHistory(false)}
-        dividers
-      >
-        <CommentEditHistory originalComment={originalComment} />
-      </DialogModal>
     </CommentsSectionWrapper>
   )
 }

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useCommentSectionComments } from '@/api/hooks'
+import { useComment, useCommentSectionComments } from '@/api/hooks'
 import { CommentFieldsFragment, CommentOrderByInput, VideoFieldsFragment } from '@/api/queries'
 import { EmptyFallback } from '@/components/EmptyFallback'
 import { Text } from '@/components/Text'
@@ -10,7 +10,7 @@ import { CommentEditHistory } from '@/components/_comments/CommentEditHistory'
 import { CommentInput } from '@/components/_comments/CommentInput'
 import { Select } from '@/components/_inputs/Select'
 import { DialogModal } from '@/components/_overlays/DialogModal'
-import { absoluteRoutes } from '@/config/routes'
+import { QUERY_PARAMS, absoluteRoutes } from '@/config/routes'
 import { COMMENTS_SORT_OPTIONS } from '@/config/sorting'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
@@ -31,7 +31,7 @@ type CommentsSectionProps = {
 
 const SCROLL_TO_COMMENT_TIMEOUT = 300
 
-export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, video, videoAuthorId, videoLoading }) => {
+export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, video, videoLoading }) => {
   const [sortCommentsBy, setSortCommentsBy] = useState(COMMENTS_SORT_OPTIONS[0].value)
   const { id: videoId } = useParams()
   const { activeMemberId, activeAccountId, signIn, activeMembership } = useUser()
@@ -56,13 +56,9 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
 
   const { addComment } = useReactionTransactions()
 
-  const { comment: commentFromUrl, loading: commentFromUrlLoading } = useComment(
-    commentIdQueryParam || '',
-
-    {
-      skip: !commentIdQueryParam || (comments && comments.length === 1),
-    }
-  )
+  const { comment: commentFromUrl, loading: commentFromUrlLoading } = useComment(commentIdQueryParam || '', {
+    skip: !commentIdQueryParam || (comments && comments.length === 1),
+  })
   const { comment: parentCommentFromUrl, loading: parentCommentFromUrlLoading } = useComment(
     commentFromUrl?.parentCommentId || '',
     {
@@ -206,6 +202,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
                 replies={comment.replies}
                 repliesCount={comment.repliesCount}
                 highlightedCommentId={highlightedCommentId}
+                indented={!!comment.parentCommentId && comment.id === commentIdQueryParam}
                 setOriginalComment={setOriginalComment}
                 setHighlightedCommentId={setHighlightedCommentId}
                 setShowEditHistory={setShowEditHistory}

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -30,6 +30,7 @@ type CommentsSectionProps = {
 const SCROLL_TO_COMMENT_TIMEOUT = 300
 
 export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, video, videoLoading }) => {
+  const mdMatch = useMediaMatch('md')
   const [sortCommentsBy, setSortCommentsBy] = useState(COMMENTS_SORT_OPTIONS[0].value)
   const { id: videoId } = useParams()
   const { activeMemberId, activeAccountId, signIn, activeMembership } = useUser()
@@ -65,13 +66,10 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
       skip: !commentFromUrl || !commentFromUrl.parentCommentId,
     }
   )
-  const commentsLoading = loading || commentFromUrlLoading || parentCommentFromUrlLoading || videoLoading
 
   const scrollToCommentInput = (smooth?: boolean) => {
     commentWrapperRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'start' })
   }
-
-  const mdMatch = useMediaMatch('md')
 
   const handleSorting = (value?: CommentOrderByInput[] | null) => {
     if (value) {
@@ -96,6 +94,7 @@ export const CommentsSection: React.FC<CommentsSectionProps> = ({ disabled, vide
     }
   }
 
+  const commentsLoading = loading || commentFromUrlLoading || parentCommentFromUrlLoading || videoLoading
   const placeholderItems = commentsLoading ? Array.from({ length: 4 }, () => ({ id: undefined })) : []
 
   useEffect(() => {


### PR DESCRIPTION
Fix: #2722

Change summary:

- Renamed/moved Comment component to InternalComment
- now Comment is a smart container that handles InternalComment + reply input + editing input and passes all the logic and fn handlers down
- CommentThread is now simplified and it serves to show a main Comment and it's replies, is up to discussion if its be needed anymore
- added useComment hook which returns a single comment with it's reactions and replies and accepts a `commented` as parameter
- updated useReactionTransactions hook to not hold any state anymore; such state is stored were it's needed instead mostly in commentSection and Comment components
- CommentSection has been simplified as well and it no longer holds a lot of business logic related to comments