### PR TITLE
Fix issues with updating channel

### DIFF
--- a/packages/atlas/src/joystream-lib/helpers.ts
+++ b/packages/atlas/src/joystream-lib/helpers.ts
@@ -72,7 +72,7 @@ export const parseExtrinsicEvents = (registry: Registry, eventRecords: EventReco
         name: 'FailedError',
         message: errorMsg,
       })
-    } else if (event.method === 'ExtrinsicSuccess') {
+    } else if (event.method === 'ExtrinsicSuccess' || event.method === 'NewAccount') {
       return events
     } else {
       SentryLogger.message('Unknown extrinsic event', 'JoystreamJs', 'warning', {

--- a/packages/atlas/src/providers/assets/assets.hooks.ts
+++ b/packages/atlas/src/providers/assets/assets.hooks.ts
@@ -29,7 +29,9 @@ export const useAsset = (dataObject?: StorageDataObjectFieldsFragment | null) =>
 }
 
 export const useRawAsset = (contentId: string | null) => {
-  return useAssetStore((state) => (contentId ? state.assets[contentId] : null))
+  return useAssetStore((state) => {
+    return contentId ? state.assets[contentId] : null
+  })
 }
 
 export const useRawAssetResolver = () => {

--- a/packages/atlas/src/providers/assets/assets.hooks.ts
+++ b/packages/atlas/src/providers/assets/assets.hooks.ts
@@ -29,9 +29,7 @@ export const useAsset = (dataObject?: StorageDataObjectFieldsFragment | null) =>
 }
 
 export const useRawAsset = (contentId: string | null) => {
-  return useAssetStore((state) => {
-    return contentId ? state.assets[contentId] : null
-  })
+  return useAssetStore((state) => (contentId ? state.assets[contentId] : null))
 }
 
 export const useRawAssetResolver = () => {

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -89,6 +89,8 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
   const [coverHashPromise, setCoverHashPromise] = useState<Promise<string> | null>(null)
 
   const { memberId, accountId, channelId, setActiveUser, refetchUserMemberships } = useUser()
+  const cachedChannelId = useRef(channelId)
+  const firstRender = useRef(true)
   const { joystream, proxyCallback } = useJoystream()
   const getBucketsConfigForNewChannel = useBucketsConfigForNewChannel()
   const handleTransaction = useTransaction()
@@ -273,25 +275,31 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
     const { title, description, isPublic, language, avatarPhoto, coverPhoto } = channel
 
     const foundLanguage = atlasConfig.derived.languagesSelectValues.find(({ value }) => value === language?.iso)
+    const isChannelChanged = cachedChannelId.current !== channel.id
 
-    reset({
-      avatar: {
-        contentId: avatarPhoto?.id,
-        assetDimensions: null,
-        imageCropData: null,
-        originalBlob: undefined,
-      },
-      cover: {
-        contentId: coverPhoto?.id,
-        assetDimensions: null,
-        imageCropData: null,
-        originalBlob: undefined,
-      },
-      title: title || '',
-      description: description || '',
-      isPublic: isPublic ?? false,
-      language: foundLanguage?.value || atlasConfig.derived.languagesSelectValues[0].value,
-    })
+    // This condition should prevent from updating cover/avatar when the upload is done
+    if (isChannelChanged || firstRender.current) {
+      reset({
+        avatar: {
+          contentId: avatarPhoto?.id,
+          assetDimensions: null,
+          imageCropData: null,
+          originalBlob: undefined,
+        },
+        cover: {
+          contentId: coverPhoto?.id,
+          assetDimensions: null,
+          imageCropData: null,
+          originalBlob: undefined,
+        },
+        title: title || '',
+        description: description || '',
+        isPublic: isPublic ?? false,
+        language: foundLanguage?.value || atlasConfig.derived.languagesSelectValues[0].value,
+      })
+      firstRender.current = false
+      cachedChannelId.current = channel.id
+    }
   }, [channel, loading, newChannel, reset])
 
   useEffect(() => {

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -266,7 +266,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
 
   // set default values for editing channel
   useEffect(() => {
-    if (loading || newChannel || !channel || isDirty) {
+    if (loading || newChannel || !channel) {
       return
     }
 
@@ -292,7 +292,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
       isPublic: isPublic ?? false,
       language: foundLanguage?.value || atlasConfig.derived.languagesSelectValues[0].value,
     })
-  }, [channel, isDirty, loading, newChannel, reset])
+  }, [channel, loading, newChannel, reset])
 
   useEffect(() => {
     if (!dirtyFields.avatar || !avatarAsset?.blob) {

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -266,7 +266,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
 
   // set default values for editing channel
   useEffect(() => {
-    if (loading || newChannel || !channel) {
+    if (loading || newChannel || !channel || isDirty) {
       return
     }
 
@@ -292,7 +292,7 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
       isPublic: isPublic ?? false,
       language: foundLanguage?.value || atlasConfig.derived.languagesSelectValues[0].value,
     })
-  }, [channel, loading, newChannel, reset])
+  }, [channel, isDirty, loading, newChannel, reset])
 
   useEffect(() => {
     if (!dirtyFields.avatar || !avatarAsset?.blob) {


### PR DESCRIPTION
Fix #3224 
While working on this task I found that updating a channel is pretty buggy right now. When testing, make sure that you manage: 
- create a new channel and set an avatar and cover
- update an existing channel without an avatar and cover
- update an existing channel with an avatar and cover
- update only one asset on an existing channel
- switch between channels while the edit channel form is open(check if the content in the form is updated correctly)
- update only one asset on an existing channel - either avatar or cover, and once this asset is uploaded and processed, try to update the channel again.

Just FYI, deleting assets won't be covered in this PR. It's still not working fully and we have a separate issue for this. 