### PR TITLE
Fix issue with showing dollars in sending funds dialogs

### DIFF
--- a/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
+++ b/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
@@ -140,7 +140,7 @@ export const SendFundsDialog: FC<SendFundsDialogProps> = ({ onExitClick, account
             color="colorText"
             format="dollar"
             variant="t100"
-            value={convertHapiToUSD(accountBalance) || 0}
+            value={accountBalanceInUsd}
             margin={{ top: 1 }}
           />
         )}

--- a/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
+++ b/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
@@ -95,9 +95,9 @@ export const SendFundsDialog: FC<SendFundsDialogProps> = ({ onExitClick, account
       }
       handleTransaction({
         snackbarSuccessMessage: {
-          title: `${formatNumber(data.amount)} ${JOY_CURRENCY_TICKER} ($${formatNumber(
-            convertedAmount || 0
-          )}) tokens have been sent over to ${data.account.slice(0, ADDRESS_CHARACTERS_LIMIT)}...
+          title: `${formatNumber(data.amount)} ${JOY_CURRENCY_TICKER} ${
+            convertedAmount === null ? '' : `$(${formatNumber(convertedAmount || 0)})`
+          } tokens have been sent over to ${data.account.slice(0, ADDRESS_CHARACTERS_LIMIT)}...
           ${data.account.slice(-ADDRESS_CHARACTERS_LIMIT)} wallet address`,
         },
         txFactory: async (updateStatus) =>
@@ -115,6 +115,7 @@ export const SendFundsDialog: FC<SendFundsDialogProps> = ({ onExitClick, account
       shouldValidate: true,
     })
   }
+  const accountBalanceInUsd = convertHapiToUSD(accountBalance)
 
   return (
     <DialogModal
@@ -133,14 +134,16 @@ export const SendFundsDialog: FC<SendFundsDialogProps> = ({ onExitClick, account
           <JoyTokenIcon variant="gray" />
           <NumberFormat value={accountBalance} as="p" variant="h400" margin={{ left: 1 }} format="short" />
         </VerticallyCenteredDiv>
-        <NumberFormat
-          as="p"
-          color="colorText"
-          format="dollar"
-          variant="t100"
-          value={convertHapiToUSD(accountBalance) || 0}
-          margin={{ top: 1 }}
-        />
+        {accountBalanceInUsd !== null && (
+          <NumberFormat
+            as="p"
+            color="colorText"
+            format="dollar"
+            variant="t100"
+            value={convertHapiToUSD(accountBalance) || 0}
+            margin={{ top: 1 }}
+          />
+        )}
       </PriceWrapper>
       <FormFieldsWrapper>
         <FormField

--- a/packages/atlas/src/components/_overlays/SendTransferDialogs/WithdrawFundsDialog.tsx
+++ b/packages/atlas/src/components/_overlays/SendTransferDialogs/WithdrawFundsDialog.tsx
@@ -85,6 +85,8 @@ export const WithdrawFundsDialog: FC<WithdrawFundsDialogProps> = ({
     return handler()
   }
 
+  const channelBalanceInUsd = convertHapiToUSD(channelBalance)
+
   return (
     <DialogModal
       show={show}
@@ -102,14 +104,16 @@ export const WithdrawFundsDialog: FC<WithdrawFundsDialogProps> = ({
           <JoyTokenIcon variant="gray" />
           <NumberFormat value={channelBalance || 0} as="p" variant="h400" margin={{ left: 1 }} format="short" />
         </VerticallyCenteredDiv>
-        <NumberFormat
-          as="p"
-          color="colorText"
-          format="dollar"
-          variant="t100"
-          value={convertHapiToUSD(channelBalance) || 0}
-          margin={{ top: 1 }}
-        />
+        {channelBalanceInUsd !== null && (
+          <NumberFormat
+            as="p"
+            color="colorText"
+            format="dollar"
+            variant="t100"
+            value={channelBalanceInUsd}
+            margin={{ top: 1 }}
+          />
+        )}
       </PriceWrapper>
       <FormField label="Amount to withdraw" error={errors.amount?.message}>
         <Controller


### PR DESCRIPTION
Small fix and follow-up after #3077, which should remove dollars conversion in these places: 
![image](https://user-images.githubusercontent.com/51168865/184079610-83529f8f-4fbf-46ee-8bfe-e28808258655.png)
![image](https://user-images.githubusercontent.com/51168865/184079650-c3ff34e4-6a30-4871-b2a9-803af31b9ad3.png)
![image](https://user-images.githubusercontent.com/51168865/184079687-585d477f-84d4-4dad-a4fd-f67f5ab5618a.png)
