### PR TITLE
Fix issue with doubled popup

### DIFF
--- a/packages/atlas/src/views/studio/YppDashboard/tabs/YppDashboardSettingsTab.tsx
+++ b/packages/atlas/src/views/studio/YppDashboard/tabs/YppDashboardSettingsTab.tsx
@@ -186,7 +186,7 @@ export const YppDashboardSettingsTab = () => {
           )
           if (data.status === 200) {
             displaySnackbar({
-              title: 'You left the progam',
+              title: 'You left the program',
               description:
                 'You are no longer member of the YouTube Partner Program. You can now connect your YouTube channel with another Joystream channel.',
               iconType: 'success',


### PR DESCRIPTION
Fix https://github.com/Joystream/atlas/issues/3589#issuecomment-1397411654

Also partly fix opting out https://github.com/Joystream/atlas/issues/3654 The problem no longer occurs. If the user doesn't sign a message and remove the collaborator, he won't be able to opt out, because we won't send the request to the backend until he does both actions.