### PR TITLE
Fix issue with showing `undefined` in ypp requirements step

### DIFF
--- a/packages/atlas/src/utils/misc.ts
+++ b/packages/atlas/src/utils/misc.ts
@@ -7,11 +7,8 @@ export const withTimeout = async <T>(promise: Promise<T>, timeout: number) => {
   return await Promise.race([timeoutPromise, promise])
 }
 
-export const pluralizeNoun = (
-  count: number,
-  noun: string,
-  { suffix, formatCount }: { suffix?: string; formatCount?: boolean } = { suffix: 's' }
-) => `${formatCount ? formatNumber(count) : count} ${noun}${count > 1 ? suffix : ''}`
+export const pluralizeNoun = (count: number, noun: string, formatCount?: boolean, suffix = 's') =>
+  `${formatCount ? formatNumber(count) : count} ${noun}${count > 1 ? suffix : ''}`
 
 export const wait = (milliseconds: number): Promise<void> =>
   new Promise((resolve) => {

--- a/packages/atlas/src/views/global/YppLandingView/YppAuthorizationModal/YppAuthorizationModal.tsx
+++ b/packages/atlas/src/views/global/YppLandingView/YppAuthorizationModal/YppAuthorizationModal.tsx
@@ -307,7 +307,7 @@ export const YppAuthorizationModal: FC<YppAuthorizationModalProps> = ({
         text: `Your YouTube channel has at least ${pluralizeNoun(
           fetchedChannelRequirements?.MINIMUM_VIDEO_COUNT ?? 0,
           'video',
-          { formatCount: true }
+          true
         )}, all published at least ${convertHoursRequirementTime(
           fetchedChannelRequirements?.MINIMUM_VIDEO_AGE_HOURS || 0
         )} ago`,
@@ -319,7 +319,7 @@ export const YppAuthorizationModal: FC<YppAuthorizationModalProps> = ({
         text: `Your YouTube channel has at least ${pluralizeNoun(
           fetchedChannelRequirements?.MINIMUM_SUBSCRIBERS_COUNT ?? 0,
           'subscriber',
-          { formatCount: true }
+          true
         )} and subscriptions are made public.`,
         fulfilled: !ytRequirmentsErrors.some(
           (error) => error === YppAuthorizationErrorCode.CHANNEL_CRITERIA_UNMET_SUBSCRIBERS


### PR DESCRIPTION
We had a small bug in the requirements step: 
![image](https://user-images.githubusercontent.com/51168865/210324652-9f3061d6-6916-417f-a089-4f2c1478bf4c.png)

This PR should fix this