### PR TITLE
Fix crashing embedded player

### DIFF
--- a/packages/atlas/src/App.tsx
+++ b/packages/atlas/src/App.tsx
@@ -1,7 +1,6 @@
 import { AnalyticsManager } from '@/AnalyticsManager'
 import { CommonProviders } from '@/CommonProviders'
 import { SignInModal } from '@/components/_auth/SignInModal'
-import { ConfirmationModalProvider } from '@/providers/confirmationModal'
 import { NftActionsProvider } from '@/providers/nftActions'
 import { NotificationsManager } from '@/providers/notifications'
 import { NftPurchaseBottomDrawer } from '@/views/global/NftPurchaseBottomDrawer'
@@ -18,23 +17,21 @@ export const App = () => {
   return (
     <CommonProviders>
       <AnalyticsManager />
-      <ConfirmationModalProvider>
-        <UserProvider>
-          <JoystreamProvider>
-            <NftActionsProvider>
-              <MainLayout />
-              <Snackbars />
-              <TransactionsManager />
-              <JoystreamManager />
-              <NotificationsManager />
-              <SignInModal />
-              <NftSettlementBottomDrawer />
-              <NftPurchaseBottomDrawer />
-              <NftSaleBottomDrawer />
-            </NftActionsProvider>
-          </JoystreamProvider>
-        </UserProvider>
-      </ConfirmationModalProvider>
+      <UserProvider>
+        <JoystreamProvider>
+          <NftActionsProvider>
+            <MainLayout />
+            <Snackbars />
+            <TransactionsManager />
+            <JoystreamManager />
+            <NotificationsManager />
+            <SignInModal />
+            <NftSettlementBottomDrawer />
+            <NftPurchaseBottomDrawer />
+            <NftSaleBottomDrawer />
+          </NftActionsProvider>
+        </JoystreamProvider>
+      </UserProvider>
     </CommonProviders>
   )
 }

--- a/packages/atlas/src/CommonProviders.tsx
+++ b/packages/atlas/src/CommonProviders.tsx
@@ -7,6 +7,7 @@ import { createApolloClient } from '@/api'
 import { useGetKillSwitch } from '@/api/hooks/admin'
 import { AdminModal } from '@/components/_overlays/AdminModal'
 import { AssetsManager, OperatorsContextProvider } from '@/providers/assets'
+import { ConfirmationModalProvider } from '@/providers/confirmationModal'
 import { OverlayManagerProvider } from '@/providers/overlayManager'
 import { GlobalStyles } from '@/styles'
 
@@ -18,17 +19,19 @@ export const CommonProviders: FC<PropsWithChildren> = ({ children }) => {
     <>
       <GlobalStyles />
       <OverlayManagerProvider>
-        <ApolloProvider client={apolloClient}>
-          <BrowserRouter>
-            <AdminModal />
-            <MaintenanceWrapper>
-              <OperatorsContextProvider>
-                <AssetsManager />
-                {children}
-              </OperatorsContextProvider>
-            </MaintenanceWrapper>
-          </BrowserRouter>
-        </ApolloProvider>
+        <ConfirmationModalProvider>
+          <ApolloProvider client={apolloClient}>
+            <BrowserRouter>
+              <AdminModal />
+              <MaintenanceWrapper>
+                <OperatorsContextProvider>
+                  <AssetsManager />
+                  {children}
+                </OperatorsContextProvider>
+              </MaintenanceWrapper>
+            </BrowserRouter>
+          </ApolloProvider>
+        </ConfirmationModalProvider>
       </OverlayManagerProvider>
     </>
   )


### PR DESCRIPTION
@drillprop found out that when ending overlay shows up in embedded player, app crashes. It was caused by `ChannelLink` which uses `useConfirmationModal`. I added `ConfirmationModalProvider` to `CommonProviders`.