### PR TITLE
Fix bad logo visibility in emebedded player

### DIFF
--- a/packages/atlas/sd.config.js
+++ b/packages/atlas/sd.config.js
@@ -86,7 +86,7 @@ module.exports = {
       type: 'value',
       transitive: true,
       matcher: (token) => token.attributes.category === 'filterEffect',
-      transformer: (token) => `${token.value.x} ${token.value.y} ${token.value.blur} ${token.value.color}`,
+      transformer: (token) => `drop-shadow(${token.value.x} ${token.value.y} ${token.value.blur} ${token.value.color})`,
     },
   },
   format: {

--- a/packages/atlas/src/components/_video/VideoPlayer/PlayerControlButton.styles.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/PlayerControlButton.styles.ts
@@ -27,7 +27,7 @@ export const ControlButton = styled.button<ControlButtonProps>`
     `}
 
   & > svg {
-    filter: drop-shadow(${cVar('effectElevation1Layer1')});
+    filter: drop-shadow(${cVar('filterEffectElevation1Layer1')});
     width: 1.5em;
     height: 1.5em;
   }

--- a/packages/atlas/src/components/_video/VideoPlayer/PlayerControlButton.styles.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/PlayerControlButton.styles.ts
@@ -27,7 +27,7 @@ export const ControlButton = styled.button<ControlButtonProps>`
     `}
 
   & > svg {
-    filter: drop-shadow(${cVar('filterEffectElevation1Layer1')});
+    filter: ${cVar('filterEffectElevation1Layer1')};
     width: 1.5em;
     height: 1.5em;
   }

--- a/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
@@ -367,7 +367,7 @@ export const StyledAtlasLogo = styled(SvgAtlasLogoFull)<{ embedded?: boolean }>`
   padding: ${({ embedded }) => (embedded ? 0 : '0.5em')};
   max-height: ${({ embedded }) => (embedded ? '2em' : '2.5em')};
   height: 100%;
-  filter: drop-shadow(${cVar('effectElevation1Layer1')});
+  filter: drop-shadow(${cVar('filterEffectElevation1Layer1')});
 
   ${defaultIconColor};
 `

--- a/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
@@ -367,7 +367,7 @@ export const StyledAtlasLogo = styled(SvgAtlasLogoFull)<{ embedded?: boolean }>`
   padding: ${({ embedded }) => (embedded ? 0 : '0.5em')};
   max-height: ${({ embedded }) => (embedded ? '2em' : '2.5em')};
   height: 100%;
-  filter: drop-shadow(${cVar('filterEffectElevation1Layer1')});
+  filter: ${cVar('filterEffectElevation1Layer1')};
 
   ${defaultIconColor};
 `

--- a/packages/atlas/src/styles/generated/variables.ts
+++ b/packages/atlas/src/styles/generated/variables.ts
@@ -131,6 +131,17 @@ export const variables = css`
     --effect-elevation-16-layer2: 0 4px 8px 0 #0000001a;
     --effect-elevation-24-layer1: 0 24px 40px 0 #00000029;
     --effect-elevation-24-layer2: 0 8px 8px 0 #0000001f;
+    --filter-effect-dividers-top: 0 1px 0 var(--color-border-muted-alpha);
+    --filter-effect-dividers-bottom: 0 -1px 0 var(--color-border-muted-alpha);
+    --filter-effect-dividers-left: 1px 0 0 var(--color-border-muted-alpha);
+    --filter-effect-dividers-right: -1px 0 0 var(--color-border-muted-alpha);
+    --filter-effect-elevation-1-layer1: 0 1px 2px #00000052;
+    --filter-effect-elevation-8-layer1: 0 8px 16px #0000001f;
+    --filter-effect-elevation-8-layer2: 0 4px 4px #0000001a;
+    --filter-effect-elevation-16-layer1: 0 16px 32px #00000029;
+    --filter-effect-elevation-16-layer2: 0 4px 8px #0000001a;
+    --filter-effect-elevation-24-layer1: 0 24px 40px #00000029;
+    --filter-effect-elevation-24-layer2: 0 8px 8px #0000001f;
     --radius-small: 2px;
     --radius-medium: 4px;
     --radius-large: 8px;
@@ -418,6 +429,23 @@ export const theme = {
   effectElevation16Layer2: { variable: 'var(--effect-elevation-16-layer2)', value: ' 0 4px 8px 0 #0000001A' },
   effectElevation24Layer1: { variable: 'var(--effect-elevation-24-layer1)', value: ' 0 24px 40px 0 #00000029' },
   effectElevation24Layer2: { variable: 'var(--effect-elevation-24-layer2)', value: ' 0 8px 8px 0 #0000001F' },
+  filterEffectDividersTop: { variable: 'var(--filter-effect-dividers-top)', value: '0 1px 0 #BBD9F621' },
+  filterEffectDividersBottom: { variable: 'var(--filter-effect-dividers-bottom)', value: '0 -1px 0 #BBD9F621' },
+  filterEffectDividersLeft: { variable: 'var(--filter-effect-dividers-left)', value: '1px 0 0 #BBD9F621' },
+  filterEffectDividersRight: { variable: 'var(--filter-effect-dividers-right)', value: '-1px 0 0 #BBD9F621' },
+  filterEffectElevation1Layer1: { variable: 'var(--filter-effect-elevation-1-layer1)', value: '0 1px 2px #00000052' },
+  filterEffectElevation8Layer1: { variable: 'var(--filter-effect-elevation-8-layer1)', value: '0 8px 16px #0000001F' },
+  filterEffectElevation8Layer2: { variable: 'var(--filter-effect-elevation-8-layer2)', value: '0 4px 4px #0000001A' },
+  filterEffectElevation16Layer1: {
+    variable: 'var(--filter-effect-elevation-16-layer1)',
+    value: '0 16px 32px #00000029',
+  },
+  filterEffectElevation16Layer2: { variable: 'var(--filter-effect-elevation-16-layer2)', value: '0 4px 8px #0000001A' },
+  filterEffectElevation24Layer1: {
+    variable: 'var(--filter-effect-elevation-24-layer1)',
+    value: '0 24px 40px #00000029',
+  },
+  filterEffectElevation24Layer2: { variable: 'var(--filter-effect-elevation-24-layer2)', value: '0 8px 8px #0000001F' },
   radiusSmall: { variable: 'var(--radius-small)', value: '2px' },
   radiusMedium: { variable: 'var(--radius-medium)', value: '4px' },
   radiusLarge: { variable: 'var(--radius-large)', value: '8px' },

--- a/packages/atlas/src/styles/generated/variables.ts
+++ b/packages/atlas/src/styles/generated/variables.ts
@@ -131,17 +131,17 @@ export const variables = css`
     --effect-elevation-16-layer2: 0 4px 8px 0 #0000001a;
     --effect-elevation-24-layer1: 0 24px 40px 0 #00000029;
     --effect-elevation-24-layer2: 0 8px 8px 0 #0000001f;
-    --filter-effect-dividers-top: 0 1px 0 var(--color-border-muted-alpha);
-    --filter-effect-dividers-bottom: 0 -1px 0 var(--color-border-muted-alpha);
-    --filter-effect-dividers-left: 1px 0 0 var(--color-border-muted-alpha);
-    --filter-effect-dividers-right: -1px 0 0 var(--color-border-muted-alpha);
-    --filter-effect-elevation-1-layer1: 0 1px 2px #00000052;
-    --filter-effect-elevation-8-layer1: 0 8px 16px #0000001f;
-    --filter-effect-elevation-8-layer2: 0 4px 4px #0000001a;
-    --filter-effect-elevation-16-layer1: 0 16px 32px #00000029;
-    --filter-effect-elevation-16-layer2: 0 4px 8px #0000001a;
-    --filter-effect-elevation-24-layer1: 0 24px 40px #00000029;
-    --filter-effect-elevation-24-layer2: 0 8px 8px #0000001f;
+    --filter-effect-dividers-top: drop-shadow(0 1px 0 var(--color-border-muted-alpha));
+    --filter-effect-dividers-bottom: drop-shadow(0 -1px 0 var(--color-border-muted-alpha));
+    --filter-effect-dividers-left: drop-shadow(1px 0 0 var(--color-border-muted-alpha));
+    --filter-effect-dividers-right: drop-shadow(-1px 0 0 var(--color-border-muted-alpha));
+    --filter-effect-elevation-1-layer1: drop-shadow(0 1px 2px #00000052);
+    --filter-effect-elevation-8-layer1: drop-shadow(0 8px 16px #0000001f);
+    --filter-effect-elevation-8-layer2: drop-shadow(0 4px 4px #0000001a);
+    --filter-effect-elevation-16-layer1: drop-shadow(0 16px 32px #00000029);
+    --filter-effect-elevation-16-layer2: drop-shadow(0 4px 8px #0000001a);
+    --filter-effect-elevation-24-layer1: drop-shadow(0 24px 40px #00000029);
+    --filter-effect-elevation-24-layer2: drop-shadow(0 8px 8px #0000001f);
     --radius-small: 2px;
     --radius-medium: 4px;
     --radius-large: 8px;
@@ -429,23 +429,44 @@ export const theme = {
   effectElevation16Layer2: { variable: 'var(--effect-elevation-16-layer2)', value: ' 0 4px 8px 0 #0000001A' },
   effectElevation24Layer1: { variable: 'var(--effect-elevation-24-layer1)', value: ' 0 24px 40px 0 #00000029' },
   effectElevation24Layer2: { variable: 'var(--effect-elevation-24-layer2)', value: ' 0 8px 8px 0 #0000001F' },
-  filterEffectDividersTop: { variable: 'var(--filter-effect-dividers-top)', value: '0 1px 0 #BBD9F621' },
-  filterEffectDividersBottom: { variable: 'var(--filter-effect-dividers-bottom)', value: '0 -1px 0 #BBD9F621' },
-  filterEffectDividersLeft: { variable: 'var(--filter-effect-dividers-left)', value: '1px 0 0 #BBD9F621' },
-  filterEffectDividersRight: { variable: 'var(--filter-effect-dividers-right)', value: '-1px 0 0 #BBD9F621' },
-  filterEffectElevation1Layer1: { variable: 'var(--filter-effect-elevation-1-layer1)', value: '0 1px 2px #00000052' },
-  filterEffectElevation8Layer1: { variable: 'var(--filter-effect-elevation-8-layer1)', value: '0 8px 16px #0000001F' },
-  filterEffectElevation8Layer2: { variable: 'var(--filter-effect-elevation-8-layer2)', value: '0 4px 4px #0000001A' },
+  filterEffectDividersTop: { variable: 'var(--filter-effect-dividers-top)', value: 'drop-shadow(0 1px 0 #BBD9F621)' },
+  filterEffectDividersBottom: {
+    variable: 'var(--filter-effect-dividers-bottom)',
+    value: 'drop-shadow(0 -1px 0 #BBD9F621)',
+  },
+  filterEffectDividersLeft: { variable: 'var(--filter-effect-dividers-left)', value: 'drop-shadow(1px 0 0 #BBD9F621)' },
+  filterEffectDividersRight: {
+    variable: 'var(--filter-effect-dividers-right)',
+    value: 'drop-shadow(-1px 0 0 #BBD9F621)',
+  },
+  filterEffectElevation1Layer1: {
+    variable: 'var(--filter-effect-elevation-1-layer1)',
+    value: 'drop-shadow(0 1px 2px #00000052)',
+  },
+  filterEffectElevation8Layer1: {
+    variable: 'var(--filter-effect-elevation-8-layer1)',
+    value: 'drop-shadow(0 8px 16px #0000001F)',
+  },
+  filterEffectElevation8Layer2: {
+    variable: 'var(--filter-effect-elevation-8-layer2)',
+    value: 'drop-shadow(0 4px 4px #0000001A)',
+  },
   filterEffectElevation16Layer1: {
     variable: 'var(--filter-effect-elevation-16-layer1)',
-    value: '0 16px 32px #00000029',
+    value: 'drop-shadow(0 16px 32px #00000029)',
   },
-  filterEffectElevation16Layer2: { variable: 'var(--filter-effect-elevation-16-layer2)', value: '0 4px 8px #0000001A' },
+  filterEffectElevation16Layer2: {
+    variable: 'var(--filter-effect-elevation-16-layer2)',
+    value: 'drop-shadow(0 4px 8px #0000001A)',
+  },
   filterEffectElevation24Layer1: {
     variable: 'var(--filter-effect-elevation-24-layer1)',
-    value: '0 24px 40px #00000029',
+    value: 'drop-shadow(0 24px 40px #00000029)',
   },
-  filterEffectElevation24Layer2: { variable: 'var(--filter-effect-elevation-24-layer2)', value: '0 8px 8px #0000001F' },
+  filterEffectElevation24Layer2: {
+    variable: 'var(--filter-effect-elevation-24-layer2)',
+    value: 'drop-shadow(0 8px 8px #0000001F)',
+  },
   radiusSmall: { variable: 'var(--radius-small)', value: '2px' },
   radiusMedium: { variable: 'var(--radius-medium)', value: '4px' },
   radiusLarge: { variable: 'var(--radius-large)', value: '8px' },


### PR DESCRIPTION
Fix #3231 

It turned out, that we can't use our effect design tokens in drop-shadow. The property `filter: drop-shadow()` has different parameters. For this reason, I decided to create another design tokens just for this purpose.