### PR TITLE
Fix issue with logo in embedded player

### DIFF
--- a/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.tsx
+++ b/packages/atlas/src/components/_video/VideoPlayer/VideoPlayer.tsx
@@ -830,11 +830,7 @@ const VideoPlayerComponent: ForwardRefRenderFunction<HTMLVideoElement, VideoPlay
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      {xsMatch ? (
-                        <StyledSvgAppLogoFullMonochrome width={undefined} />
-                      ) : (
-                        <StyledAppLogoShortMonochrome width={undefined} />
-                      )}
+                      {xsMatch ? <StyledSvgAppLogoFullMonochrome /> : <StyledAppLogoShortMonochrome />}
                     </a>
                   )}
                 </ScreenControls>


### PR DESCRIPTION
Fix #3188 
If I'm not mistaken, the bug was present only on firefox. This should fix the problem. Tested on both browsers(chrome, firefox) and with different logos (used gleev logo, to see if that's happening, because it has different width) 