### PR TITLE
fix issue when reuploading file

### DIFF
--- a/packages/atlas/src/providers/uploadsManager/useStartFileUpload.ts
+++ b/packages/atlas/src/providers/uploadsManager/useStartFileUpload.ts
@@ -119,7 +119,7 @@ export const useStartFileUpload = () => {
         formData.append('dataObjectId', asset.id)
         formData.append('storageBucketId', uploadOperator.id)
         formData.append('bagId', bagId)
-        formData.append('file', fileToUpload, (file as File).name)
+        formData.append('file', fileToUpload)
 
         rax.attach()
         const raxConfig: RetryConfig = {


### PR DESCRIPTION
`file` is `null` when re-uploading so this would always throw