### PR TITLE
Remove comment tweaks

### DIFF
--- a/packages/atlas/src/components/_comments/Comment/Comment.styles.ts
+++ b/packages/atlas/src/components/_comments/Comment/Comment.styles.ts
@@ -27,19 +27,27 @@ export const CommentWrapper = styled.div<{ shouldShowKebabButton: boolean }>`
 
   :hover {
     ${KebabMenuIconButton} {
-      opacity: ${({ shouldShowKebabButton: isActive }) => (isActive ? 1 : 0)};
+      opacity: ${({ shouldShowKebabButton }) => (shouldShowKebabButton ? 1 : 0)};
     }
   }
 `
 
-export const CommentHeader = styled.div<{ isDeleted: boolean }>`
+export const CommentArticle = styled.article<{ isDeleted?: boolean }>`
+  display: grid;
+  grid-auto-flow: row;
+  gap: ${({ isDeleted }) => (isDeleted ? sizes(3) : sizes(2))};
+  align-items: start;
+`
+
+export const CommentHeader = styled.header`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  margin-bottom: ${({ isDeleted }) => (isDeleted ? sizes(3) : sizes(2))};
 `
 
-export const StyledLink = styled(Link)<{ isProcessing?: boolean }>`
+const isPropValid = (prop: PropertyKey) => prop !== 'isProcessing'
+
+export const StyledLink = styled(Link, { shouldForwardProp: isPropValid })<{ isProcessing?: boolean }>`
   text-decoration: none;
   pointer-events: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
   touch-action: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
@@ -75,8 +83,9 @@ export const DeletedComment = styled(Text)`
   align-items: center;
 `
 
-export const CommentFooter = styled.div`
-  margin-top: ${sizes(2)};
+export const CommentFooter = styled.footer<{ isProcessing?: boolean }>`
+  pointer-events: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
+  touch-action: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
 `
 
 export const CommentFooterItems = styled.div`

--- a/packages/atlas/src/components/_comments/Comment/Comment.styles.ts
+++ b/packages/atlas/src/components/_comments/Comment/Comment.styles.ts
@@ -39,8 +39,10 @@ export const CommentHeader = styled.div<{ isDeleted: boolean }>`
   margin-bottom: ${({ isDeleted }) => (isDeleted ? sizes(3) : sizes(2))};
 `
 
-export const StyledLink = styled(Link)`
+export const StyledLink = styled(Link)<{ isProcessing?: boolean }>`
   text-decoration: none;
+  pointer-events: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
+  touch-action: ${({ isProcessing }) => (isProcessing ? 'none' : 'unset')};
 `
 
 export const CommentHeaderDot = styled.div`

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -52,7 +52,7 @@ export type InternalCommentProps = {
   isEdited: boolean | undefined
   isAbleToEdit: boolean | undefined
   isModerated: boolean | undefined
-  type: 'default' | 'deleted' | 'options'
+  type: 'default' | 'deleted' | 'options' | 'processing'
   reactions: Omit<ReactionChipProps, 'onReactionClick'>[] | undefined
   reactionPopoverDismissed: boolean | undefined
   replyAvatars?: (AvatarGroupUrlAvatar & { handle: string })[]
@@ -125,7 +125,7 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
     {
       icon: <SvgActionTrash />,
       onClick: onDeleteClick,
-      title: 'Remove',
+      title: 'Delete',
       destructive: true,
     },
   ]
@@ -181,6 +181,7 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
 
   return (
     <CommentRow
+      processing={type === 'processing'}
       indented={indented}
       highlighted={highlighted}
       isMemberAvatarLoading={loading || isMemberAvatarLoading}
@@ -205,7 +206,7 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
             ) : (
               <div>
                 <CommentHeader isDeleted={isDeleted}>
-                  <StyledLink to={memberUrl || ''}>
+                  <StyledLink to={memberUrl || ''} isProcessing={type === 'processing'}>
                     <Text variant="h200" margin={{ right: 2 }}>
                       {memberHandle}
                     </Text>
@@ -232,7 +233,7 @@ export const InternalComment: React.FC<InternalCommentProps> = ({
                 </CommentHeader>
                 {isDeleted ? (
                   <DeletedComment variant="t200" color={cVar('colorTextMuted')}>
-                    <StyledSvgActionTrash /> Comment deleted by the {isModerated ? 'channel owner' : 'author'}
+                    <StyledSvgActionTrash /> Comment deleted by {isModerated ? 'channel owner' : 'author'}
                   </DeletedComment>
                 ) : (
                   <CommentBody>{text}</CommentBody>

--- a/packages/atlas/src/components/_comments/CommentRow/CommentRow.styles.ts
+++ b/packages/atlas/src/components/_comments/CommentRow/CommentRow.styles.ts
@@ -2,19 +2,23 @@ import styled from '@emotion/styled'
 
 import { cVar, media, sizes } from '@/styles'
 
-export const OutlineBox = styled.div<{ highlighted: boolean; withoutOutlineBox: boolean }>`
+export const OutlineBox = styled.div<{ highlighted: boolean; withoutOutlineBox: boolean; processing?: boolean }>`
   padding: ${({ withoutOutlineBox: withoutOutline }) => (withoutOutline ? 0 : sizes(2))};
   margin: ${({ withoutOutlineBox: withoutOutline }) => (withoutOutline ? 0 : `-${sizes(2)}`)};
   width: 100%;
   background-color: ${({ highlighted }) => (highlighted ? cVar('colorBackgroundAlpha') : 'transparent')};
   border: 1px solid ${({ highlighted }) => (highlighted ? cVar('colorBackgroundAlpha') : 'transparent')};
   border-radius: ${cVar('radiusLarge')};
-  transition: background-color ${cVar('animationTransitionSlow')}, border ${cVar('animationTransitionSlow')};
+  transition: background-color ${cVar('animationTransitionSlow')}, border ${cVar('animationTransitionSlow')},
+    opacity ${cVar('animationTransitionFast')};
 
   ${media.sm} {
     padding: ${({ withoutOutlineBox: withoutOutline }) => (withoutOutline ? 0 : sizes(4))};
     margin: ${({ withoutOutlineBox: withoutOutline }) => (withoutOutline ? 0 : `-${sizes(4)}`)};
   }
+
+  opacity: ${({ processing }) => (processing ? 0.5 : 1)};
+  cursor: ${({ processing }) => (processing ? 'not-allowed' : 'unset')};
 `
 
 export const ContentWrapper = styled.div<{ indented: boolean }>`

--- a/packages/atlas/src/components/_comments/CommentRow/CommentRow.tsx
+++ b/packages/atlas/src/components/_comments/CommentRow/CommentRow.tsx
@@ -8,6 +8,7 @@ import { ContentWrapper, OutlineBox } from './CommentRow.styles'
 
 export type CommentRowProps = {
   indented?: boolean
+  processing?: boolean
   highlighted?: boolean
   isMemberAvatarLoading?: boolean
   isMemberAvatarClickable?: boolean
@@ -21,6 +22,7 @@ export type CommentRowProps = {
 
 export const CommentRow: React.FC<CommentRowProps> = ({
   indented,
+  processing,
   highlighted,
   children,
   memberAvatarUrl,
@@ -51,6 +53,7 @@ export const CommentRow: React.FC<CommentRowProps> = ({
   const avatarSize = getAvatarSize()
   return (
     <OutlineBox
+      processing={processing}
       highlighted={!!highlighted}
       withoutOutlineBox={withoutOutlineBox}
       onMouseEnter={onMouseEnter}

--- a/packages/atlas/src/hooks/useReactionTransactions.ts
+++ b/packages/atlas/src/hooks/useReactionTransactions.ts
@@ -1,5 +1,6 @@
 import { useApolloClient } from '@apollo/client'
 import { useCallback } from 'react'
+import { useNavigate } from 'react-router'
 
 import {
   GetCommentDocument,
@@ -22,6 +23,7 @@ import {
   GetVideoQueryVariables,
 } from '@/api/queries'
 import { ReactionId } from '@/config/reactions'
+import { absoluteRoutes } from '@/config/routes'
 import { VideoReaction } from '@/joystream-lib'
 import { useJoystream } from '@/providers/joystream'
 import { useTransaction } from '@/providers/transactionManager'
@@ -32,6 +34,7 @@ export const useReactionTransactions = () => {
   const { activeMemberId } = useUser()
   const { joystream, proxyCallback } = useJoystream()
   const handleTransaction = useTransaction()
+  const navigate = useNavigate()
   const client = useApolloClient()
 
   const refetchComment = useCallback(
@@ -228,7 +231,7 @@ export const useReactionTransactions = () => {
     [activeMemberId, handleTransaction, joystream, proxyCallback, refetchEdits]
   )
   const deleteComment = useCallback(
-    async (commentId: string, videoTitle?: string) => {
+    async (commentId: string, videoTitle?: string, videoId?: string) => {
       if (!joystream || !activeMemberId) {
         ConsoleLogger.error('no joystream or active member')
         return
@@ -240,17 +243,25 @@ export const useReactionTransactions = () => {
         snackbarSuccessMessage: {
           title: 'Comment deleted',
           description: `Your comment to the video ${videoTitle} has been deleted`,
+          actionText: 'Go to video',
+          onActionClick: () => navigate(absoluteRoutes.viewer.video(videoId)),
         },
         minimized: {
           signErrorMessage: 'Failed to delete comment',
         },
       })
     },
-    [activeMemberId, handleTransaction, joystream, proxyCallback]
+    [activeMemberId, handleTransaction, joystream, navigate, proxyCallback]
   )
 
   const moderateComment = useCallback(
-    async (commentId: string, channelId: string, commentAuthorHandle?: string, videoTitle?: string) => {
+    async (
+      commentId: string,
+      channelId: string,
+      commentAuthorHandle?: string,
+      videoTitle?: string,
+      videoId?: string
+    ) => {
       if (!joystream || !activeMemberId) {
         ConsoleLogger.error('no joystream or active member')
         return
@@ -267,13 +278,15 @@ export const useReactionTransactions = () => {
         snackbarSuccessMessage: {
           title: 'Comment deleted',
           description: `${commentAuthorHandle}'s comment to your video ${videoTitle} has been deleted`,
+          actionText: 'Go to video',
+          onActionClick: () => navigate(absoluteRoutes.viewer.video(videoId)),
         },
         minimized: {
           signErrorMessage: 'Failed to delete comment',
         },
       })
     },
-    [activeMemberId, handleTransaction, joystream, proxyCallback]
+    [activeMemberId, handleTransaction, joystream, navigate, proxyCallback]
   )
 
   const likeOrDislikeVideo = useCallback(

--- a/packages/atlas/src/providers/transactionManager/useTransaction.ts
+++ b/packages/atlas/src/providers/transactionManager/useTransaction.ts
@@ -15,20 +15,17 @@ import { useTransactionManagerStore } from './store'
 
 import { useConfirmationModal } from '../confirmationModal'
 import { useConnectionStatusStore } from '../connectionStatus'
-import { useSnackbar } from '../snackbars'
+import { DisplaySnackbarArgs, useSnackbar } from '../snackbars'
 
 type UpdateStatusFn = (status: ExtrinsicStatus | null) => void
-type SnackbarSuccessMessage = {
-  title: string
-  description?: string
-}
+
 type HandleTransactionOpts<T extends ExtrinsicResult> = {
   txFactory: (updateStatus: UpdateStatusFn) => Promise<T>
   preProcess?: () => void | Promise<void>
   onTxFinalize?: (data: T) => Promise<unknown>
   onTxSync?: (data: T, metaStatus?: MetaprotocolTransactionSuccessFieldsFragment) => Promise<unknown>
   onError?: () => void
-  snackbarSuccessMessage?: SnackbarSuccessMessage
+  snackbarSuccessMessage?: DisplaySnackbarArgs
   minimized?: {
     signErrorMessage: string
   }


### PR DESCRIPTION
Fix #2801 

I'm not sure if I fully understand point 5: 
> As is: In a deleted comment, which remains in the main thread, the gap between the “Comment deleted by the channel owner/comment author” message and the header part of the Comment body component is unchanged, set to 8px.
To be: It should be set to 12px, just like the gap between the deletion message and the header part of the Comment body component.

For me, the gap between the text `Comment deleted...` and the header looks correct(12px).
Deleted:
![image](https://user-images.githubusercontent.com/51168865/172140381-338f3ab3-1d45-41d4-8cd1-5e52ad24369f.png)
Not deleted: 
![image](https://user-images.githubusercontent.com/51168865/172140519-b7126e8b-f309-4a7c-89a0-3dd1bf3e4f59.png)


@toiletgranny could you explain which gap you referring to?

