### PR TITLE
Fees support in components

### DIFF
--- a/packages/atlas/src/components/ActionBar/ActionBar.tsx
+++ b/packages/atlas/src/components/ActionBar/ActionBar.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 
+import { Fee } from '@/components/Fee'
 import { Text } from '@/components/Text'
 import { TooltipProps } from '@/components/Tooltip'
 import { ButtonProps } from '@/components/_buttons/Button'
@@ -14,10 +15,7 @@ import {
   FeeContainer,
   SecondaryButton,
   StyledInformation,
-  StyledPrimaryText,
 } from './ActionBar.styles'
-
-import { NumberFormat } from '../NumberFormat'
 
 export type ActionDialogButtonProps = {
   text?: string
@@ -44,16 +42,7 @@ export const ActionBar = forwardRef<HTMLDivElement, ActionBarProps>(
     return (
       <ActionBarContainer ref={ref} className={className} isActive={isActive}>
         <FeeContainer>
-          <StyledPrimaryText as="span" variant={smMatch ? 'h400' : 'h200'}>
-            Fee: <NumberFormat as="span" format="short" withToken value={fee ?? 0} />
-          </StyledPrimaryText>
-          <StyledInformation
-            multiline
-            icon
-            placement="top-end"
-            headerText="Blockchain transaction"
-            text="This action requires a blockchain transaction, which comes with a fee."
-          />
+          <Fee amount={fee ?? 0} variant={smMatch ? 'h400' : 'h200'} />
         </FeeContainer>
         {infoBadge ? (
           <DraftsBadgeContainer>

--- a/packages/atlas/src/components/Avatar/Avatar.tsx
+++ b/packages/atlas/src/components/Avatar/Avatar.tsx
@@ -23,6 +23,16 @@ export type AvatarProps = PropsWithChildren<{
   withoutOutline?: boolean
   loading?: boolean
   className?: string
+  /**
+   * @description preview - 136px x 136px
+   * @description cover - default: 64px x 64px, md: 88px x 88px
+   * @description default - 32px x 32px
+   * @description fill - 100% x 100%
+   * @description bid - 24px x 24px
+   * @description small - 40px x 40px
+   * @description channel - default: 88px x 88px, md: 136px x 136px
+   * @description channel-card - default: 88px x 88px, md: 104px x 104px
+   */
   size?: AvatarSize
   editable?: boolean
   newChannel?: boolean

--- a/packages/atlas/src/components/Fee/Fee.stories.tsx
+++ b/packages/atlas/src/components/Fee/Fee.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, Story } from '@storybook/react'
+
+import { Fee, FeeProps } from './Fee'
+
+export default {
+  title: 'other/Fee',
+  component: Fee,
+  argTypes: {
+    className: { table: { disable: true } },
+    variant: { table: { disable: true } },
+    color: { table: { disable: true } },
+  },
+  args: {
+    variant: 'h500',
+    amount: 0,
+    loading: false,
+    hideOnMobile: false,
+  },
+} as Meta<FeeProps>
+
+const Template: Story<FeeProps> = (args) => <Fee {...args} />
+
+export const Default = Template.bind({})

--- a/packages/atlas/src/components/Fee/Fee.stories.tsx
+++ b/packages/atlas/src/components/Fee/Fee.stories.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled'
 import { Meta, Story } from '@storybook/react'
+
+import { sizes } from '@/styles'
 
 import { Fee, FeeProps } from './Fee'
 
@@ -18,6 +21,14 @@ export default {
   },
 } as Meta<FeeProps>
 
-const Template: Story<FeeProps> = (args) => <Fee {...args} />
+const Template: Story<FeeProps> = (args) => (
+  <Wrapper>
+    <Fee {...args} />
+  </Wrapper>
+)
 
 export const Default = Template.bind({})
+
+const Wrapper = styled.div`
+  padding: ${sizes(20)};
+`

--- a/packages/atlas/src/components/Fee/Fee.tsx
+++ b/packages/atlas/src/components/Fee/Fee.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled'
+import { FC } from 'react'
+
+import { Information } from '@/components/Information'
+import { NumberFormat } from '@/components/NumberFormat'
+import { Text, TextVariant } from '@/components/Text'
+import { Color } from '@/components/Text/Text.styles'
+import { useMediaMatch } from '@/hooks/useMediaMatch'
+
+export type FeeProps = {
+  amount: number
+  variant: TextVariant
+  color?: Color
+  hideOnMobile?: boolean
+  className?: string
+  loading?: boolean
+}
+
+export const Fee: FC<FeeProps> = ({
+  amount,
+  variant = 't100',
+  color = 'colorTextStrong',
+  hideOnMobile,
+  className,
+  loading,
+}) => {
+  const smMatch = useMediaMatch('sm')
+  return (
+    <Wrapper className={className}>
+      {(!hideOnMobile || smMatch) && (
+        <>
+          <Text as="span" variant={variant} color={color}>
+            Fee:&nbsp;{amount < 0.01 && '<'}&nbsp;
+          </Text>
+          <NumberFormat
+            displayedValue={amount < 0.01 ? 0.01 : undefined}
+            value={amount}
+            as="span"
+            variant={variant}
+            color={loading ? 'colorText' : color}
+            withToken
+            withTooltip
+            format="short"
+            margin={{ right: 1 }}
+          />
+        </>
+      )}
+      <Information
+        placement="top-start"
+        text="This action requires a blockchain transaction, which comes with a fee."
+        headerText="Blockchain transaction"
+        multiline
+        icon
+      />
+    </Wrapper>
+  )
+}
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`

--- a/packages/atlas/src/components/Fee/Fee.tsx
+++ b/packages/atlas/src/components/Fee/Fee.tsx
@@ -37,7 +37,7 @@ export const Fee: FC<FeeProps> = ({
             value={amount}
             as="span"
             variant={variant}
-            color={loading ? 'colorText' : color}
+            color={loading ? 'colorTextMuted' : color}
             withToken
             withTooltip
             format="short"

--- a/packages/atlas/src/components/Fee/Fee.tsx
+++ b/packages/atlas/src/components/Fee/Fee.tsx
@@ -42,6 +42,7 @@ export const Fee: FC<FeeProps> = ({
             withTooltip
             format="short"
             margin={{ right: 1 }}
+            tooltipAsWrapper
           />
         </>
       )}

--- a/packages/atlas/src/components/Fee/index.ts
+++ b/packages/atlas/src/components/Fee/index.ts
@@ -1,0 +1,1 @@
+export * from './Fee'

--- a/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import { forwardRef, useRef } from 'react'
 import mergeRefs from 'react-merge-refs'
 
@@ -42,15 +41,22 @@ export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
     const hasDecimals = value - Math.floor(value) !== 0
     const hasTooltip =
       withTooltip || (format === 'short' && (value > 999 || hasDecimals)) || (format === 'dollar' && hasDecimals)
+    const content = (
+      <Text {...textProps} variant={variant} ref={mergeRefs([ref, textRef])}>
+        {displayedValue || formattedValue}
+        {withToken && ` ${JOY_CURRENCY_TICKER}`}
+      </Text>
+    )
 
-    return (
-      <>
-        <Text {...textProps} variant={variant} ref={mergeRefs([ref, textRef])}>
-          {displayedValue || formattedValue}
-          {withToken && ` ${JOY_CURRENCY_TICKER}`}
-        </Text>
-        {hasTooltip && <StyledTooltip reference={textRef} placement="top" delay={[500, null]} text={tooltipText} />}
-      </>
+    // TODO: This is workaround. For some reason this tooltip doesn't work properly.
+    //  Dear developer, if you find a solution, the project will thank you, otherwise we should consider
+    //  using Floating UI (https://github.com/floating-ui/floating-ui)
+    return hasTooltip ? (
+      <Tooltip placement="top" delay={[500, null]} text={tooltipText}>
+        {content}
+      </Tooltip>
+    ) : (
+      content
     )
   }
 )
@@ -87,7 +93,3 @@ const formatNumberShort = (num: number): string => {
 
 const formatDollars = (num: number) =>
   (num >= 1 ? dollarFormatter.format(num) : dollarSmallNumberFormatter.format(num)).replaceAll(',', ' ')
-
-const StyledTooltip = styled(Tooltip)`
-  position: absolute;
-`

--- a/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
@@ -15,10 +15,11 @@ export type NumberFormatProps = {
   withTooltip?: boolean
   children?: never
   variant?: TextVariant
+  displayedValue?: string | number
 } & Omit<TextProps, 'children' | 'variant'>
 
 export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
-  ({ value, format = 'full', withToken, withTooltip, variant = 'no-variant', ...textProps }, ref) => {
+  ({ value, format = 'full', withToken, withTooltip, variant = 'no-variant', displayedValue, ...textProps }, ref) => {
     const textRef = useRef<HTMLHeadingElement>(null)
     let formattedValue
     let tooltipText
@@ -45,7 +46,7 @@ export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
     return (
       <>
         <Text {...textProps} variant={variant} ref={mergeRefs([ref, textRef])}>
-          {formattedValue}
+          {displayedValue || formattedValue}
           {withToken && ` ${JOY_CURRENCY_TICKER}`}
         </Text>
         {hasTooltip && <StyledTooltip reference={textRef} placement="top" delay={[500, null]} text={tooltipText} />}

--- a/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
@@ -15,10 +15,23 @@ export type NumberFormatProps = {
   children?: never
   variant?: TextVariant
   displayedValue?: string | number
+  tooltipAsWrapper?: boolean
 } & Omit<TextProps, 'children' | 'variant'>
 
 export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
-  ({ value, format = 'full', withToken, withTooltip, variant = 'no-variant', displayedValue, ...textProps }, ref) => {
+  (
+    {
+      value,
+      format = 'full',
+      withToken,
+      withTooltip,
+      variant = 'no-variant',
+      displayedValue,
+      tooltipAsWrapper,
+      ...textProps
+    },
+    ref
+  ) => {
     const textRef = useRef<HTMLHeadingElement>(null)
     let formattedValue
     let tooltipText
@@ -51,12 +64,19 @@ export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
     // TODO: This is workaround. For some reason this tooltip doesn't work properly.
     //  Dear developer, if you find a solution, the project will thank you, otherwise we should consider
     //  using Floating UI (https://github.com/floating-ui/floating-ui)
-    return hasTooltip ? (
-      <Tooltip placement="top" delay={[500, null]} text={tooltipText}>
+    if (tooltipAsWrapper) {
+      return (
+        <Tooltip placement="top" delay={[500, null]} text={hasTooltip ? tooltipText : undefined}>
+          {content}
+        </Tooltip>
+      )
+    }
+
+    return (
+      <>
         {content}
-      </Tooltip>
-    ) : (
-      content
+        <Tooltip reference={textRef} placement="top" delay={[500, null]} text={hasTooltip ? tooltipText : undefined} />
+      </>
     )
   }
 )

--- a/packages/atlas/src/components/Text/Text.styles.ts
+++ b/packages/atlas/src/components/Text/Text.styles.ts
@@ -4,8 +4,9 @@ import styled from '@emotion/styled'
 import { cVar, sizes, theme } from '@/styles'
 
 type FilterStartingWith<Keys, Prefix extends string> = Keys extends `${Prefix}${infer _}` ? Keys : never
+export type Color = FilterStartingWith<keyof typeof theme, 'color'> | 'inherit'
 export type TextBaseProps = {
-  color?: FilterStartingWith<keyof typeof theme, 'color'> | 'inherit'
+  color?: Color
   clampAfterLine?: number
   margin?: MarginProps
   align?: AlignProps

--- a/packages/atlas/src/components/_comments/CommentInput/CommentInput.stories.tsx
+++ b/packages/atlas/src/components/_comments/CommentInput/CommentInput.stories.tsx
@@ -11,6 +11,7 @@ export default {
     onComment: { table: { disable: true } },
     onCancel: { table: { disable: true } },
     className: { table: { disable: true } },
+    fee: { type: 'number' },
   },
   args: {
     cancelButton: false,

--- a/packages/atlas/src/components/_comments/CommentInput/CommentInput.styles.ts
+++ b/packages/atlas/src/components/_comments/CommentInput/CommentInput.styles.ts
@@ -132,4 +132,5 @@ export const Flex = styled.div`
   display: flex;
   align-items: center;
   justify-content: end;
+  margin-right: ${sizes(4)};
 `

--- a/packages/atlas/src/components/_comments/CommentInput/CommentInput.tsx
+++ b/packages/atlas/src/components/_comments/CommentInput/CommentInput.tsx
@@ -2,10 +2,9 @@ import { ChangeEvent, forwardRef, useEffect, useRef, useState } from 'react'
 import mergeRefs from 'react-merge-refs'
 import useResizeObserver from 'use-resize-observer'
 
-import { Information } from '@/components/Information'
+import { Fee } from '@/components/Fee'
 import { Text } from '@/components/Text'
 import { Button } from '@/components/_buttons/Button'
-import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useSnackbar } from '@/providers/snackbars'
 import { formatNumber } from '@/utils/number'
 
@@ -34,6 +33,7 @@ export type CommentInputProps = {
   initialFocus?: boolean
   reply?: boolean
   className?: string
+  fee?: number
 } & Omit<CommentRowProps, 'isInput'>
 
 const COMMENT_LIMIT = 50000
@@ -54,11 +54,11 @@ export const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>(
       initialFocus,
       reply,
       className,
+      fee = 0,
       ...rest
     },
     ref
   ) => {
-    const smMatch = useMediaMatch('sm')
     const containerRef = useRef<HTMLLabelElement>(null)
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
     const [active, setActive] = useState(false)
@@ -151,15 +151,7 @@ export const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>(
 
           <ButtonsContainer>
             <Flex>
-              <Information
-                placement="top-start"
-                headerText="Comments on blockchain"
-                text="To publish a comment you need to sign a transaction. For now, no fees are involved."
-                multiline
-              />
-              <Text as="span" variant="t100" color="colorText" margin={{ left: 1, right: 4 }}>
-                {smMatch && 'We store comments on blockchain'}
-              </Text>
+              <Fee amount={fee} color="colorText" variant="t100" hideOnMobile />
             </Flex>
             {onCancel && (
               <Button

--- a/packages/atlas/src/components/_overlays/AlertDialogModal/AlertDialogModal.stories.tsx
+++ b/packages/atlas/src/components/_overlays/AlertDialogModal/AlertDialogModal.stories.tsx
@@ -14,6 +14,7 @@ export default {
     className: { table: { disable: true } },
     show: { table: { disable: true } },
     onExitClick: { table: { disable: true } },
+    fee: { type: 'number' },
   },
   args: {
     title: 'There is an information of the utmost importance!',

--- a/packages/atlas/src/components/_overlays/Dialog/Dialog.tsx
+++ b/packages/atlas/src/components/_overlays/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import { FC, FormEvent, PropsWithChildren, ReactNode, Ref } from 'react'
 
+import { Fee } from '@/components/Fee'
 import { Text } from '@/components/Text'
 import { Button, ButtonProps } from '@/components/_buttons/Button'
 import { SvgActionClose } from '@/components/_icons'
@@ -35,6 +36,7 @@ export type DialogProps = PropsWithChildren<{
   className?: string
   contentClassName?: string
   contentRef?: Ref<HTMLDivElement>
+  fee?: number
 }>
 
 export const Dialog: FC<DialogProps> = ({
@@ -53,10 +55,12 @@ export const Dialog: FC<DialogProps> = ({
   className,
   contentClassName,
   contentRef,
+  fee,
 }) => {
   const isCompact = size === 'compact'
   const smMatch = useMediaMatch('sm')
   const hasFooter = !!additionalActionsNode || !!primaryButton || !!secondaryButton
+  const hasAdditionalActionsNode = !!additionalActionsNode || fee !== undefined
   const buttonSize = isCompact ? 'small' : 'medium'
 
   return (
@@ -84,9 +88,10 @@ export const Dialog: FC<DialogProps> = ({
       {hasFooter && (
         <Footer
           dividers={dividers || actionDivider}
-          data-has-additional-actions={!!additionalActionsNode}
+          data-has-additional-actions={!!hasAdditionalActionsNode}
           additionalActionsNodeMobilePosition={additionalActionsNodeMobilePosition}
         >
+          {fee !== undefined && <Fee amount={fee} variant="h200" color="colorTextStrong" />}
           {additionalActionsNode}
           <FooterButtonsContainer additionalActionsNodeMobilePosition={additionalActionsNodeMobilePosition}>
             {secondaryButton && (

--- a/packages/atlas/src/components/_overlays/DialogModal/DialogModal.stories.tsx
+++ b/packages/atlas/src/components/_overlays/DialogModal/DialogModal.stories.tsx
@@ -17,6 +17,7 @@ export default {
     className: { table: { disable: true } },
     show: { table: { disable: true } },
     headerIcon: { table: { disable: true } },
+    fee: { type: 'number' },
   },
   args: {
     title: 'There is an information of the utmost importance!',

--- a/packages/atlas/src/components/_video/ReactionsOnboardingPopover/ReactionsOnboardingPopover.tsx
+++ b/packages/atlas/src/components/_video/ReactionsOnboardingPopover/ReactionsOnboardingPopover.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, forwardRef } from 'react'
 
+import { NumberFormat } from '@/components/NumberFormat'
 import { Text } from '@/components/Text'
+import { Button } from '@/components/_buttons/Button'
 import { SvgOtherThumbsUpIllustrationSvg } from '@/components/_illustrations'
 import { DialogPopover } from '@/components/_overlays/DialogPopover'
 import { PopoverImperativeHandle } from '@/components/_overlays/Popover'
@@ -13,10 +15,11 @@ type ReactionsOnboardingPopoverProps = {
   onConfirm?: () => void
   disabled?: boolean
   trigger: ReactNode
+  fee?: number
 }
 
 export const ReactionsOnboardingPopover = forwardRef<PopoverImperativeHandle, ReactionsOnboardingPopoverProps>(
-  ({ onDecline, disabled, onConfirm, trigger }, ref) => {
+  ({ onDecline, disabled, onConfirm, trigger, fee = 0 }, ref) => {
     const setReactionPopoverDismission = usePersonalDataStore((state) => state.actions.setReactionPopoverDismission)
 
     return (
@@ -40,6 +43,16 @@ export const ReactionsOnboardingPopover = forwardRef<PopoverImperativeHandle, Re
           text: 'Cancel',
           onClick: onDecline,
         }}
+        additionalActionsNode={
+          <Button
+            size="small"
+            variant="tertiary"
+            to="https://joystream.gitbook.io/testnet-workspace/system/fees"
+            openLinkInNewTab
+          >
+            Learn more
+          </Button>
+        }
         trigger={trigger}
       >
         <PopoverIllustrationWrapper>
@@ -47,11 +60,12 @@ export const ReactionsOnboardingPopover = forwardRef<PopoverImperativeHandle, Re
         </PopoverIllustrationWrapper>
         <PopoverContentWrapper>
           <Text as="h4" variant="h300">
-            We save social interactions on blockchain
+            Comments and reactions are stored on blockchain and come with a fee
           </Text>
           <Text as="p" variant="t200" color="colorText" margin={{ top: 2 }}>
-            Comments and reactions are stored on blockchain, meaning every action needs a wallet signature to take
-            effect. Transaction fees apply.
+            <NumberFormat value={fee} as="span" color="colorText" variant="t200" format="short" withToken /> is the
+            transaction fee for each reaction you leave under a video or comment, while the fee for posting a comment
+            depends on its length.
           </Text>
         </PopoverContentWrapper>
       </DialogPopover>


### PR DESCRIPTION
Closes #2815 

**Designs**
- Designs, docs, and changelog for **comments & reactions** [can be found here](https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=2140%3A135509),
- Designs, docs, and changelog for the **Action bar component** (a footer we display in _NFT minting / buying / bidding_, _Video Posting / editing/ deleting_, _Updating Membership_, _Channel Creation / Editing_) [can be found here](https://www.figma.com/file/Pf31tuYpozYmpq163U2ho8/Web-components?node-id=8477%3A161454),
   - I mentioned this change [in this PR](https://github.com/Joystream/atlas/pull/2857#issuecomment-1160498065), as you requested Klaudiusz.   
- **🆕 NEW** Designs, docs, and changelog for the **Dialog footer component** [can be found here](https://www.figma.com/file/Pf31tuYpozYmpq163U2ho8/Web-components?node-id=8638%3A171330). Once this is implemented, we can proceed with the following changes:
   - Add the fee info to the delete video alert dialog, designs for which [can be found here](https://www.figma.com/file/xm6vBdSnQDroc57rGfGtPM/Video-workspace?node-id=3171%3A168073),
   - Add the fee info to the remove NFT from sale alert dialog, designs for which [can be found here](https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=5076%3A261284),
   - Add the fee info to the remove change NFT price dialiog, designs for which [can be found here](https://www.figma.com/file/sMydmZJlzhK91FTIPOd7D2/Video-page?node-id=4924%3A266241).
