### PR TITLE
Reporting tweaks

### DIFF
--- a/packages/atlas/src/components/_auth/SignInModal/SignInModal.tsx
+++ b/packages/atlas/src/components/_auth/SignInModal/SignInModal.tsx
@@ -212,7 +212,7 @@ export const SignInModal: FC = () => {
       dividers={currentStep !== 'creating'}
       primaryButton={primaryButtonProps}
       secondaryButton={backButtonVisible ? { text: 'Back', onClick: goToPreviousStep } : undefined}
-      onEscPress={() => setSignInModalOpen(false)}
+      onClickOutside={() => setSignInModalOpen(false)}
       additionalActionsNode={
         currentStep !== 'creating' ? (
           <Button variant="tertiary" onClick={() => setSignInModalOpen(false)}>

--- a/packages/atlas/src/components/_overlays/AlertDialogModal/AlertDialogModal.tsx
+++ b/packages/atlas/src/components/_overlays/AlertDialogModal/AlertDialogModal.tsx
@@ -55,7 +55,7 @@ export const AlertDialogModal: FC<AlertDialogModalProps> = ({
   const primaryButtonColor = isInformative ? 'primary' : type
 
   return (
-    <Modal show={show} onEscPress={secondaryButton?.onClick || onExitClick} onExitClick={onExitClick}>
+    <Modal show={show} onClickOutside={() => secondaryButton?.onClick?.() || onExitClick?.()} onExitClick={onExitClick}>
       <Dialog
         {...dialogProps}
         primaryButton={primaryButton ? { ...primaryButton, variant: primaryButtonColor } : undefined}

--- a/packages/atlas/src/components/_overlays/DialogModal/DialogModal.tsx
+++ b/packages/atlas/src/components/_overlays/DialogModal/DialogModal.tsx
@@ -16,13 +16,7 @@ export const DialogModal: FC<DialogModalProps> = ({
   ...dialogProps
 }) => {
   return (
-    <Modal
-      show={show}
-      onExitClick={onExitClick}
-      onEscPress={onEscPress ? onEscPress : onExitClick || dialogProps.secondaryButton?.onClick}
-      size={size}
-      onClickOutside={onClickOutside}
-    >
+    <Modal show={show} onExitClick={onExitClick} onEscPress={onEscPress} size={size} onClickOutside={onClickOutside}>
       <Dialog {...dialogProps} onExitClick={onExitClick}>
         {children}
       </Dialog>

--- a/packages/atlas/src/components/_overlays/DialogModal/DialogModal.tsx
+++ b/packages/atlas/src/components/_overlays/DialogModal/DialogModal.tsx
@@ -3,20 +3,18 @@ import { FC } from 'react'
 import { Dialog, DialogProps } from '@/components/_overlays/Dialog'
 import { Modal, ModalProps } from '@/components/_overlays/Modal'
 
-export type DialogModalProps = Pick<ModalProps, 'show' | 'size' | 'onClickOutside' | 'onEscPress'> &
-  Omit<DialogProps, 'size'>
+export type DialogModalProps = Pick<ModalProps, 'show' | 'size' | 'onClickOutside'> & Omit<DialogProps, 'size'>
 
 export const DialogModal: FC<DialogModalProps> = ({
   show,
   onExitClick,
   onClickOutside,
-  onEscPress,
   size,
   children,
   ...dialogProps
 }) => {
   return (
-    <Modal show={show} onExitClick={onExitClick} onEscPress={onEscPress} size={size} onClickOutside={onClickOutside}>
+    <Modal show={show} onExitClick={onExitClick} size={size} onClickOutside={onClickOutside}>
       <Dialog {...dialogProps} onExitClick={onExitClick}>
         {children}
       </Dialog>

--- a/packages/atlas/src/components/_overlays/Modal/Modal.tsx
+++ b/packages/atlas/src/components/_overlays/Modal/Modal.tsx
@@ -14,32 +14,23 @@ export type ModalProps = PropsWithChildren<{
   noBoxShadow?: boolean
   size?: ModalSize
   onClickOutside?: (event?: MouseEvent) => void
-  onEscPress?: () => void
   className?: string
 }> &
   Pick<DialogProps, 'onExitClick' | 'additionalActionsNode'>
 
-export const Modal: FC<ModalProps> = ({
-  children,
-  size = 'small',
-  show,
-  onClickOutside,
-  onEscPress,
-  className,
-  noBoxShadow,
-}) => {
+export const Modal: FC<ModalProps> = ({ children, size = 'small', show, onClickOutside, className, noBoxShadow }) => {
   const { modalContainerRef, incrementOverlaysOpenCount, decrementOverlaysOpenCount, lastOverlayId } =
     useOverlayManager()
   const [overlayId, setOverlayId] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!onEscPress) {
+    if (!onClickOutside) {
       return
     }
     const handleEscPress = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (lastOverlayId === overlayId) {
-          onEscPress?.()
+          onClickOutside?.()
         }
       }
     }
@@ -48,7 +39,7 @@ export const Modal: FC<ModalProps> = ({
     return () => {
       document.removeEventListener('keydown', handleEscPress)
     }
-  }, [lastOverlayId, onEscPress, overlayId])
+  }, [lastOverlayId, onClickOutside, overlayId])
 
   return (
     <Portal containerRef={modalContainerRef}>

--- a/packages/atlas/src/components/_overlays/Modal/Modal.tsx
+++ b/packages/atlas/src/components/_overlays/Modal/Modal.tsx
@@ -23,7 +23,6 @@ export const Modal: FC<ModalProps> = ({
   children,
   size = 'small',
   show,
-  onExitClick,
   onClickOutside,
   onEscPress,
   className,
@@ -61,7 +60,7 @@ export const Modal: FC<ModalProps> = ({
         unmountOnExit
         appear
       >
-        <ModalBackdrop onClick={onExitClick || onClickOutside} />
+        <ModalBackdrop onClick={onClickOutside} />
       </CSSTransition>
       <CSSTransition
         in={show}

--- a/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
+++ b/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
@@ -70,7 +70,7 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
   })
   return (
     <DialogModal
-      onExitClick={handleClose}
+      onClickOutside={handleClose}
       title={`Report ${type}`}
       show={show}
       onSubmit={submit}

--- a/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
+++ b/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
@@ -27,8 +27,14 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
   const {
     register,
     handleSubmit,
+    resetField,
     formState: { errors },
   } = useForm<{ rationale: string }>()
+
+  const handleClose = () => {
+    resetField('rationale')
+    onClose()
+  }
 
   const submit = handleSubmit(async ({ rationale }) => {
     try {
@@ -64,13 +70,13 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
   })
   return (
     <DialogModal
-      onExitClick={onClose}
+      onExitClick={handleClose}
       title={`Report ${type}`}
       show={show}
       onSubmit={submit}
       secondaryButton={{
         text: 'Cancel',
-        onClick: onClose,
+        onClick: handleClose,
       }}
       primaryButton={{
         disabled: reportVideoLoading || reportChannelLoading,
@@ -86,7 +92,10 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
         }`}
       >
         <TextArea
-          {...register('rationale', { required: { value: true, message: 'Provide details for your report.' } })}
+          {...register('rationale', {
+            required: { value: true, message: 'Provide details for your report.' },
+            maxLength: { value: 400, message: 'Your report is too long.' },
+          })}
           counter
           error={!!errors.rationale}
           maxLength={400}

--- a/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
+++ b/packages/atlas/src/components/_overlays/ReportModal/ReportModal.tsx
@@ -54,7 +54,7 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
           },
         })
       }
-      onClose()
+      handleClose()
       displaySnackbar({
         title: 'Thank you for your report',
         description: `Your report helps make ${APP_NAME} a better place. Our team will be reviewing it shortly and taking action if necessary.`,
@@ -70,7 +70,6 @@ export const ReportModal: FC<ReportModalProps> = ({ entityId, show, onClose, typ
   })
   return (
     <DialogModal
-      onClickOutside={handleClose}
       title={`Report ${type}`}
       show={show}
       onSubmit={submit}


### PR DESCRIPTION
Fix #3204
Regarding changes to dialog.  Previously we were closing modals on click outside, and on press escape always when the `onClose` handler was provided i.e there was an X button in the top right corner.  I think we should explicitly declare how the dialog should behave in those cases. This is a much simpler approach and we will avoid some unexpected results in the future. 