### PR TITLE
Persist form data when faucet error occurs

### DIFF
--- a/packages/atlas/src/components/_auth/SignInModal/SignInModal.tsx
+++ b/packages/atlas/src/components/_auth/SignInModal/SignInModal.tsx
@@ -188,7 +188,7 @@ export const SignInModal: FC = () => {
             break
         }
 
-        goToPreviousStep()
+        goToPreviousStep(data)
         return
       }
     },


### PR DESCRIPTION
This is a follow-up after https://github.com/Joystream/atlas/pull/3363
Previously when the error occurs after membership creation we didn't persist the data in the sign-in modal. The form was just cleared. 