### PR TITLE
fix subtitles edit and missing data in VideoForm

### DIFF
--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -208,6 +208,9 @@ const queryCacheFields: CachePolicyFields<keyof Query> = {
 const videoCacheFields: CachePolicyFields<keyof FullVideoFieldsFragment> = {
   createdAt: createDateHandler(),
   publishedBeforeJoystream: createDateHandler(),
+  subtitles: {
+    merge: (existing, incoming) => incoming,
+  },
 }
 
 const channelCacheFields: CachePolicyFields<keyof FullChannelFieldsFragment> = {

--- a/packages/atlas/src/components/_inputs/SubtitlesBox/SubtitlesBox.tsx
+++ b/packages/atlas/src/components/_inputs/SubtitlesBox/SubtitlesBox.tsx
@@ -6,6 +6,8 @@ import { ListItemProps } from '@/components/ListItem'
 import { Text } from '@/components/Text'
 import { Button } from '@/components/_buttons/Button'
 import { ContextMenu } from '@/components/_overlays/ContextMenu'
+import { atlasConfig } from '@/config'
+import { useAsset } from '@/providers/assets/assets.hooks'
 import { useConfirmationModal } from '@/providers/confirmationModal'
 import { SubtitlesInput } from '@/types/subtitles'
 
@@ -29,14 +31,16 @@ export const SubtitlesBox: FC<SubtitleBoxProps> = ({
   type,
   file,
   isUploadedAsSrt,
-  url,
   id,
   onChange,
   onRemove,
+  asset,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const [openUnsuportedFileDialog, closeUnsuportedFileDialog] = useConfirmationModal()
   const hasFile = !!file || !!id
+
+  const { url } = useAsset(asset)
 
   const handleDownload = async (url = '') => {
     const response = await axios.get(url, { responseType: 'blob' })
@@ -108,7 +112,7 @@ export const SubtitlesBox: FC<SubtitleBoxProps> = ({
     <SubtitleBoxWrapper className={className}>
       <SubtitleDetails>
         <Text variant="t100-strong" as="p">
-          {languageIso} {type === 'closed-captions' ? '(CC)' : ''}
+          {atlasConfig.derived.languagesLookup[languageIso]} {type === 'closed-captions' ? '(CC)' : ''}
         </Text>
         {!hasFile && (
           <SubtitlesFileName variant="t100" as="p" color="colorText">

--- a/packages/atlas/src/components/_inputs/SubtitlesComboBox/SubtitlesCombobox.tsx
+++ b/packages/atlas/src/components/_inputs/SubtitlesComboBox/SubtitlesCombobox.tsx
@@ -116,18 +116,18 @@ export const SubtitlesCombobox: FC<SubtitlesComboboxProps> = ({
         }}
         notFoundNode={notFoundNode}
       />
-      {subtitlesArray?.map(({ languageIso, file, type, id, url, isUploadedAsSrt }) => (
+      {subtitlesArray?.map(({ languageIso, file, type, id, asset, isUploadedAsSrt }) => (
         <SubtitlesBox
           key={languageIso + type}
           isUploadedAsSrt={isUploadedAsSrt}
           type={type}
-          languageIso={atlasConfig.derived.languagesLookup[languageIso]}
+          languageIso={languageIso}
           onRemove={() => {
             onLanguageDelete({ languageIso, type })
           }}
           file={file}
-          url={url}
           id={id}
+          asset={asset}
           onChange={(e) => {
             onSubtitlesAdd({ languageIso, file: e.currentTarget.files?.[0], type })
           }}

--- a/packages/atlas/src/types/subtitles.ts
+++ b/packages/atlas/src/types/subtitles.ts
@@ -9,6 +9,5 @@ export type SubtitlesInput = {
   file?: File
   id?: string
   asset?: StorageDataObjectFieldsFragment | null
-  url?: string
   isUploadedAsSrt?: boolean
 }

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoForm/VideoForm.tsx
@@ -792,7 +792,7 @@ export const VideoForm: FC<VideoFormProps> = memo(({ onSubmit, setFormStatus }) 
             name="subtitlesArray"
             rules={{
               validate: (value) => {
-                const languageWithoutFile = value?.find((language) => !language.file && !language.url)
+                const languageWithoutFile = value?.find((language) => !language.file && !language.asset)
                 return value && languageWithoutFile ? 'Provide a file for every new subtitles language.' : true
               },
             }}

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.hooks.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.hooks.ts
@@ -93,7 +93,8 @@ export const useHandleVideoWorkspaceSubmit = () => {
             }))
           )
         }
-        if (tabData?.subtitlesArray) {
+        // if data.metadata.subtitles is not set, that means that subtitles weren't changed
+        if (tabData?.subtitlesArray && data.metadata.subtitles) {
           const oldAssetsIds = tabData.subtitlesArray.map((subtitle) => subtitle.id)
           const currentSubtitlesIdsLookup = createLookup(data.metadata.subtitles || [])
           const removedSubtitlesIds = oldAssetsIds.filter(


### PR DESCRIPTION
Fixes #3375

The issue was again with loading of subtitles when all of them had the asset missing. Because the metadata was defined, but missing assets would not get resolved, the form though that the data was still loading. While investigating I found a couple more issues with subtitles edit/removal, all should be fixed now.
