### PR TITLE
Fix issue with displaying incorrect invitation lock

### DIFF
--- a/packages/atlas/src/joystream-lib/lib.ts
+++ b/packages/atlas/src/joystream-lib/lib.ts
@@ -8,6 +8,7 @@ import BN from 'bn.js'
 import { proxy } from 'comlink'
 
 import { PERBILL_ONE_PERCENT } from '@/joystream-lib/config'
+import { parseAccountBalance } from '@/joystream-lib/utils'
 import { ConsoleLogger, SentryLogger } from '@/utils/logs'
 
 import { JoystreamLibError } from './errors'
@@ -90,10 +91,7 @@ export class JoystreamLib {
     await this.ensureApi()
 
     const balances = await this.api.derive.balances.all(accountId)
-    return {
-      availableBalance: balances.freeBalance.toString(),
-      lockedBalance: balances.lockedBalance.toString(),
-    }
+    return parseAccountBalance(balances)
   }
 
   async subscribeAccountBalance(
@@ -102,11 +100,8 @@ export class JoystreamLib {
   ) {
     await this.ensureApi()
 
-    const unsubscribe = await this.api.derive.balances.all(accountId, ({ availableBalance, freeBalance }) => {
-      callback({
-        availableBalance: availableBalance.toString(),
-        lockedBalance: freeBalance.sub(availableBalance).toString(),
-      })
+    const unsubscribe = await this.api.derive.balances.all(accountId, (balances) => {
+      callback(parseAccountBalance(balances))
     })
 
     return proxy(unsubscribe)

--- a/packages/atlas/src/joystream-lib/lib.ts
+++ b/packages/atlas/src/joystream-lib/lib.ts
@@ -102,8 +102,11 @@ export class JoystreamLib {
   ) {
     await this.ensureApi()
 
-    const unsubscribe = await this.api.derive.balances.all(accountId, ({ availableBalance, lockedBalance }) => {
-      callback({ availableBalance: availableBalance.toString(), lockedBalance: lockedBalance.toString() })
+    const unsubscribe = await this.api.derive.balances.all(accountId, ({ availableBalance, freeBalance }) => {
+      callback({
+        availableBalance: availableBalance.toString(),
+        lockedBalance: freeBalance.sub(availableBalance).toString(),
+      })
     })
 
     return proxy(unsubscribe)

--- a/packages/atlas/src/joystream-lib/types.ts
+++ b/packages/atlas/src/joystream-lib/types.ts
@@ -12,6 +12,13 @@ export type ChannelId = string
 export type VideoId = string
 export type CategoryId = string
 
+export type AccountBalanceInfo = {
+  // transferable balance account
+  availableBalance: StringifiedNumber
+  // locked balance (e.g. invitation lock) on top of `availableBalance`
+  lockedBalance: StringifiedNumber
+}
+
 export type DataObjectMetadata = {
   size: number
   ipfsHash: string

--- a/packages/atlas/src/joystream-lib/utils.ts
+++ b/packages/atlas/src/joystream-lib/utils.ts
@@ -1,7 +1,8 @@
+import { DeriveBalancesAll } from '@polkadot/api-derive/balances/types'
 import BN from 'bn.js'
 
 import { HAPI_TO_JOY_RATE } from '@/joystream-lib/config'
-import { ChannelInputAssets, VideoInputAssets } from '@/joystream-lib/types'
+import { AccountBalanceInfo, ChannelInputAssets, VideoInputAssets } from '@/joystream-lib/types'
 import { ConsoleLogger } from '@/utils/logs'
 
 const MAX_SAFE_NUMBER_BN = new BN(Number.MAX_SAFE_INTEGER)
@@ -64,4 +65,17 @@ export const calculateAssetsBloatFee = (
     return new BN(0)
   }
   return dataObjectStateBloatBondValue.muln(Object.values(assets).length)
+}
+
+export const parseAccountBalance = (balances: DeriveBalancesAll): AccountBalanceInfo => {
+  /*
+    balances.freeBalance = all the tokens in the account
+    balances.availableBalance = "transferable balance" (freeBalance - any locks)
+  */
+
+  const lockedBalance = BN.max(new BN(0), balances.freeBalance.sub(balances.availableBalance))
+  return {
+    availableBalance: balances.availableBalance.toString(),
+    lockedBalance: lockedBalance.toString(),
+  }
 }


### PR DESCRIPTION
During testing, I discovered we were displaying an incorrect invitation lock balance. 
Previously when someone had no transferable balance and made a transaction invitation lock balance wasn't decreased.
This PR should fix this.