### PR TITLE
properly assign buckets to new channels

### DIFF
--- a/packages/atlas/codegen.config.yml
+++ b/packages/atlas/codegen.config.yml
@@ -1,6 +1,6 @@
 overwrite: true
 
-schema: ${VITE_LOCAL_ORION_URL}
+schema: ${VITE_NEXT_ORION_URL}
 
 documents:
   - './src/api/queries/**/*.graphql'

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -22,7 +22,7 @@
     "svgs:icons-import": "node ./scripts/figma-import --icons",
     "svgs:icons-generate": "svgr --config-file svgr.config.js -d src/components/_icons src/components/_icons/svgs && prettier --write src/components/_icons",
     "svgs:icons": "yarn svgs:icons-import && yarn svgs:icons-generate",
-    "graphql": "rimraf src/api/queries/__generated__ && graphql-codegen --config codegen.config.yml -r dotenv/config",
+    "graphql": "rimraf src/api/queries/__generated__ && DOTENV_CONFIG_PATH=\"./src/.env\" graphql-codegen --config codegen.config.yml -r dotenv/config",
     "test": "vitest run",
     "test:dev": "vitest dev",
     "madge:circular": "madge --circular ./src/* --ts-config ./tsconfig.json --extensions ts,tsx",

--- a/packages/atlas/src/.env
+++ b/packages/atlas/src/.env
@@ -11,10 +11,10 @@ VITE_DEVELOPMENT_NODE_URL=wss://atlas-dev.joystream.org/ws-rpc
 VITE_DEVELOPMENT_FAUCET_URL=https://atlas-dev.joystream.org/member-faucet/register
 VITE_DEVELOPMENT_OFFICIAL_JOYSTREAM_CHANNEL_ID=12
 
-VITE_NEXT_ORION_URL=https://atlas-next.joystream.org/orion/graphql
-VITE_NEXT_QUERY_NODE_SUBSCRIPTION_URL=wss://atlas-next.joystream.org/query-node/server/graphql
-VITE_NEXT_NODE_URL=wss://atlas-next.joystream.org/ws-rpc
-VITE_NEXT_FAUCET_URL=https://atlas-next.joystream.org/member-faucet/register
+VITE_NEXT_ORION_URL=https:/35.175.137.224.nip.io/orion/graphql
+VITE_NEXT_QUERY_NODE_SUBSCRIPTION_URL=wss://35.175.137.224.nip.io/query-node/server/graphql
+VITE_NEXT_NODE_URL=wss://35.175.137.224.nip.io/ws-rpc
+VITE_NEXT_FAUCET_URL=https://35.175.137.224.nip.io/member-faucet/register
 VITE_NEXT_OFFICIAL_JOYSTREAM_CHANNEL_ID=12
 
 VITE_PRODUCTION_ORION_URL=https://orion.joystream.org/graphql

--- a/packages/atlas/src/api/queries/__generated__/baseTypes.generated.ts
+++ b/packages/atlas/src/api/queries/__generated__/baseTypes.generated.ts
@@ -6320,6 +6320,10 @@ export type Channel = BaseGraphQlObject & {
   ownerCuratorGroupId?: Maybe<Scalars['String']>
   ownerMember?: Maybe<Membership>
   ownerMemberId?: Maybe<Scalars['String']>
+  /** Channel's privilege level */
+  privilegeLevel?: Maybe<Scalars['Int']>
+  /** Channel's reward account, storing the income from the nft sales and channel payouts. */
+  rewardAccount: Scalars['String']
   /** The title of the Channel */
   title?: Maybe<Scalars['String']>
   updatedAt?: Maybe<Scalars['DateTime']>
@@ -6328,6 +6332,158 @@ export type Channel = BaseGraphQlObject & {
   videoreactedeventvideoChannel?: Maybe<Array<VideoReactedEvent>>
   videos: Array<Video>
   views: Scalars['Int']
+}
+
+export type ChannelAssetsDeletedByModeratorEvent = BaseGraphQlObject & {
+  __typename?: 'ChannelAssetsDeletedByModeratorEvent'
+  /** Actor that deleted the channel assets. */
+  actor: ContentActor
+  /** ID  of the deleted video */
+  assetIds: Array<Scalars['Int']>
+  /** Channel whose assets are deleted */
+  channelId: Scalars['Int']
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Network the block was produced in. */
+  network: Network
+  /** why the channel assets were deleted */
+  rationale: Scalars['String']
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+}
+
+export type ChannelAssetsDeletedByModeratorEventConnection = {
+  __typename?: 'ChannelAssetsDeletedByModeratorEventConnection'
+  edges: Array<ChannelAssetsDeletedByModeratorEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type ChannelAssetsDeletedByModeratorEventCreateInput = {
+  actor: Scalars['JSONObject']
+  assetIds: Array<Scalars['Int']>
+  channelId: Scalars['Float']
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  network: Network
+  rationale: Scalars['String']
+}
+
+export type ChannelAssetsDeletedByModeratorEventEdge = {
+  __typename?: 'ChannelAssetsDeletedByModeratorEventEdge'
+  cursor: Scalars['String']
+  node: ChannelAssetsDeletedByModeratorEvent
+}
+
+export enum ChannelAssetsDeletedByModeratorEventOrderByInput {
+  ChannelIdAsc = 'channelId_ASC',
+  ChannelIdDesc = 'channelId_DESC',
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  RationaleAsc = 'rationale_ASC',
+  RationaleDesc = 'rationale_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+}
+
+export type ChannelAssetsDeletedByModeratorEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  assetIds?: InputMaybe<Array<Scalars['Int']>>
+  channelId?: InputMaybe<Scalars['Float']>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  network?: InputMaybe<Network>
+  rationale?: InputMaybe<Scalars['String']>
+}
+
+export type ChannelAssetsDeletedByModeratorEventWhereInput = {
+  AND?: InputMaybe<Array<ChannelAssetsDeletedByModeratorEventWhereInput>>
+  NOT?: InputMaybe<Array<ChannelAssetsDeletedByModeratorEventWhereInput>>
+  OR?: InputMaybe<Array<ChannelAssetsDeletedByModeratorEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  assetIds_containsAll?: InputMaybe<Array<Scalars['Int']>>
+  assetIds_containsAny?: InputMaybe<Array<Scalars['Int']>>
+  assetIds_containsNone?: InputMaybe<Array<Scalars['Int']>>
+  channelId_eq?: InputMaybe<Scalars['Int']>
+  channelId_gt?: InputMaybe<Scalars['Int']>
+  channelId_gte?: InputMaybe<Scalars['Int']>
+  channelId_in?: InputMaybe<Array<Scalars['Int']>>
+  channelId_lt?: InputMaybe<Scalars['Int']>
+  channelId_lte?: InputMaybe<Scalars['Int']>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  rationale_contains?: InputMaybe<Scalars['String']>
+  rationale_endsWith?: InputMaybe<Scalars['String']>
+  rationale_eq?: InputMaybe<Scalars['String']>
+  rationale_in?: InputMaybe<Array<Scalars['String']>>
+  rationale_startsWith?: InputMaybe<Scalars['String']>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+}
+
+export type ChannelAssetsDeletedByModeratorEventWhereUniqueInput = {
+  id: Scalars['ID']
 }
 
 export type ChannelCategoriesByNameFtsOutput = {
@@ -6472,7 +6628,154 @@ export type ChannelCreateInput = {
   language?: InputMaybe<Scalars['ID']>
   ownerCuratorGroup?: InputMaybe<Scalars['ID']>
   ownerMember?: InputMaybe<Scalars['ID']>
+  privilegeLevel?: InputMaybe<Scalars['Float']>
+  rewardAccount: Scalars['String']
   title?: InputMaybe<Scalars['String']>
+}
+
+export type ChannelDeletedByModeratorEvent = BaseGraphQlObject & {
+  __typename?: 'ChannelDeletedByModeratorEvent'
+  /** Actor that deleted the video. */
+  actor: ContentActor
+  /** ID  of the deleted channel */
+  channelId: Scalars['Int']
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Network the block was produced in. */
+  network: Network
+  /** Why the video was deleted */
+  rationale: Scalars['String']
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+}
+
+export type ChannelDeletedByModeratorEventConnection = {
+  __typename?: 'ChannelDeletedByModeratorEventConnection'
+  edges: Array<ChannelDeletedByModeratorEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type ChannelDeletedByModeratorEventCreateInput = {
+  actor: Scalars['JSONObject']
+  channelId: Scalars['Float']
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  network: Network
+  rationale: Scalars['String']
+}
+
+export type ChannelDeletedByModeratorEventEdge = {
+  __typename?: 'ChannelDeletedByModeratorEventEdge'
+  cursor: Scalars['String']
+  node: ChannelDeletedByModeratorEvent
+}
+
+export enum ChannelDeletedByModeratorEventOrderByInput {
+  ChannelIdAsc = 'channelId_ASC',
+  ChannelIdDesc = 'channelId_DESC',
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  RationaleAsc = 'rationale_ASC',
+  RationaleDesc = 'rationale_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+}
+
+export type ChannelDeletedByModeratorEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  channelId?: InputMaybe<Scalars['Float']>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  network?: InputMaybe<Network>
+  rationale?: InputMaybe<Scalars['String']>
+}
+
+export type ChannelDeletedByModeratorEventWhereInput = {
+  AND?: InputMaybe<Array<ChannelDeletedByModeratorEventWhereInput>>
+  NOT?: InputMaybe<Array<ChannelDeletedByModeratorEventWhereInput>>
+  OR?: InputMaybe<Array<ChannelDeletedByModeratorEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  channelId_eq?: InputMaybe<Scalars['Int']>
+  channelId_gt?: InputMaybe<Scalars['Int']>
+  channelId_gte?: InputMaybe<Scalars['Int']>
+  channelId_in?: InputMaybe<Array<Scalars['Int']>>
+  channelId_lt?: InputMaybe<Scalars['Int']>
+  channelId_lte?: InputMaybe<Scalars['Int']>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  rationale_contains?: InputMaybe<Scalars['String']>
+  rationale_endsWith?: InputMaybe<Scalars['String']>
+  rationale_eq?: InputMaybe<Scalars['String']>
+  rationale_in?: InputMaybe<Array<Scalars['String']>>
+  rationale_startsWith?: InputMaybe<Scalars['String']>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+}
+
+export type ChannelDeletedByModeratorEventWhereUniqueInput = {
+  id: Scalars['ID']
 }
 
 export type ChannelEdge = {
@@ -6632,6 +6935,10 @@ export enum ChannelOrderByInput {
   OwnerCuratorGroupDesc = 'ownerCuratorGroup_DESC',
   OwnerMemberAsc = 'ownerMember_ASC',
   OwnerMemberDesc = 'ownerMember_DESC',
+  PrivilegeLevelAsc = 'privilegeLevel_ASC',
+  PrivilegeLevelDesc = 'privilegeLevel_DESC',
+  RewardAccountAsc = 'rewardAccount_ASC',
+  RewardAccountDesc = 'rewardAccount_DESC',
   TitleAsc = 'title_ASC',
   TitleDesc = 'title_DESC',
   UpdatedAtAsc = 'updatedAt_ASC',
@@ -6650,6 +6957,8 @@ export type ChannelUpdateInput = {
   language?: InputMaybe<Scalars['ID']>
   ownerCuratorGroup?: InputMaybe<Scalars['ID']>
   ownerMember?: InputMaybe<Scalars['ID']>
+  privilegeLevel?: InputMaybe<Scalars['Float']>
+  rewardAccount?: InputMaybe<Scalars['String']>
   title?: InputMaybe<Scalars['String']>
 }
 
@@ -6734,6 +7043,17 @@ export type ChannelWhereInput = {
   ownednftcreatorChannel_some?: InputMaybe<OwnedNftWhereInput>
   ownerCuratorGroup?: InputMaybe<CuratorGroupWhereInput>
   ownerMember?: InputMaybe<MembershipWhereInput>
+  privilegeLevel_eq?: InputMaybe<Scalars['Int']>
+  privilegeLevel_gt?: InputMaybe<Scalars['Int']>
+  privilegeLevel_gte?: InputMaybe<Scalars['Int']>
+  privilegeLevel_in?: InputMaybe<Array<Scalars['Int']>>
+  privilegeLevel_lt?: InputMaybe<Scalars['Int']>
+  privilegeLevel_lte?: InputMaybe<Scalars['Int']>
+  rewardAccount_contains?: InputMaybe<Scalars['String']>
+  rewardAccount_endsWith?: InputMaybe<Scalars['String']>
+  rewardAccount_eq?: InputMaybe<Scalars['String']>
+  rewardAccount_in?: InputMaybe<Array<Scalars['String']>>
+  rewardAccount_startsWith?: InputMaybe<Scalars['String']>
   title_contains?: InputMaybe<Scalars['String']>
   title_endsWith?: InputMaybe<Scalars['String']>
   title_eq?: InputMaybe<Scalars['String']>
@@ -9689,6 +10009,7 @@ export type ElectionRound = BaseGraphQlObject & {
   id: Scalars['ID']
   /** Sign if election has already finished. */
   isFinished: Scalars['Boolean']
+  newcandidateeventelectionRound?: Maybe<Array<NewCandidateEvent>>
   nextElectedCouncil?: Maybe<ElectedCouncil>
   nextElectedCouncilId?: Maybe<Scalars['String']>
   referendumStageRevealing?: Maybe<ReferendumStageRevealing>
@@ -9803,6 +10124,9 @@ export type ElectionRoundWhereInput = {
   id_in?: InputMaybe<Array<Scalars['ID']>>
   isFinished_eq?: InputMaybe<Scalars['Boolean']>
   isFinished_in?: InputMaybe<Array<Scalars['Boolean']>>
+  newcandidateeventelectionRound_every?: InputMaybe<NewCandidateEventWhereInput>
+  newcandidateeventelectionRound_none?: InputMaybe<NewCandidateEventWhereInput>
+  newcandidateeventelectionRound_some?: InputMaybe<NewCandidateEventWhereInput>
   nextElectedCouncil?: InputMaybe<ElectedCouncilWhereInput>
   referendumStageRevealing?: InputMaybe<ReferendumStageRevealingWhereInput>
   referendumStageVoting?: InputMaybe<ReferendumStageVotingWhereInput>
@@ -14709,6 +15033,8 @@ export type NewCandidateEvent = BaseGraphQlObject &
     createdById: Scalars['ID']
     deletedAt?: Maybe<Scalars['DateTime']>
     deletedById?: Maybe<Scalars['ID']>
+    electionRound: ElectionRound
+    electionRoundId: Scalars['String']
     id: Scalars['ID']
     /** Blocknumber of the block in which the event was emitted. */
     inBlock: Scalars['Int']
@@ -14739,6 +15065,7 @@ export type NewCandidateEventConnection = {
 export type NewCandidateEventCreateInput = {
   balance: Scalars['String']
   candidate: Scalars['ID']
+  electionRound: Scalars['ID']
   inBlock: Scalars['Float']
   inExtrinsic?: InputMaybe<Scalars['String']>
   indexInBlock: Scalars['Float']
@@ -14762,6 +15089,8 @@ export enum NewCandidateEventOrderByInput {
   CreatedAtDesc = 'createdAt_DESC',
   DeletedAtAsc = 'deletedAt_ASC',
   DeletedAtDesc = 'deletedAt_DESC',
+  ElectionRoundAsc = 'electionRound_ASC',
+  ElectionRoundDesc = 'electionRound_DESC',
   InBlockAsc = 'inBlock_ASC',
   InBlockDesc = 'inBlock_DESC',
   InExtrinsicAsc = 'inExtrinsic_ASC',
@@ -14781,6 +15110,7 @@ export enum NewCandidateEventOrderByInput {
 export type NewCandidateEventUpdateInput = {
   balance?: InputMaybe<Scalars['String']>
   candidate?: InputMaybe<Scalars['ID']>
+  electionRound?: InputMaybe<Scalars['ID']>
   inBlock?: InputMaybe<Scalars['Float']>
   inExtrinsic?: InputMaybe<Scalars['String']>
   indexInBlock?: InputMaybe<Scalars['Float']>
@@ -14815,6 +15145,7 @@ export type NewCandidateEventWhereInput = {
   deletedAt_lte?: InputMaybe<Scalars['DateTime']>
   deletedById_eq?: InputMaybe<Scalars['ID']>
   deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  electionRound?: InputMaybe<ElectionRoundWhereInput>
   id_eq?: InputMaybe<Scalars['ID']>
   id_in?: InputMaybe<Array<Scalars['ID']>>
   inBlock_eq?: InputMaybe<Scalars['Int']>
@@ -20660,11 +20991,17 @@ export type Query = {
   categoryStickyThreadUpdateEventByUniqueInput?: Maybe<CategoryStickyThreadUpdateEvent>
   categoryStickyThreadUpdateEvents: Array<CategoryStickyThreadUpdateEvent>
   categoryStickyThreadUpdateEventsConnection: CategoryStickyThreadUpdateEventConnection
+  channelAssetsDeletedByModeratorEventByUniqueInput?: Maybe<ChannelAssetsDeletedByModeratorEvent>
+  channelAssetsDeletedByModeratorEvents: Array<ChannelAssetsDeletedByModeratorEvent>
+  channelAssetsDeletedByModeratorEventsConnection: ChannelAssetsDeletedByModeratorEventConnection
   channelByUniqueInput?: Maybe<Channel>
   channelCategories: Array<ChannelCategory>
   channelCategoriesByName: Array<ChannelCategoriesByNameFtsOutput>
   channelCategoriesConnection: ChannelCategoryConnection
   channelCategoryByUniqueInput?: Maybe<ChannelCategory>
+  channelDeletedByModeratorEventByUniqueInput?: Maybe<ChannelDeletedByModeratorEvent>
+  channelDeletedByModeratorEvents: Array<ChannelDeletedByModeratorEvent>
+  channelDeletedByModeratorEventsConnection: ChannelDeletedByModeratorEventConnection
   channelNftCollectors: Array<ChannelNftCollectors>
   channelNftCollectorsByUniqueInput?: Maybe<ChannelNftCollectors>
   channelNftCollectorsConnection: ChannelNftCollectorsConnection
@@ -21074,11 +21411,20 @@ export type Query = {
   upcomingWorkingGroupOpeningByUniqueInput?: Maybe<UpcomingWorkingGroupOpening>
   upcomingWorkingGroupOpenings: Array<UpcomingWorkingGroupOpening>
   upcomingWorkingGroupOpeningsConnection: UpcomingWorkingGroupOpeningConnection
+  videoAssetsDeletedByModeratorEventByUniqueInput?: Maybe<VideoAssetsDeletedByModeratorEvent>
+  videoAssetsDeletedByModeratorEvents: Array<VideoAssetsDeletedByModeratorEvent>
+  videoAssetsDeletedByModeratorEventsConnection: VideoAssetsDeletedByModeratorEventConnection
   videoByUniqueInput?: Maybe<Video>
   videoCategories: Array<VideoCategory>
   videoCategoriesByName: Array<VideoCategoriesByNameFtsOutput>
   videoCategoriesConnection: VideoCategoryConnection
   videoCategoryByUniqueInput?: Maybe<VideoCategory>
+  videoDeletedByModeratorEventByUniqueInput?: Maybe<VideoDeletedByModeratorEvent>
+  videoDeletedByModeratorEvents: Array<VideoDeletedByModeratorEvent>
+  videoDeletedByModeratorEventsConnection: VideoDeletedByModeratorEventConnection
+  videoDeletedEventByUniqueInput?: Maybe<VideoDeletedEvent>
+  videoDeletedEvents: Array<VideoDeletedEvent>
+  videoDeletedEventsConnection: VideoDeletedEventConnection
   /** Get current video hero */
   videoHero: VideoHero
   videoMediaEncodingByUniqueInput?: Maybe<VideoMediaEncoding>
@@ -21099,6 +21445,9 @@ export type Query = {
   videoReactionsPreferenceEventByUniqueInput?: Maybe<VideoReactionsPreferenceEvent>
   videoReactionsPreferenceEvents: Array<VideoReactionsPreferenceEvent>
   videoReactionsPreferenceEventsConnection: VideoReactionsPreferenceEventConnection
+  videoVisibilitySetByModeratorEventByUniqueInput?: Maybe<VideoVisibilitySetByModeratorEvent>
+  videoVisibilitySetByModeratorEvents: Array<VideoVisibilitySetByModeratorEvent>
+  videoVisibilitySetByModeratorEventsConnection: VideoVisibilitySetByModeratorEventConnection
   videos: Array<Video>
   videosConnection: VideoConnection
   voteCastEventByUniqueInput?: Maybe<VoteCastEvent>
@@ -22031,6 +22380,26 @@ export type QueryCategoryStickyThreadUpdateEventsConnectionArgs = {
   where?: InputMaybe<CategoryStickyThreadUpdateEventWhereInput>
 }
 
+export type QueryChannelAssetsDeletedByModeratorEventByUniqueInputArgs = {
+  where: ChannelAssetsDeletedByModeratorEventWhereUniqueInput
+}
+
+export type QueryChannelAssetsDeletedByModeratorEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<ChannelAssetsDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<ChannelAssetsDeletedByModeratorEventWhereInput>
+}
+
+export type QueryChannelAssetsDeletedByModeratorEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<ChannelAssetsDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<ChannelAssetsDeletedByModeratorEventWhereInput>
+}
+
 export type QueryChannelByUniqueInputArgs = {
   where: ChannelWhereUniqueInput
 }
@@ -22060,6 +22429,26 @@ export type QueryChannelCategoriesConnectionArgs = {
 
 export type QueryChannelCategoryByUniqueInputArgs = {
   where: ChannelCategoryWhereUniqueInput
+}
+
+export type QueryChannelDeletedByModeratorEventByUniqueInputArgs = {
+  where: ChannelDeletedByModeratorEventWhereUniqueInput
+}
+
+export type QueryChannelDeletedByModeratorEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<ChannelDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<ChannelDeletedByModeratorEventWhereInput>
+}
+
+export type QueryChannelDeletedByModeratorEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<ChannelDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<ChannelDeletedByModeratorEventWhereInput>
 }
 
 export type QueryChannelNftCollectorsArgs = {
@@ -24714,6 +25103,26 @@ export type QueryUpcomingWorkingGroupOpeningsConnectionArgs = {
   where?: InputMaybe<UpcomingWorkingGroupOpeningWhereInput>
 }
 
+export type QueryVideoAssetsDeletedByModeratorEventByUniqueInputArgs = {
+  where: VideoAssetsDeletedByModeratorEventWhereUniqueInput
+}
+
+export type QueryVideoAssetsDeletedByModeratorEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoAssetsDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoAssetsDeletedByModeratorEventWhereInput>
+}
+
+export type QueryVideoAssetsDeletedByModeratorEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoAssetsDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoAssetsDeletedByModeratorEventWhereInput>
+}
+
 export type QueryVideoByUniqueInputArgs = {
   where: VideoWhereUniqueInput
 }
@@ -24743,6 +25152,46 @@ export type QueryVideoCategoriesConnectionArgs = {
 
 export type QueryVideoCategoryByUniqueInputArgs = {
   where: VideoCategoryWhereUniqueInput
+}
+
+export type QueryVideoDeletedByModeratorEventByUniqueInputArgs = {
+  where: VideoDeletedByModeratorEventWhereUniqueInput
+}
+
+export type QueryVideoDeletedByModeratorEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoDeletedByModeratorEventWhereInput>
+}
+
+export type QueryVideoDeletedByModeratorEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoDeletedByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoDeletedByModeratorEventWhereInput>
+}
+
+export type QueryVideoDeletedEventByUniqueInputArgs = {
+  where: VideoDeletedEventWhereUniqueInput
+}
+
+export type QueryVideoDeletedEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoDeletedEventOrderByInput>>
+  where?: InputMaybe<VideoDeletedEventWhereInput>
+}
+
+export type QueryVideoDeletedEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoDeletedEventOrderByInput>>
+  where?: InputMaybe<VideoDeletedEventWhereInput>
 }
 
 export type QueryVideoMediaEncodingByUniqueInputArgs = {
@@ -24863,6 +25312,26 @@ export type QueryVideoReactionsPreferenceEventsConnectionArgs = {
   last?: InputMaybe<Scalars['Int']>
   orderBy?: InputMaybe<Array<VideoReactionsPreferenceEventOrderByInput>>
   where?: InputMaybe<VideoReactionsPreferenceEventWhereInput>
+}
+
+export type QueryVideoVisibilitySetByModeratorEventByUniqueInputArgs = {
+  where: VideoVisibilitySetByModeratorEventWhereUniqueInput
+}
+
+export type QueryVideoVisibilitySetByModeratorEventsArgs = {
+  limit?: InputMaybe<Scalars['Int']>
+  offset?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoVisibilitySetByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoVisibilitySetByModeratorEventWhereInput>
+}
+
+export type QueryVideoVisibilitySetByModeratorEventsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']>
+  before?: InputMaybe<Scalars['String']>
+  first?: InputMaybe<Scalars['Int']>
+  last?: InputMaybe<Scalars['Int']>
+  orderBy?: InputMaybe<Array<VideoVisibilitySetByModeratorEventOrderByInput>>
+  where?: InputMaybe<VideoVisibilitySetByModeratorEventWhereInput>
 }
 
 export type QueryVideosArgs = {
@@ -30087,6 +30556,166 @@ export type Video = BaseGraphQlObject & {
   views: Scalars['Int']
 }
 
+export type VideoAssetsDeletedByModeratorEvent = BaseGraphQlObject & {
+  __typename?: 'VideoAssetsDeletedByModeratorEvent'
+  /** Actor that deleted the channel assets. */
+  actor: ContentActor
+  /** Does deleted video assets belongs to NFT */
+  areNftAssets?: Maybe<Scalars['Boolean']>
+  /** ID  of the deleted video */
+  assetIds: Array<Scalars['Int']>
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Network the block was produced in. */
+  network: Network
+  /** why the channel assets were deleted */
+  rationale: Scalars['String']
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+  /** Video whose assets are being deleted */
+  videoId: Scalars['Int']
+}
+
+export type VideoAssetsDeletedByModeratorEventConnection = {
+  __typename?: 'VideoAssetsDeletedByModeratorEventConnection'
+  edges: Array<VideoAssetsDeletedByModeratorEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type VideoAssetsDeletedByModeratorEventCreateInput = {
+  actor: Scalars['JSONObject']
+  areNftAssets?: InputMaybe<Scalars['Boolean']>
+  assetIds: Array<Scalars['Int']>
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  network: Network
+  rationale: Scalars['String']
+  videoId: Scalars['Float']
+}
+
+export type VideoAssetsDeletedByModeratorEventEdge = {
+  __typename?: 'VideoAssetsDeletedByModeratorEventEdge'
+  cursor: Scalars['String']
+  node: VideoAssetsDeletedByModeratorEvent
+}
+
+export enum VideoAssetsDeletedByModeratorEventOrderByInput {
+  AreNftAssetsAsc = 'areNftAssets_ASC',
+  AreNftAssetsDesc = 'areNftAssets_DESC',
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  RationaleAsc = 'rationale_ASC',
+  RationaleDesc = 'rationale_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+  VideoIdAsc = 'videoId_ASC',
+  VideoIdDesc = 'videoId_DESC',
+}
+
+export type VideoAssetsDeletedByModeratorEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  areNftAssets?: InputMaybe<Scalars['Boolean']>
+  assetIds?: InputMaybe<Array<Scalars['Int']>>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  network?: InputMaybe<Network>
+  rationale?: InputMaybe<Scalars['String']>
+  videoId?: InputMaybe<Scalars['Float']>
+}
+
+export type VideoAssetsDeletedByModeratorEventWhereInput = {
+  AND?: InputMaybe<Array<VideoAssetsDeletedByModeratorEventWhereInput>>
+  NOT?: InputMaybe<Array<VideoAssetsDeletedByModeratorEventWhereInput>>
+  OR?: InputMaybe<Array<VideoAssetsDeletedByModeratorEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  areNftAssets_eq?: InputMaybe<Scalars['Boolean']>
+  areNftAssets_in?: InputMaybe<Array<Scalars['Boolean']>>
+  assetIds_containsAll?: InputMaybe<Array<Scalars['Int']>>
+  assetIds_containsAny?: InputMaybe<Array<Scalars['Int']>>
+  assetIds_containsNone?: InputMaybe<Array<Scalars['Int']>>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  rationale_contains?: InputMaybe<Scalars['String']>
+  rationale_endsWith?: InputMaybe<Scalars['String']>
+  rationale_eq?: InputMaybe<Scalars['String']>
+  rationale_in?: InputMaybe<Array<Scalars['String']>>
+  rationale_startsWith?: InputMaybe<Scalars['String']>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+  videoId_eq?: InputMaybe<Scalars['Int']>
+  videoId_gt?: InputMaybe<Scalars['Int']>
+  videoId_gte?: InputMaybe<Scalars['Int']>
+  videoId_in?: InputMaybe<Array<Scalars['Int']>>
+  videoId_lt?: InputMaybe<Scalars['Int']>
+  videoId_lte?: InputMaybe<Scalars['Int']>
+}
+
+export type VideoAssetsDeletedByModeratorEventWhereUniqueInput = {
+  id: Scalars['ID']
+}
+
 export type VideoCategoriesByNameFtsOutput = {
   __typename?: 'VideoCategoriesByNameFTSOutput'
   highlight: Scalars['String']
@@ -30239,6 +30868,285 @@ export type VideoCreateInput = {
   reactionsCount: Scalars['Float']
   thumbnailPhoto?: InputMaybe<Scalars['ID']>
   title?: InputMaybe<Scalars['String']>
+}
+
+export type VideoDeletedByModeratorEvent = BaseGraphQlObject & {
+  __typename?: 'VideoDeletedByModeratorEvent'
+  /** Actor that deleted the video. */
+  actor: ContentActor
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Network the block was produced in. */
+  network: Network
+  /** Why the video was deleted */
+  rationale: Scalars['String']
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+  /** ID  of the deleted video */
+  videoId: Scalars['Int']
+}
+
+export type VideoDeletedByModeratorEventConnection = {
+  __typename?: 'VideoDeletedByModeratorEventConnection'
+  edges: Array<VideoDeletedByModeratorEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type VideoDeletedByModeratorEventCreateInput = {
+  actor: Scalars['JSONObject']
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  network: Network
+  rationale: Scalars['String']
+  videoId: Scalars['Float']
+}
+
+export type VideoDeletedByModeratorEventEdge = {
+  __typename?: 'VideoDeletedByModeratorEventEdge'
+  cursor: Scalars['String']
+  node: VideoDeletedByModeratorEvent
+}
+
+export enum VideoDeletedByModeratorEventOrderByInput {
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  RationaleAsc = 'rationale_ASC',
+  RationaleDesc = 'rationale_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+  VideoIdAsc = 'videoId_ASC',
+  VideoIdDesc = 'videoId_DESC',
+}
+
+export type VideoDeletedByModeratorEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  network?: InputMaybe<Network>
+  rationale?: InputMaybe<Scalars['String']>
+  videoId?: InputMaybe<Scalars['Float']>
+}
+
+export type VideoDeletedByModeratorEventWhereInput = {
+  AND?: InputMaybe<Array<VideoDeletedByModeratorEventWhereInput>>
+  NOT?: InputMaybe<Array<VideoDeletedByModeratorEventWhereInput>>
+  OR?: InputMaybe<Array<VideoDeletedByModeratorEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  rationale_contains?: InputMaybe<Scalars['String']>
+  rationale_endsWith?: InputMaybe<Scalars['String']>
+  rationale_eq?: InputMaybe<Scalars['String']>
+  rationale_in?: InputMaybe<Array<Scalars['String']>>
+  rationale_startsWith?: InputMaybe<Scalars['String']>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+  videoId_eq?: InputMaybe<Scalars['Int']>
+  videoId_gt?: InputMaybe<Scalars['Int']>
+  videoId_gte?: InputMaybe<Scalars['Int']>
+  videoId_in?: InputMaybe<Array<Scalars['Int']>>
+  videoId_lt?: InputMaybe<Scalars['Int']>
+  videoId_lte?: InputMaybe<Scalars['Int']>
+}
+
+export type VideoDeletedByModeratorEventWhereUniqueInput = {
+  id: Scalars['ID']
+}
+
+export type VideoDeletedEvent = BaseGraphQlObject & {
+  __typename?: 'VideoDeletedEvent'
+  /** Actor that deleted the video. */
+  actor: ContentActor
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Network the block was produced in. */
+  network: Network
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+  /** ID  of the deleted video */
+  videoId: Scalars['Int']
+}
+
+export type VideoDeletedEventConnection = {
+  __typename?: 'VideoDeletedEventConnection'
+  edges: Array<VideoDeletedEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type VideoDeletedEventCreateInput = {
+  actor: Scalars['JSONObject']
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  network: Network
+  videoId: Scalars['Float']
+}
+
+export type VideoDeletedEventEdge = {
+  __typename?: 'VideoDeletedEventEdge'
+  cursor: Scalars['String']
+  node: VideoDeletedEvent
+}
+
+export enum VideoDeletedEventOrderByInput {
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+  VideoIdAsc = 'videoId_ASC',
+  VideoIdDesc = 'videoId_DESC',
+}
+
+export type VideoDeletedEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  network?: InputMaybe<Network>
+  videoId?: InputMaybe<Scalars['Float']>
+}
+
+export type VideoDeletedEventWhereInput = {
+  AND?: InputMaybe<Array<VideoDeletedEventWhereInput>>
+  NOT?: InputMaybe<Array<VideoDeletedEventWhereInput>>
+  OR?: InputMaybe<Array<VideoDeletedEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+  videoId_eq?: InputMaybe<Scalars['Int']>
+  videoId_gt?: InputMaybe<Scalars['Int']>
+  videoId_gte?: InputMaybe<Scalars['Int']>
+  videoId_in?: InputMaybe<Array<Scalars['Int']>>
+  videoId_lt?: InputMaybe<Scalars['Int']>
+  videoId_lte?: InputMaybe<Scalars['Int']>
+}
+
+export type VideoDeletedEventWhereUniqueInput = {
+  id: Scalars['ID']
 }
 
 export type VideoEdge = {
@@ -31076,6 +31984,159 @@ export type VideoUpdateInput = {
   reactionsCount?: InputMaybe<Scalars['Float']>
   thumbnailPhoto?: InputMaybe<Scalars['ID']>
   title?: InputMaybe<Scalars['String']>
+}
+
+export type VideoVisibilitySetByModeratorEvent = BaseGraphQlObject & {
+  __typename?: 'VideoVisibilitySetByModeratorEvent'
+  /** Actor that deleted the channel assets. */
+  actor: ContentActor
+  createdAt: Scalars['DateTime']
+  createdById: Scalars['ID']
+  deletedAt?: Maybe<Scalars['DateTime']>
+  deletedById?: Maybe<Scalars['ID']>
+  id: Scalars['ID']
+  /** Blocknumber of the block in which the event was emitted. */
+  inBlock: Scalars['Int']
+  /** Hash of the extrinsic which caused the event to be emitted. */
+  inExtrinsic?: Maybe<Scalars['String']>
+  /** Index of event in block from which it was emitted. */
+  indexInBlock: Scalars['Int']
+  /** Is video being censored/hidden (yes if true) */
+  isHidden: Scalars['Boolean']
+  /** Network the block was produced in. */
+  network: Network
+  /** Why video's visibality status was set */
+  rationale: Scalars['String']
+  updatedAt?: Maybe<Scalars['DateTime']>
+  updatedById?: Maybe<Scalars['ID']>
+  version: Scalars['Int']
+  /** Video whose visiblity/censorship status is changed */
+  videoId: Scalars['Int']
+}
+
+export type VideoVisibilitySetByModeratorEventConnection = {
+  __typename?: 'VideoVisibilitySetByModeratorEventConnection'
+  edges: Array<VideoVisibilitySetByModeratorEventEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']
+}
+
+export type VideoVisibilitySetByModeratorEventCreateInput = {
+  actor: Scalars['JSONObject']
+  inBlock: Scalars['Float']
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock: Scalars['Float']
+  isHidden: Scalars['Boolean']
+  network: Network
+  rationale: Scalars['String']
+  videoId: Scalars['Float']
+}
+
+export type VideoVisibilitySetByModeratorEventEdge = {
+  __typename?: 'VideoVisibilitySetByModeratorEventEdge'
+  cursor: Scalars['String']
+  node: VideoVisibilitySetByModeratorEvent
+}
+
+export enum VideoVisibilitySetByModeratorEventOrderByInput {
+  CreatedAtAsc = 'createdAt_ASC',
+  CreatedAtDesc = 'createdAt_DESC',
+  DeletedAtAsc = 'deletedAt_ASC',
+  DeletedAtDesc = 'deletedAt_DESC',
+  InBlockAsc = 'inBlock_ASC',
+  InBlockDesc = 'inBlock_DESC',
+  InExtrinsicAsc = 'inExtrinsic_ASC',
+  InExtrinsicDesc = 'inExtrinsic_DESC',
+  IndexInBlockAsc = 'indexInBlock_ASC',
+  IndexInBlockDesc = 'indexInBlock_DESC',
+  IsHiddenAsc = 'isHidden_ASC',
+  IsHiddenDesc = 'isHidden_DESC',
+  NetworkAsc = 'network_ASC',
+  NetworkDesc = 'network_DESC',
+  RationaleAsc = 'rationale_ASC',
+  RationaleDesc = 'rationale_DESC',
+  UpdatedAtAsc = 'updatedAt_ASC',
+  UpdatedAtDesc = 'updatedAt_DESC',
+  VideoIdAsc = 'videoId_ASC',
+  VideoIdDesc = 'videoId_DESC',
+}
+
+export type VideoVisibilitySetByModeratorEventUpdateInput = {
+  actor?: InputMaybe<Scalars['JSONObject']>
+  inBlock?: InputMaybe<Scalars['Float']>
+  inExtrinsic?: InputMaybe<Scalars['String']>
+  indexInBlock?: InputMaybe<Scalars['Float']>
+  isHidden?: InputMaybe<Scalars['Boolean']>
+  network?: InputMaybe<Network>
+  rationale?: InputMaybe<Scalars['String']>
+  videoId?: InputMaybe<Scalars['Float']>
+}
+
+export type VideoVisibilitySetByModeratorEventWhereInput = {
+  AND?: InputMaybe<Array<VideoVisibilitySetByModeratorEventWhereInput>>
+  NOT?: InputMaybe<Array<VideoVisibilitySetByModeratorEventWhereInput>>
+  OR?: InputMaybe<Array<VideoVisibilitySetByModeratorEventWhereInput>>
+  actor_json?: InputMaybe<Scalars['JSONObject']>
+  createdAt_eq?: InputMaybe<Scalars['DateTime']>
+  createdAt_gt?: InputMaybe<Scalars['DateTime']>
+  createdAt_gte?: InputMaybe<Scalars['DateTime']>
+  createdAt_lt?: InputMaybe<Scalars['DateTime']>
+  createdAt_lte?: InputMaybe<Scalars['DateTime']>
+  createdById_eq?: InputMaybe<Scalars['ID']>
+  createdById_in?: InputMaybe<Array<Scalars['ID']>>
+  deletedAt_all?: InputMaybe<Scalars['Boolean']>
+  deletedAt_eq?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_gte?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lt?: InputMaybe<Scalars['DateTime']>
+  deletedAt_lte?: InputMaybe<Scalars['DateTime']>
+  deletedById_eq?: InputMaybe<Scalars['ID']>
+  deletedById_in?: InputMaybe<Array<Scalars['ID']>>
+  id_eq?: InputMaybe<Scalars['ID']>
+  id_in?: InputMaybe<Array<Scalars['ID']>>
+  inBlock_eq?: InputMaybe<Scalars['Int']>
+  inBlock_gt?: InputMaybe<Scalars['Int']>
+  inBlock_gte?: InputMaybe<Scalars['Int']>
+  inBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  inBlock_lt?: InputMaybe<Scalars['Int']>
+  inBlock_lte?: InputMaybe<Scalars['Int']>
+  inExtrinsic_contains?: InputMaybe<Scalars['String']>
+  inExtrinsic_endsWith?: InputMaybe<Scalars['String']>
+  inExtrinsic_eq?: InputMaybe<Scalars['String']>
+  inExtrinsic_in?: InputMaybe<Array<Scalars['String']>>
+  inExtrinsic_startsWith?: InputMaybe<Scalars['String']>
+  indexInBlock_eq?: InputMaybe<Scalars['Int']>
+  indexInBlock_gt?: InputMaybe<Scalars['Int']>
+  indexInBlock_gte?: InputMaybe<Scalars['Int']>
+  indexInBlock_in?: InputMaybe<Array<Scalars['Int']>>
+  indexInBlock_lt?: InputMaybe<Scalars['Int']>
+  indexInBlock_lte?: InputMaybe<Scalars['Int']>
+  isHidden_eq?: InputMaybe<Scalars['Boolean']>
+  isHidden_in?: InputMaybe<Array<Scalars['Boolean']>>
+  network_eq?: InputMaybe<Network>
+  network_in?: InputMaybe<Array<Network>>
+  rationale_contains?: InputMaybe<Scalars['String']>
+  rationale_endsWith?: InputMaybe<Scalars['String']>
+  rationale_eq?: InputMaybe<Scalars['String']>
+  rationale_in?: InputMaybe<Array<Scalars['String']>>
+  rationale_startsWith?: InputMaybe<Scalars['String']>
+  updatedAt_eq?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_gte?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lt?: InputMaybe<Scalars['DateTime']>
+  updatedAt_lte?: InputMaybe<Scalars['DateTime']>
+  updatedById_eq?: InputMaybe<Scalars['ID']>
+  updatedById_in?: InputMaybe<Array<Scalars['ID']>>
+  videoId_eq?: InputMaybe<Scalars['Int']>
+  videoId_gt?: InputMaybe<Scalars['Int']>
+  videoId_gte?: InputMaybe<Scalars['Int']>
+  videoId_in?: InputMaybe<Array<Scalars['Int']>>
+  videoId_lt?: InputMaybe<Scalars['Int']>
+  videoId_lte?: InputMaybe<Scalars['Int']>
+}
+
+export type VideoVisibilitySetByModeratorEventWhereUniqueInput = {
+  id: Scalars['ID']
 }
 
 export type VideoWhereInput = {

--- a/packages/atlas/src/api/queries/__generated__/storage.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/storage.generated.tsx
@@ -5,9 +5,9 @@ import * as Types from './baseTypes.generated'
 import { DistributionBucketOperatorFieldFragmentDoc } from './fragments.generated'
 
 const defaultOptions = {} as const
-export type GetDistributionBucketsWithOperatorsQueryVariables = Types.Exact<{ [key: string]: never }>
+export type GetDistributionBucketsWithBagsQueryVariables = Types.Exact<{ [key: string]: never }>
 
-export type GetDistributionBucketsWithOperatorsQuery = {
+export type GetDistributionBucketsWithBagsQuery = {
   __typename?: 'Query'
   distributionBuckets: Array<{
     __typename?: 'DistributionBucket'
@@ -29,9 +29,9 @@ export type GetDistributionBucketsWithOperatorsQuery = {
   }>
 }
 
-export type GetStorageBucketsQueryVariables = Types.Exact<{ [key: string]: never }>
+export type GetStorageBucketsWithBagsQueryVariables = Types.Exact<{ [key: string]: never }>
 
-export type GetStorageBucketsQuery = {
+export type GetStorageBucketsWithBagsQuery = {
   __typename?: 'Query'
   storageBuckets: Array<{
     __typename?: 'StorageBucket'
@@ -41,9 +41,28 @@ export type GetStorageBucketsQuery = {
   }>
 }
 
-export const GetDistributionBucketsWithOperatorsDocument = gql`
-  query GetDistributionBucketsWithOperators {
-    distributionBuckets(limit: 50, where: { distributing_eq: true }) {
+export type GetBasicDistributionBucketsQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetBasicDistributionBucketsQuery = {
+  __typename?: 'Query'
+  distributionBuckets: Array<{
+    __typename?: 'DistributionBucket'
+    id: string
+    bucketIndex: number
+    family: { __typename?: 'DistributionBucketFamily'; id: string }
+  }>
+}
+
+export type GetBasicStorageBucketsQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type GetBasicStorageBucketsQuery = {
+  __typename?: 'Query'
+  storageBuckets: Array<{ __typename?: 'StorageBucket'; id: string }>
+}
+
+export const GetDistributionBucketsWithBagsDocument = gql`
+  query GetDistributionBucketsWithBags {
+    distributionBuckets(limit: 500, where: { distributing_eq: true }) {
       id
       bags {
         id
@@ -57,58 +76,56 @@ export const GetDistributionBucketsWithOperatorsDocument = gql`
 `
 
 /**
- * __useGetDistributionBucketsWithOperatorsQuery__
+ * __useGetDistributionBucketsWithBagsQuery__
  *
- * To run a query within a React component, call `useGetDistributionBucketsWithOperatorsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetDistributionBucketsWithOperatorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetDistributionBucketsWithBagsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetDistributionBucketsWithBagsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetDistributionBucketsWithOperatorsQuery({
+ * const { data, loading, error } = useGetDistributionBucketsWithBagsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useGetDistributionBucketsWithOperatorsQuery(
+export function useGetDistributionBucketsWithBagsQuery(
   baseOptions?: Apollo.QueryHookOptions<
-    GetDistributionBucketsWithOperatorsQuery,
-    GetDistributionBucketsWithOperatorsQueryVariables
+    GetDistributionBucketsWithBagsQuery,
+    GetDistributionBucketsWithBagsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetDistributionBucketsWithOperatorsQuery, GetDistributionBucketsWithOperatorsQueryVariables>(
-    GetDistributionBucketsWithOperatorsDocument,
+  return Apollo.useQuery<GetDistributionBucketsWithBagsQuery, GetDistributionBucketsWithBagsQueryVariables>(
+    GetDistributionBucketsWithBagsDocument,
     options
   )
 }
-export function useGetDistributionBucketsWithOperatorsLazyQuery(
+export function useGetDistributionBucketsWithBagsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetDistributionBucketsWithOperatorsQuery,
-    GetDistributionBucketsWithOperatorsQueryVariables
+    GetDistributionBucketsWithBagsQuery,
+    GetDistributionBucketsWithBagsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<
-    GetDistributionBucketsWithOperatorsQuery,
-    GetDistributionBucketsWithOperatorsQueryVariables
-  >(GetDistributionBucketsWithOperatorsDocument, options)
+  return Apollo.useLazyQuery<GetDistributionBucketsWithBagsQuery, GetDistributionBucketsWithBagsQueryVariables>(
+    GetDistributionBucketsWithBagsDocument,
+    options
+  )
 }
-export type GetDistributionBucketsWithOperatorsQueryHookResult = ReturnType<
-  typeof useGetDistributionBucketsWithOperatorsQuery
+export type GetDistributionBucketsWithBagsQueryHookResult = ReturnType<typeof useGetDistributionBucketsWithBagsQuery>
+export type GetDistributionBucketsWithBagsLazyQueryHookResult = ReturnType<
+  typeof useGetDistributionBucketsWithBagsLazyQuery
 >
-export type GetDistributionBucketsWithOperatorsLazyQueryHookResult = ReturnType<
-  typeof useGetDistributionBucketsWithOperatorsLazyQuery
+export type GetDistributionBucketsWithBagsQueryResult = Apollo.QueryResult<
+  GetDistributionBucketsWithBagsQuery,
+  GetDistributionBucketsWithBagsQueryVariables
 >
-export type GetDistributionBucketsWithOperatorsQueryResult = Apollo.QueryResult<
-  GetDistributionBucketsWithOperatorsQuery,
-  GetDistributionBucketsWithOperatorsQueryVariables
->
-export const GetStorageBucketsDocument = gql`
-  query GetStorageBuckets {
+export const GetStorageBucketsWithBagsDocument = gql`
+  query GetStorageBucketsWithBags {
     storageBuckets(
-      limit: 50
+      limit: 500
       where: {
         operatorStatus_json: { isTypeOf_eq: "StorageBucketOperatorStatusActive" }
         operatorMetadata: { nodeEndpoint_contains: "http" }
@@ -126,35 +143,139 @@ export const GetStorageBucketsDocument = gql`
 `
 
 /**
- * __useGetStorageBucketsQuery__
+ * __useGetStorageBucketsWithBagsQuery__
  *
- * To run a query within a React component, call `useGetStorageBucketsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetStorageBucketsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetStorageBucketsWithBagsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStorageBucketsWithBagsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetStorageBucketsQuery({
+ * const { data, loading, error } = useGetStorageBucketsWithBagsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useGetStorageBucketsQuery(
-  baseOptions?: Apollo.QueryHookOptions<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>
+export function useGetStorageBucketsWithBagsQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetStorageBucketsWithBagsQuery, GetStorageBucketsWithBagsQueryVariables>
 ) {
   const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useQuery<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>(GetStorageBucketsDocument, options)
-}
-export function useGetStorageBucketsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useLazyQuery<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>(
-    GetStorageBucketsDocument,
+  return Apollo.useQuery<GetStorageBucketsWithBagsQuery, GetStorageBucketsWithBagsQueryVariables>(
+    GetStorageBucketsWithBagsDocument,
     options
   )
 }
-export type GetStorageBucketsQueryHookResult = ReturnType<typeof useGetStorageBucketsQuery>
-export type GetStorageBucketsLazyQueryHookResult = ReturnType<typeof useGetStorageBucketsLazyQuery>
-export type GetStorageBucketsQueryResult = Apollo.QueryResult<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>
+export function useGetStorageBucketsWithBagsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetStorageBucketsWithBagsQuery, GetStorageBucketsWithBagsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetStorageBucketsWithBagsQuery, GetStorageBucketsWithBagsQueryVariables>(
+    GetStorageBucketsWithBagsDocument,
+    options
+  )
+}
+export type GetStorageBucketsWithBagsQueryHookResult = ReturnType<typeof useGetStorageBucketsWithBagsQuery>
+export type GetStorageBucketsWithBagsLazyQueryHookResult = ReturnType<typeof useGetStorageBucketsWithBagsLazyQuery>
+export type GetStorageBucketsWithBagsQueryResult = Apollo.QueryResult<
+  GetStorageBucketsWithBagsQuery,
+  GetStorageBucketsWithBagsQueryVariables
+>
+export const GetBasicDistributionBucketsDocument = gql`
+  query GetBasicDistributionBuckets {
+    distributionBuckets(limit: 500, where: { acceptingNewBags_eq: true }) {
+      id
+      bucketIndex
+      family {
+        id
+      }
+    }
+  }
+`
+
+/**
+ * __useGetBasicDistributionBucketsQuery__
+ *
+ * To run a query within a React component, call `useGetBasicDistributionBucketsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetBasicDistributionBucketsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetBasicDistributionBucketsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetBasicDistributionBucketsQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetBasicDistributionBucketsQuery, GetBasicDistributionBucketsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetBasicDistributionBucketsQuery, GetBasicDistributionBucketsQueryVariables>(
+    GetBasicDistributionBucketsDocument,
+    options
+  )
+}
+export function useGetBasicDistributionBucketsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetBasicDistributionBucketsQuery, GetBasicDistributionBucketsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetBasicDistributionBucketsQuery, GetBasicDistributionBucketsQueryVariables>(
+    GetBasicDistributionBucketsDocument,
+    options
+  )
+}
+export type GetBasicDistributionBucketsQueryHookResult = ReturnType<typeof useGetBasicDistributionBucketsQuery>
+export type GetBasicDistributionBucketsLazyQueryHookResult = ReturnType<typeof useGetBasicDistributionBucketsLazyQuery>
+export type GetBasicDistributionBucketsQueryResult = Apollo.QueryResult<
+  GetBasicDistributionBucketsQuery,
+  GetBasicDistributionBucketsQueryVariables
+>
+export const GetBasicStorageBucketsDocument = gql`
+  query GetBasicStorageBuckets {
+    storageBuckets(limit: 500, where: { acceptingNewBags_eq: true }) {
+      id
+    }
+  }
+`
+
+/**
+ * __useGetBasicStorageBucketsQuery__
+ *
+ * To run a query within a React component, call `useGetBasicStorageBucketsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetBasicStorageBucketsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetBasicStorageBucketsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetBasicStorageBucketsQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetBasicStorageBucketsQuery, GetBasicStorageBucketsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetBasicStorageBucketsQuery, GetBasicStorageBucketsQueryVariables>(
+    GetBasicStorageBucketsDocument,
+    options
+  )
+}
+export function useGetBasicStorageBucketsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetBasicStorageBucketsQuery, GetBasicStorageBucketsQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetBasicStorageBucketsQuery, GetBasicStorageBucketsQueryVariables>(
+    GetBasicStorageBucketsDocument,
+    options
+  )
+}
+export type GetBasicStorageBucketsQueryHookResult = ReturnType<typeof useGetBasicStorageBucketsQuery>
+export type GetBasicStorageBucketsLazyQueryHookResult = ReturnType<typeof useGetBasicStorageBucketsLazyQuery>
+export type GetBasicStorageBucketsQueryResult = Apollo.QueryResult<
+  GetBasicStorageBucketsQuery,
+  GetBasicStorageBucketsQueryVariables
+>

--- a/packages/atlas/src/api/queries/storage.graphql
+++ b/packages/atlas/src/api/queries/storage.graphql
@@ -1,5 +1,5 @@
-query GetDistributionBucketsWithOperators {
-  distributionBuckets(limit: 50, where: { distributing_eq: true }) {
+query GetDistributionBucketsWithBags {
+  distributionBuckets(limit: 500, where: { distributing_eq: true }) {
     id
     bags {
       id
@@ -10,9 +10,9 @@ query GetDistributionBucketsWithOperators {
   }
 }
 
-query GetStorageBuckets {
+query GetStorageBucketsWithBags {
   storageBuckets(
-    limit: 50
+    limit: 500
     where: {
       operatorStatus_json: { isTypeOf_eq: "StorageBucketOperatorStatusActive" }
       operatorMetadata: { nodeEndpoint_contains: "http" }
@@ -25,5 +25,21 @@ query GetStorageBuckets {
     bags {
       id
     }
+  }
+}
+
+query GetBasicDistributionBuckets {
+  distributionBuckets(limit: 500, where: { acceptingNewBags_eq: true }) {
+    id
+    bucketIndex
+    family {
+      id
+    }
+  }
+}
+
+query GetBasicStorageBuckets {
+  storageBuckets(limit: 500, where: { acceptingNewBags_eq: true }) {
+    id
   }
 }

--- a/packages/atlas/src/config/joystream.ts
+++ b/packages/atlas/src/config/joystream.ts
@@ -1,3 +1,21 @@
 export const JOY_CURRENCY_TICKER = 'tJOY'
 export const JOYSTREAM_SS58_PREFIX = 126
 export const HAPI_TO_JOY_RATE = 10 ** 10
+
+// config taken from Rhodes testnet
+export const NEW_CHANNEL_DISTRIBUTION_BUCKETS_PER_FAMILY: Record<number, number> = {
+  0: 3,
+  1: 3,
+  2: 2,
+  3: 1,
+  4: 1,
+  5: 1,
+  6: 1,
+  7: 1,
+  8: 1,
+  9: 1,
+  10: 1,
+  11: 1,
+  12: 1,
+}
+export const NEW_CHANNEL_STORAGE_BUCKETS_COUNT = 5

--- a/packages/atlas/src/joystream-lib/config.ts
+++ b/packages/atlas/src/joystream-lib/config.ts
@@ -1,21 +1,3 @@
 export const NFT_DEFAULT_BID_LOCK_DURATION = 30 * 10 // 10 blocks is 1 minute
 export const NFT_DEFAULT_EXTENSION_PERIOD = 5
 export const NFT_PERBILL_PERCENT = 10_000_000
-
-export const DISTRIBUTION_BUCKETS_PER_FAMILY: Record<string, number> = {
-  '0': 3,
-  '1': 3,
-  '2': 2,
-  '3': 1,
-  '4': 1,
-  '5': 1,
-  '6': 1,
-  '7': 1,
-  '8': 1,
-  '9': 1,
-  '10': 1,
-  '11': 1,
-  '12': 1,
-}
-
-export const STORAGE_BUCKETS_COUNT = 2

--- a/packages/atlas/src/providers/assets/assets.provider.tsx
+++ b/packages/atlas/src/providers/assets/assets.provider.tsx
@@ -18,12 +18,12 @@ import {
 import { useLocation } from 'react-router'
 
 import {
-  GetDistributionBucketsWithOperatorsDocument,
-  GetDistributionBucketsWithOperatorsQuery,
-  GetDistributionBucketsWithOperatorsQueryVariables,
-  GetStorageBucketsDocument,
-  GetStorageBucketsQuery,
-  GetStorageBucketsQueryVariables,
+  GetDistributionBucketsWithBagsDocument,
+  GetDistributionBucketsWithBagsQuery,
+  GetDistributionBucketsWithBagsQueryVariables,
+  GetStorageBucketsWithBagsDocument,
+  GetStorageBucketsWithBagsQuery,
+  GetStorageBucketsWithBagsQueryVariables,
 } from '@/api/queries'
 import { ViewErrorFallback } from '@/components/ViewErrorFallback'
 import { ASSET_MIN_DISTRIBUTOR_REFETCH_TIME } from '@/config/assets'
@@ -70,10 +70,10 @@ export const OperatorsContextProvider: FC<PropsWithChildren> = ({ children }) =>
     const now = new Date()
     let userCoordinates: UserCoordinates | null = null
     const distributionOperatorsPromise = client.query<
-      GetDistributionBucketsWithOperatorsQuery,
-      GetDistributionBucketsWithOperatorsQueryVariables
+      GetDistributionBucketsWithBagsQuery,
+      GetDistributionBucketsWithBagsQueryVariables
     >({
-      query: GetDistributionBucketsWithOperatorsDocument,
+      query: GetDistributionBucketsWithBagsDocument,
       fetchPolicy: 'network-only',
     })
     if ((!coordinates || !expiry || now.getTime() > expiry) && !disableUserLocation) {
@@ -138,8 +138,11 @@ export const OperatorsContextProvider: FC<PropsWithChildren> = ({ children }) =>
   }, [client, coordinates, disableUserLocation, expiry, setUserLocation])
 
   const fetchStorageOperators = useCallback(() => {
-    const storageOperatorsPromise = client.query<GetStorageBucketsQuery, GetStorageBucketsQueryVariables>({
-      query: GetStorageBucketsDocument,
+    const storageOperatorsPromise = client.query<
+      GetStorageBucketsWithBagsQuery,
+      GetStorageBucketsWithBagsQueryVariables
+    >({
+      query: GetStorageBucketsWithBagsDocument,
       fetchPolicy: 'network-only',
     })
     storageOperatorsMappingPromiseRef.current = storageOperatorsPromise.then((result) => {

--- a/packages/atlas/src/providers/joystream/joystream.hooks.ts
+++ b/packages/atlas/src/providers/joystream/joystream.hooks.ts
@@ -1,6 +1,18 @@
+import { useApolloClient } from '@apollo/client'
 import BN from 'bn.js'
-import { useCallback, useContext } from 'react'
+import { sampleSize } from 'lodash-es'
+import { useCallback, useContext, useEffect, useRef } from 'react'
 
+import {
+  GetBasicDistributionBucketsDocument,
+  GetBasicDistributionBucketsQuery,
+  GetBasicDistributionBucketsQueryVariables,
+  GetBasicStorageBucketsDocument,
+  GetBasicStorageBucketsQuery,
+  GetBasicStorageBucketsQueryVariables,
+} from '@/api/queries'
+import { NEW_CHANNEL_DISTRIBUTION_BUCKETS_PER_FAMILY, NEW_CHANNEL_STORAGE_BUCKETS_COUNT } from '@/config/joystream'
+import { ChannelInputBuckets } from '@/joystream-lib'
 import { hapiBnToTokenNumber, tokenNumberToHapiBn } from '@/utils/number'
 
 import { JoystreamContext, JoystreamContextValue } from './joystream.provider'
@@ -35,4 +47,75 @@ export const useTokenPrice = () => {
     convertToTokenPrice,
     isLoadingPrice,
   }
+}
+
+export const useBucketsConfigForNewChannel = () => {
+  const allStorageBuckets = useRef<number[]>()
+  const allDistributionFamiliesToBucketsMapping = useRef<Record<number, number[]>>()
+
+  const client = useApolloClient()
+
+  // get all storage buckets
+  useEffect(() => {
+    const storageBucketsPromise = client.query<GetBasicStorageBucketsQuery, GetBasicStorageBucketsQueryVariables>({
+      query: GetBasicStorageBucketsDocument,
+      fetchPolicy: 'network-only',
+    })
+
+    storageBucketsPromise.then(({ data }) => {
+      allStorageBuckets.current = (data as GetBasicStorageBucketsQuery).storageBuckets.map(({ id }) => parseInt(id))
+    })
+  }, [client])
+
+  // get all distribution buckets
+  useEffect(() => {
+    const distributionBucketsPromise = client.query<
+      GetBasicDistributionBucketsQuery,
+      GetBasicDistributionBucketsQueryVariables
+    >({
+      query: GetBasicDistributionBucketsDocument,
+      fetchPolicy: 'network-only',
+    })
+
+    distributionBucketsPromise.then(({ data }) => {
+      allDistributionFamiliesToBucketsMapping.current = (
+        data as GetBasicDistributionBucketsQuery
+      ).distributionBuckets.reduce((acc, cur) => {
+        const familyId = parseInt(cur.family.id)
+        if (!acc[familyId]) {
+          acc[familyId] = []
+        }
+
+        acc[familyId].push(cur.bucketIndex)
+
+        return acc
+      }, {} as Record<number, number[]>)
+    })
+  }, [client])
+
+  const getBucketsConfigForNewChannel = useCallback((): ChannelInputBuckets => {
+    const storageBuckets = allStorageBuckets.current
+    const distributionFamiliesToBucketsMapping = allDistributionFamiliesToBucketsMapping.current
+
+    const storage = storageBuckets ? sampleSize(storageBuckets, NEW_CHANNEL_STORAGE_BUCKETS_COUNT) : []
+    const distribution = distributionFamiliesToBucketsMapping
+      ? Object.entries(distributionFamiliesToBucketsMapping).reduce((acc, [familyIdStr, buckets]) => {
+          const familyId = parseInt(familyIdStr)
+          const familyBuckets: ChannelInputBuckets['distribution'] = sampleSize(
+            buckets,
+            NEW_CHANNEL_DISTRIBUTION_BUCKETS_PER_FAMILY[familyId]
+          ).map((bucketIndex) => ({ distributionBucketIndex: bucketIndex, distributionBucketFamilyId: familyId }))
+          return [...acc, ...familyBuckets]
+        }, [] as ChannelInputBuckets['distribution'])
+      : []
+
+    return {
+      storage: storage.length ? storage : [0],
+      distribution: distribution.length
+        ? distribution
+        : [{ distributionBucketFamilyId: 0, distributionBucketIndex: 0 }],
+    }
+  }, [])
+
+  return getBucketsConfigForNewChannel
 }

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -28,7 +28,7 @@ import { useHeadTags } from '@/hooks/useHeadTags'
 import { ChannelExtrinsicResult, ChannelInputAssets, ChannelInputMetadata } from '@/joystream-lib'
 import { useAsset, useAssetStore, useOperatorsContext, useRawAsset } from '@/providers/assets'
 import { useConnectionStatusStore } from '@/providers/connectionStatus'
-import { useJoystream } from '@/providers/joystream'
+import { useBucketsConfigForNewChannel, useJoystream } from '@/providers/joystream'
 import { useSnackbar } from '@/providers/snackbars'
 import { useTransaction } from '@/providers/transactions'
 import { useUploadsStore } from '@/providers/uploadsManager'
@@ -84,6 +84,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
 
   const { memberId, accountId, channelId, setActiveUser, refetchUserMemberships } = useUser()
   const { joystream, proxyCallback } = useJoystream()
+  const getBucketsConfigForNewChannel = useBucketsConfigForNewChannel()
   const handleTransaction = useTransaction()
   const { displaySnackbar } = useSnackbar()
   const nodeConnectionStatus = useConnectionStatusStore((state) => state.nodeConnectionStatus)
@@ -203,7 +204,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
           memberId,
           channelMetadata,
           channelAssets,
-          // TODO: provide better values
+          // TODO: use basic buckets config for fee estimation
           { storage: [0], distribution: [{ distributionBucketFamilyId: 0, distributionBucketIndex: 0 }] },
         ]
       : undefined
@@ -391,13 +392,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
         newChannel
           ? (
               await joystream.extrinsics
-            ).createChannel(
-              memberId,
-              metadata,
-              assets,
-              { storage: [0], distribution: [{ distributionBucketFamilyId: 0, distributionBucketIndex: 0 }] }, // TODO: provide better values
-              proxyCallback(updateStatus)
-            )
+            ).createChannel(memberId, metadata, assets, getBucketsConfigForNewChannel(), proxyCallback(updateStatus))
           : (
               await joystream.extrinsics
             ).updateChannel(channelId ?? '', memberId, metadata, assets, proxyCallback(updateStatus)),


### PR DESCRIPTION
Resolves #2909

Whenever channel create view is opened, we will fetch all the distribution and storage buckets and then select random ones according to policies defined in `@/config/joystream`

For testing you can do the following:
1. In `useBucketsConfigForNewChannel`, comment out `client.query` calls and replace with (this is result of the respective queries ran on current production testnet):
```tsx
const storageBucketsPromise = Promise.resolve(
  JSON.parse('{"data":{"storageBuckets":[{"id":"3"},{"id":"6"},{"id":"8"},{"id":"2"},{"id":"1"}]}}')
)

const distributionBucketsPromise = Promise.resolve(
  JSON.parse(
    '{"data":{"distributionBuckets":[{"id":"0:0","bucketIndex":0,"family":{"id":"0"}},{"id":"2:0","bucketIndex":0,"family":{"id":"2"}},{"id":"1:1","bucketIndex":1,"family":{"id":"1"}},{"id":"1:2","bucketIndex":2,"family":{"id":"1"}},{"id":"1:3","bucketIndex":3,"family":{"id":"1"}},{"id":"4:1","bucketIndex":1,"family":{"id":"4"}},{"id":"3:0","bucketIndex":0,"family":{"id":"3"}},{"id":"12:0","bucketIndex":0,"family":{"id":"12"}},{"id":"12:2","bucketIndex":2,"family":{"id":"12"}},{"id":"12:1","bucketIndex":1,"family":{"id":"12"}},{"id":"11:0","bucketIndex":0,"family":{"id":"11"}},{"id":"7:0","bucketIndex":0,"family":{"id":"7"}},{"id":"4:0","bucketIndex":0,"family":{"id":"4"}},{"id":"0:3","bucketIndex":3,"family":{"id":"0"}},{"id":"1:4","bucketIndex":4,"family":{"id":"1"}},{"id":"0:1","bucketIndex":1,"family":{"id":"0"}},{"id":"9:0","bucketIndex":0,"family":{"id":"9"}},{"id":"1:0","bucketIndex":0,"family":{"id":"1"}},{"id":"2:1","bucketIndex":1,"family":{"id":"2"}},{"id":"0:2","bucketIndex":2,"family":{"id":"0"}}]}}'
  )
)
```
2. Log the result of `getBucketsConfigForNewChannel()` somewhere