### PR TITLE
Set fixed height to all logos

### DIFF
--- a/packages/atlas/src/components/_navigation/SidenavStudio/SidenavStudio.tsx
+++ b/packages/atlas/src/components/_navigation/SidenavStudio/SidenavStudio.tsx
@@ -94,7 +94,7 @@ export const SidenavStudio: FC<SidenavStudioProps> = ({ className }) => {
     <SidenavBase
       expanded={expanded}
       toggleSideNav={setExpanded}
-      logoNode={<SvgAppLogoStudio />}
+      logoNode={<SvgAppLogoStudio height={32} width={undefined} />}
       logoLinkUrl={absoluteRoutes.studio.index()}
       items={studioNavbarItemsWithBadge}
       buttonsContent={buttons}

--- a/packages/atlas/src/components/_navigation/SidenavViewer/SidenavViewer.tsx
+++ b/packages/atlas/src/components/_navigation/SidenavViewer/SidenavViewer.tsx
@@ -98,7 +98,7 @@ export const SidenavViewer: FC = () => {
     <SidenavBase
       expanded={expanded}
       toggleSideNav={setExpanded}
-      logoNode={<SvgAppLogoFull />}
+      logoNode={<SvgAppLogoFull height={32} width={undefined} />}
       logoLinkUrl={absoluteRoutes.viewer.index()}
       items={viewerNavItems}
       additionalContent={

--- a/packages/atlas/src/components/_navigation/TopbarBase/TopbarBase.tsx
+++ b/packages/atlas/src/components/_navigation/TopbarBase/TopbarBase.tsx
@@ -17,7 +17,11 @@ export const TopbarBase: FC<TopbarBaseProps> = ({ children, fullLogoNode, logoLi
 
   return (
     <Header className={className} data-scroll-lock-fill-gap>
-      {!noLogo && <LogoLink to={logoLinkUrl}>{mdMatch ? fullLogoNode : <SvgAppLogoShort />}</LogoLink>}
+      {!noLogo && (
+        <LogoLink to={logoLinkUrl}>
+          {mdMatch ? fullLogoNode : <SvgAppLogoShort height={32} width={undefined} />}
+        </LogoLink>
+      )}
       {children}
     </Header>
   )

--- a/packages/atlas/src/components/_navigation/TopbarStudio/TopbarStudio.tsx
+++ b/packages/atlas/src/components/_navigation/TopbarStudio/TopbarStudio.tsx
@@ -62,7 +62,7 @@ export const TopbarStudio: FC<StudioTopbarProps> = ({ hideChannelInfo }) => {
   return (
     <>
       <StyledTopbarBase
-        fullLogoNode={<SvgAppLogoStudio />}
+        fullLogoNode={<SvgAppLogoStudio height={32} width={undefined} />}
         withoutHamburgerButton={hideChannelInfo}
         logoLinkUrl={absoluteRoutes.studio.index()}
       >

--- a/packages/atlas/src/components/_navigation/TopbarViewer/TopbarViewer.tsx
+++ b/packages/atlas/src/components/_navigation/TopbarViewer/TopbarViewer.tsx
@@ -93,7 +93,7 @@ export const TopbarViewer: FC = () => {
       <StyledTopbarBase
         hasFocus={searchOpen}
         noLogo={!mdMatch && !!searchQuery}
-        fullLogoNode={<SvgAppLogoFull />}
+        fullLogoNode={<SvgAppLogoFull height={32} width={undefined} />}
         logoLinkUrl={absoluteRoutes.viewer.index()}
       >
         <SearchbarContainer>

--- a/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
+++ b/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.styles.ts
@@ -367,6 +367,7 @@ export const StyledAtlasLogo = styled(SvgAppLogoFull)<{ embedded?: boolean }>`
   padding: ${({ embedded }) => (embedded ? 0 : '0.5em')};
   max-height: ${({ embedded }) => (embedded ? '2em' : '2.5em')};
   height: 100%;
+  width: unset;
   filter: ${cVar('filterEffectElevation1Layer1')};
 
   ${defaultIconColor};
@@ -376,6 +377,7 @@ export const StyledAtlasLogoShort = styled(SvgAppLogoShort)`
   padding: 0.5em;
   max-height: 2.5em;
   height: 100%;
+  width: unset;
 
   ${defaultIconColor};
 `

--- a/packages/atlas/src/views/legal/LegalLayout.tsx
+++ b/packages/atlas/src/views/legal/LegalLayout.tsx
@@ -18,7 +18,10 @@ const legalRoutes = [
 export const LegalLayout: FC = () => {
   return (
     <div>
-      <StyledTopbarBase fullLogoNode={<SvgAppLogoFull />} logoLinkUrl={absoluteRoutes.viewer.index()} />
+      <StyledTopbarBase
+        fullLogoNode={<SvgAppLogoFull height={32} width={undefined} />}
+        logoLinkUrl={absoluteRoutes.viewer.index()}
+      />
       <Container>
         <Routes>
           {legalRoutes.map((route) => (

--- a/packages/atlas/src/views/playground/PlaygroundLayout.tsx
+++ b/packages/atlas/src/views/playground/PlaygroundLayout.tsx
@@ -54,7 +54,7 @@ const PlaygroundLayout = () => {
       <TopbarBase
         fullLogoNode={
           <LogoWrapper>
-            <SvgAppLogoShort />
+            <SvgAppLogoShort height={32} width={undefined} />
             <Text as="p" variant="h500" margin={{ left: 2 }}>
               Playground
             </Text>


### PR DESCRIPTION
I found that if we change the SVG in the Gleev app, most navigation components were broken. For example, this happen when I replaced the logo file: 
![image](https://user-images.githubusercontent.com/51168865/199958159-38b72b17-092e-406e-bcbb-12b5d9560c86.png)

These changes are done to make sure that all the logos always occupy the same amount of space, no matter what size SVG has. 