### PR TITLE
Create video tile variation for synced video

### DIFF
--- a/packages/atlas/src/types/storage.ts
+++ b/packages/atlas/src/types/storage.ts
@@ -1,4 +1,4 @@
-export type AssetUploadStatus = 'completed' | 'inProgress' | 'error' | 'reconnecting' | 'processing'
+export type AssetUploadStatus = 'completed' | 'inProgress' | 'error' | 'reconnecting' | 'processing' | 'yt-sync'
 
 export type UploadStatus = {
   lastStatus?: AssetUploadStatus


### PR DESCRIPTION
partly fixes #3448 
Designs: https://www.figma.com/file/LF7LOMhOA46bRcYHWlw1Bq/My-videos-page?node-id=1801%3A46731&t=YVNPqpH7zO4jpepg-4
I only added a tile variant. If you want to test it visually go to `VideoTilePublisher.tsx` and replace line 94 with 
```tsx
    const uploadVideoStatus = useUploadsStore((state) => ({
      ...state.uploadsStatus[video?.media?.id || ''],
      lastStatus: 'yt-sync',
    }))
```
and go to `/studio/videos`

I didn't add the integration because it's currently impossible to get consistent information on which uploaded videos are actually synced from youtube and which are failed uploads.
