### PR TITLE
Update read only reaction chip

### DIFF
--- a/packages/atlas/src/components/_comments/ReactionChip/ReactionChip.styles.ts
+++ b/packages/atlas/src/components/_comments/ReactionChip/ReactionChip.styles.ts
@@ -50,6 +50,12 @@ export const ReactionChipButton = styled.button<ReactionChipButtonProps>`
   ${({ state }) => state === 'default' && getHoverStyles};
 `
 
-export const StyledEmojiWrapper = styled(EmojiWrapper)`
+const readOnlyStyles = css`
+  filter: grayscale(100%);
+  opacity: 0.85;
+`
+
+export const StyledEmojiWrapper = styled(EmojiWrapper)<{ readOnly: boolean }>`
   margin-right: ${sizes(2)};
+  ${({ readOnly }) => readOnly && readOnlyStyles};
 `

--- a/packages/atlas/src/components/_comments/ReactionChip/ReactionChip.tsx
+++ b/packages/atlas/src/components/_comments/ReactionChip/ReactionChip.tsx
@@ -38,7 +38,9 @@ export const ReactionChip: React.FC<ReactionChipProps> = ({
         title={`${pluralizeNoun(count || 0, 'user')} reacted with ${REACTION_TYPE[reactionId].name}`}
         onClick={() => state === 'default' && onReactionClick?.(reactionId)}
       >
-        <StyledEmojiWrapper block>{REACTION_TYPE[reactionId].emoji} </StyledEmojiWrapper>
+        <StyledEmojiWrapper readOnly={state === 'read-only'} block>
+          {REACTION_TYPE[reactionId].emoji}{' '}
+        </StyledEmojiWrapper>
         {isProcessing ? <Loader variant="xsmall" /> : <Text variant="t100">{formatNumberShort(count)}</Text>}
       </ReactionChipButton>
     </div>


### PR DESCRIPTION
We had some discussion about the reaction chips yesterday and as a result, the design changed a bit.
This small PR should update the look of the `read-only` reaction chip, which will only be used for deleted comments:
Design:
https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2400%3A217592
Usage: 
https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2464%3A406669

![image](https://user-images.githubusercontent.com/51168865/171124187-0ddda08b-618b-4e89-81ae-6ef89c2dceac.png)
![image](https://user-images.githubusercontent.com/51168865/171124337-a38dbfec-d147-418b-b8e1-0e365b8348a7.png)
