### PR TITLE
Don't resolve non-accepted and broken assets

### DIFF
--- a/packages/atlas/src/providers/assets/assetsManager.tsx
+++ b/packages/atlas/src/providers/assets/assetsManager.tsx
@@ -98,7 +98,7 @@ export const AssetsManager: FC = () => {
           }
         }
       }
-      // once asset couldn't be resolved set url to null and set default placeholder
+      // once the asset couldn't be resolved, set URL to null, which means that only the default image placeholder will be shown
       addAsset(dataObject.id, { url: null })
       removePendingAsset(dataObject.id)
       removeAssetBeingResolved(dataObject.id)

--- a/packages/atlas/src/providers/assets/assetsManager.tsx
+++ b/packages/atlas/src/providers/assets/assetsManager.tsx
@@ -32,6 +32,11 @@ export const AssetsManager: FC = () => {
       if (assetIdsBeingResolved.has(dataObject.id)) {
         return
       }
+      if (!dataObject.isAccepted) {
+        addAsset(dataObject.id, { url: null })
+        removePendingAsset(dataObject.id)
+        return
+      }
       addAssetBeingResolved(dataObject.id)
 
       const distributionOperators = await getAllDistributionOperatorsForBag(dataObject.storageBag.id)
@@ -93,7 +98,10 @@ export const AssetsManager: FC = () => {
           }
         }
       }
-
+      // once asset couldn't be resolved set url to null and set default placeholder
+      addAsset(dataObject.id, { url: null })
+      removePendingAsset(dataObject.id)
+      removeAssetBeingResolved(dataObject.id)
       SentryLogger.error('None of the distributors provided the asset', 'AssetsManager', null, {
         asset: { dataObject, sortedDistributionOperators },
       })


### PR DESCRIPTION
Fix #3194 

I think this should do the job. Assets that are not accepted won't be resolved.  It also removes infinite loading on some video tiles and sets a default placeholder. 