### PR TITLE
bring back video categories in VideoWorkspace

### DIFF
--- a/packages/atlas/src/CommonProviders.tsx
+++ b/packages/atlas/src/CommonProviders.tsx
@@ -42,7 +42,7 @@ export const CommonProviders: FC<PropsWithChildren> = ({ children }) => {
 }
 
 const MaintenanceWrapper: FC<PropsWithChildren> = ({ children }) => {
-  const { isKilled, wasKilledLastTime, error, loading } = useGetKillSwitch({ context: { delay: 2000 } })
+  const { isKilled, wasKilledLastTime, error, loading } = useGetKillSwitch({ context: { delay: 1000 } })
 
   if (isKilled || (error && wasKilledLastTime) || (loading && wasKilledLastTime)) {
     return <Maintenance />

--- a/packages/atlas/src/CommonProviders.tsx
+++ b/packages/atlas/src/CommonProviders.tsx
@@ -42,7 +42,7 @@ export const CommonProviders: FC<PropsWithChildren> = ({ children }) => {
 }
 
 const MaintenanceWrapper: FC<PropsWithChildren> = ({ children }) => {
-  const { isKilled, wasKilledLastTime, error, loading } = useGetKillSwitch()
+  const { isKilled, wasKilledLastTime, error, loading } = useGetKillSwitch({ context: { delay: 2000 } })
 
   if (isKilled || (error && wasKilledLastTime) || (loading && wasKilledLastTime)) {
     return <Maintenance />

--- a/packages/atlas/src/api/client/index.ts
+++ b/packages/atlas/src/api/client/index.ts
@@ -7,6 +7,8 @@ import { ORION_GRAPHQL_URL, QUERY_NODE_GRAPHQL_SUBSCRIPTION_URL } from '@/config
 
 import cache from './cache'
 
+const BATCHED_QUERIES = ['GetBasicVideos', 'GetDistributionBucketsWithBags', 'GetStorageBucketsWithBags']
+
 const delayLink = new ApolloLink((operation, forward) => {
   const ctx = operation.getContext()
   if (!ctx.delay) {
@@ -39,7 +41,7 @@ const createApolloClient = () => {
 
   const orionSplitLink = split(
     ({ operationName }) => {
-      return operationName === 'GetBasicVideos'
+      return BATCHED_QUERIES.includes(operationName)
     },
     batchedOrionLink,
     orionLink

--- a/packages/atlas/src/providers/videoWorkspace/hooks.ts
+++ b/packages/atlas/src/providers/videoWorkspace/hooks.ts
@@ -4,6 +4,7 @@ import { useContext, useEffect, useMemo, useState } from 'react'
 import { useLocation, useMatch } from 'react-router'
 import { useNavigate } from 'react-router-dom'
 
+import { useCategories } from '@/api/hooks/categories'
 import { useFullVideo } from '@/api/hooks/video'
 import { cancelledVideoFilter } from '@/config/contentFilter'
 import { absoluteRoutes } from '@/config/routes'
@@ -44,6 +45,7 @@ export const useVideoWorkspaceData = () => {
       },
     }
   )
+  const { categories } = useCategories()
 
   const subtitlesAssets = useSubtitlesAssets(video?.subtitles)
 
@@ -95,11 +97,11 @@ export const useVideoWorkspaceData = () => {
   const normalizedData: VideoWorkspaceVideoFormFields = {
     title: editedVideoInfo.isDraft ? draft?.title ?? '' : video?.title ?? '',
     description: (editedVideoInfo.isDraft ? draft?.description : video?.description) ?? '',
-    category: (editedVideoInfo.isDraft ? draft?.category : video?.category?.id) ?? null,
+    category: (editedVideoInfo.isDraft ? draft?.category ?? categories?.[0]?.id : video?.category?.id) ?? null,
     licenseCode: (editedVideoInfo.isDraft ? draft?.licenseCode : video?.license?.code) ?? DEFAULT_LICENSE_ID,
     licenseCustomText: (editedVideoInfo.isDraft ? draft?.licenseCustomText : video?.license?.customText) ?? null,
     licenseAttribution: (editedVideoInfo.isDraft ? draft?.licenseAttribution : video?.license?.attribution) ?? null,
-    language: (editedVideoInfo.isDraft ? draft?.language : video?.language?.iso) ?? 'en',
+    language: (editedVideoInfo.isDraft ? draft?.language ?? 'en' : video?.language?.iso) ?? null,
     isPublic: (editedVideoInfo.isDraft ? draft?.isPublic : video?.isPublic) ?? true,
     isExplicit: (editedVideoInfo.isDraft ? draft?.isExplicit : video?.isExplicit) ?? false,
     hasMarketing: (editedVideoInfo.isDraft ? draft?.hasMarketing : video?.hasMarketing) ?? false,

--- a/packages/atlas/src/providers/videoWorkspace/provider.tsx
+++ b/packages/atlas/src/providers/videoWorkspace/provider.tsx
@@ -1,6 +1,8 @@
 import { FC, PropsWithChildren, createContext, useCallback, useMemo, useState } from 'react'
 
+import { useCategories } from '@/api/hooks/categories'
 import { createId } from '@/utils/createId'
+import { SentryLogger } from '@/utils/logs'
 
 import { ContextValue, VideoWorkspace } from './types'
 
@@ -20,6 +22,12 @@ export const VideoWorkspaceProvider: FC<PropsWithChildren> = ({ children }) => {
   const setEditedVideo = useCallback((video?: VideoWorkspace) => {
     setEditedVideoInfo(!video ? generateVideo() : video)
   }, [])
+
+  // trigger categories fetch so that they are available once the video workspace is opened
+  useCategories(undefined, {
+    context: { delay: 1500 },
+    onError: (error) => SentryLogger.error('Failed to fetch video categories', 'VideoWorkspaceProvider', error),
+  })
 
   const value = useMemo(
     () => ({

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
@@ -44,7 +44,7 @@ import {
 import { SubtitlesInput } from '@/types/subtitles'
 import { createId } from '@/utils/createId'
 import { pastDateValidation, requiredValidation, textFieldValidation } from '@/utils/formValidationOptions'
-import { ConsoleLogger, SentryLogger } from '@/utils/logs'
+import { ConsoleLogger } from '@/utils/logs'
 import { convertSrtToVtt } from '@/utils/subtitles'
 
 import { useVideoFormAssets, useVideoFormDraft } from './VideoForm.hooks'
@@ -115,9 +115,7 @@ export const VideoForm: FC<VideoFormProps> = memo(({ onSubmit, setFormStatus }) 
   const isNew = !isEdit
   const mintNft = editedVideoInfo?.mintNft
 
-  const { error: categoriesError } = useCategories(undefined, {
-    onError: (error) => SentryLogger.error('Failed to fetch categories', 'VideoWorkspace', error),
-  })
+  const { categories, error: categoriesError } = useCategories()
 
   const {
     register,
@@ -462,12 +460,12 @@ export const VideoForm: FC<VideoFormProps> = memo(({ onSubmit, setFormStatus }) 
   const handleDeleteVideo = () => {
     editedVideoInfo && deleteVideo(editedVideoInfo.id)
   }
-  // TODO uncomment once we have categories available
-  // const categoriesSelectItems: SelectItem[] =
-  //   categories?.map((c) => ({
-  //     name: c.name || 'Unknown category',
-  //     value: c.id,
-  //   })) || []
+
+  const categoriesSelectItems: SelectItem[] =
+    categories?.map((c) => ({
+      name: c.name || 'Unknown category',
+      value: c.id,
+    })) || []
 
   const getHiddenSectionLabel = () => {
     if (videoFieldsLocked) {
@@ -542,8 +540,7 @@ export const VideoForm: FC<VideoFormProps> = memo(({ onSubmit, setFormStatus }) 
           disabled={videoFieldsLocked}
         />
       </FormField>
-      {/* TODO uncomment once we have categories available */}
-      {/* <FormField label="Category" error={errors.category?.message}>
+      <FormField label="Category" error={errors.category?.message}>
         <Controller
           name="category"
           control={control}
@@ -564,7 +561,7 @@ export const VideoForm: FC<VideoFormProps> = memo(({ onSubmit, setFormStatus }) 
             />
           )}
         />
-      </FormField> */}
+      </FormField>
       <FormField label="Language">
         <Controller
           name="language"


### PR DESCRIPTION
Scope of changes:
- Bring back category select in VideoForm
- Select first category by default
- Pre-load categories in VideoWorkspaceProvider
- Small queries orchestration improvements:
  - Added delay to GetKillSwitch query
  - Added distribution and storage buckets to batched queries
