### PR TITLE
Fix likes and dislikes counter

### DIFF
--- a/packages/atlas/src/components/_video/ReactionStepper/ReactionStepper.tsx
+++ b/packages/atlas/src/components/_video/ReactionStepper/ReactionStepper.tsx
@@ -50,7 +50,7 @@ export const ReactionStepper: FC<ReactionStepperProps> = ({
             reactionPopoverDismissed={reactionPopoverDismissed}
             onReact={onReact}
             type={reaction}
-            reactionsNumber={likes}
+            reactionsNumber={reaction === 'like' ? likes : dislikes}
             onPopoverShow={async () => {
               setIsPopoverOpen(true)
               await onCalculateFee?.(reaction)


### PR DESCRIPTION
Fix #3223 
Not a QN issue. I did a small mistake during ReactionStepper refactor. That's why likes and dislikes weren't counted correctly. 