### PR TITLE
Fix studio redirects

### DIFF
--- a/packages/atlas/src/providers/user/user.provider.tsx
+++ b/packages/atlas/src/providers/user/user.provider.tsx
@@ -25,6 +25,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   const {
     memberships: currentMemberships,
     previousData,
+    loading: membershipsLoading,
     refetch,
     error,
   } = useMemberships(
@@ -48,7 +49,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const signIn = useCallback(
     async (walletName?: string): Promise<boolean> => {
-      let accounts = walletAccounts
+      let accounts = []
 
       if (!walletName) {
         setSignInModalOpen(true)
@@ -95,7 +96,7 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
 
       return true
     },
-    [initSignerWallet, memberId, refetch, setActiveUser, setSignInModalOpen, walletAccounts]
+    [initSignerWallet, memberId, refetch, setActiveUser, setSignInModalOpen]
   )
 
   // keep user used by loggers in sync
@@ -132,12 +133,13 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
   const contextValue: UserContextValue = useMemo(
     () => ({
       memberships: memberships || [],
+      membershipsLoading,
       activeMembership,
       isAuthLoading,
       signIn,
       refetchUserMemberships,
     }),
-    [memberships, activeMembership, isAuthLoading, signIn, refetchUserMemberships]
+    [memberships, activeMembership, isAuthLoading, signIn, refetchUserMemberships, membershipsLoading]
   )
 
   if (error) {

--- a/packages/atlas/src/providers/user/user.types.ts
+++ b/packages/atlas/src/providers/user/user.types.ts
@@ -15,6 +15,7 @@ export type SignerWalletStatus = 'unknown' | 'connected' | 'disconnected' | 'pen
 export type SignerWalletAccount = WalletAccount
 export type UserContextValue = {
   memberships: Membership[]
+  membershipsLoading: boolean
   activeMembership: Membership | null
 
   isAuthLoading: boolean

--- a/packages/atlas/src/views/studio/StudioLayout.tsx
+++ b/packages/atlas/src/views/studio/StudioLayout.tsx
@@ -37,7 +37,7 @@ const StudioLayout = () => {
   const displayedLocation = useVideoWorkspaceRouting()
   const internetConnectionStatus = useConnectionStatusStore((state) => state.internetConnectionStatus)
   const nodeConnectionStatus = useConnectionStatusStore((state) => state.nodeConnectionStatus)
-  const { channelId, memberships, isLoggedIn, isAuthLoading } = useUser()
+  const { channelId, memberships, isLoggedIn, isAuthLoading, membershipsLoading, isWalletLoading } = useUser()
 
   const [openUnsupportedBrowserDialog, closeUnsupportedBrowserDialog] = useConfirmationModal()
   const [enterLocation] = useState(location.pathname)
@@ -72,7 +72,7 @@ const StudioLayout = () => {
         nodeConnectionStatus={nodeConnectionStatus}
         isConnectedToInternet={internetConnectionStatus === 'connected'}
       />
-      {isAuthLoading ? (
+      {isAuthLoading || membershipsLoading || isWalletLoading ? (
         <StudioLoading />
       ) : (
         <>


### PR DESCRIPTION
Fixes #3246

I noticed that this line https://github.com/Joystream/atlas/pull/3253/files#diff-3f09a3eb15223392d4e71639fbf35349926f439f12cf86a2f9b4e776370da3e0R52 was causing a lot of unnecessary rerenders of `StudioLayout` and it seems it's not needed there. I don't see any issues after removing it, but make sure I'm not wrong.