### PR TITLE
Fix issue with misaligned text in comment input

### DIFF
--- a/packages/atlas/src/components/Fee/Fee.tsx
+++ b/packages/atlas/src/components/Fee/Fee.tsx
@@ -47,7 +47,6 @@ export const Fee: FC<FeeProps> = ({
             withTooltip
             format="short"
             margin={{ right: 1 }}
-            tooltipAsWrapper
           />
         </>
       )}

--- a/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/atlas/src/components/NumberFormat/NumberFormat.tsx
@@ -18,23 +18,10 @@ export type NumberFormatProps = {
   children?: never
   variant?: TextVariant
   displayedValue?: string | number
-  tooltipAsWrapper?: boolean
 } & Omit<TextProps, 'children' | 'variant'>
 
 export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
-  (
-    {
-      value,
-      format = 'full',
-      withToken,
-      withTooltip,
-      variant = 'no-variant',
-      displayedValue,
-      tooltipAsWrapper,
-      ...textProps
-    },
-    ref
-  ) => {
+  ({ value, format = 'full', withToken, withTooltip, variant = 'no-variant', displayedValue, ...textProps }, ref) => {
     const internalValue = BN.isBN(value) ? hapiBnToTokenNumber(value) : value
     const textRef = useRef<HTMLHeadingElement>(null)
     let formattedValue
@@ -66,17 +53,6 @@ export const NumberFormat = forwardRef<HTMLHeadingElement, NumberFormatProps>(
         {withToken && ` ${JOY_CURRENCY_TICKER}`}
       </StyledText>
     )
-
-    // TODO: This is workaround. For some reason this tooltip doesn't work properly.
-    //  Dear developer, if you find a solution, the project will thank you, otherwise we should consider
-    //  using Floating UI (https://github.com/floating-ui/floating-ui)
-    if (tooltipAsWrapper) {
-      return (
-        <Tooltip placement="top" delay={[500, null]} text={hasTooltip ? tooltipText : undefined}>
-          {content}
-        </Tooltip>
-      )
-    }
 
     return (
       <>

--- a/packages/atlas/src/views/global/NftPurchaseBottomDrawer/NftPurchaseBottomDrawer.tsx
+++ b/packages/atlas/src/views/global/NftPurchaseBottomDrawer/NftPurchaseBottomDrawer.tsx
@@ -605,7 +605,6 @@ export const NftPurchaseBottomDrawer: FC = () => {
                     withToken
                     format="short"
                     withTooltip
-                    tooltipAsWrapper
                     variant="h500"
                   />
                 </Row>


### PR DESCRIPTION
Fix #3073 
I'm pretty sure we don't need to wrap elements with the tooltip component anymore. The main thing why tooltips were not showing up was this text component issue, which was already fixed in  https://github.com/Joystream/atlas/pull/2987