### PR TITLE
Update ypp backend statuses

### DIFF
--- a/packages/atlas/src/views/global/YppLandingView/YppHero.tsx
+++ b/packages/atlas/src/views/global/YppLandingView/YppHero.tsx
@@ -31,17 +31,17 @@ import {
 import { useGetYppLastVerifiedChannels } from './YppLandingView.hooks'
 import { BackgroundContainer, StyledLimitedWidthContainer } from './YppLandingView.styles'
 
-type YppStatus = 'have-channel' | 'no-channel' | 'ypp-signed' | 'connect-wallet' | null
+type YppAtlasStatus = 'have-channel' | 'no-channel' | 'ypp-signed' | 'connect-wallet' | null
 
 type YppHeroProps = {
   onSignUpClick: () => void
   onSelectChannel: () => void
-  yppStatus: YppStatus
+  yppAtlasStatus: YppAtlasStatus
   hasAnotherUnsyncedChannel?: boolean
   selectedChannelTitle?: string | null
 }
 
-const getButtonText = (variant: YppStatus) => {
+const getButtonText = (variant: YppAtlasStatus) => {
   switch (variant) {
     case 'have-channel':
     case 'connect-wallet':
@@ -56,7 +56,7 @@ const getButtonText = (variant: YppStatus) => {
 export const YppHero: FC<YppHeroProps> = ({
   onSignUpClick,
   onSelectChannel,
-  yppStatus,
+  yppAtlasStatus,
   hasAnotherUnsyncedChannel,
   selectedChannelTitle,
 }) => {
@@ -107,18 +107,18 @@ export const YppHero: FC<YppHeroProps> = ({
               <SwitchTransition>
                 <CSSTransition
                   timeout={parseInt(cVar('animationTimingFast', true))}
-                  key={yppStatus ? 'status-set' : 'loading'}
+                  key={yppAtlasStatus ? 'status-set' : 'loading'}
                   classNames={transitions.names.fade}
                 >
-                  {yppStatus ? (
+                  {yppAtlasStatus ? (
                     <Button
                       size="large"
-                      variant={yppStatus === 'ypp-signed' ? 'secondary' : 'primary'}
+                      variant={yppAtlasStatus === 'ypp-signed' ? 'secondary' : 'primary'}
                       icon={<SvgActionChevronR />}
                       iconPlacement="right"
                       onClick={onSignUpClick}
                     >
-                      {getButtonText(yppStatus)}
+                      {getButtonText(yppAtlasStatus)}
                     </Button>
                   ) : (
                     <SkeletonLoader width={190} height={48} />

--- a/packages/atlas/src/views/global/YppLandingView/YppHero.tsx
+++ b/packages/atlas/src/views/global/YppLandingView/YppHero.tsx
@@ -71,10 +71,9 @@ export const YppHero: FC<YppHeroProps> = ({
   })
 
   const { channels, loading } = useGetYppLastVerifiedChannels()
-  const items =
-    channels?.length && !loading
-      ? channels.map((channel) => <ChannelCard key={channel.id} channel={channel} withFollowButton={false} />)
-      : Array.from({ length: 30 }).map((_, idx) => <ChannelCard key={idx} loading withFollowButton={false} />)
+  const items = !loading
+    ? channels?.map((channel) => <ChannelCard key={channel.id} channel={channel} withFollowButton={false} />)
+    : Array.from({ length: 30 }).map((_, idx) => <ChannelCard key={idx} loading withFollowButton={false} />)
 
   return (
     <BackgroundContainer noBackground>
@@ -167,17 +166,19 @@ export const YppHero: FC<YppHeroProps> = ({
         </HeroImageWrapper>
         <LayoutGrid>
           <GridItem colStart={{ base: 1, sm: 2 }} colSpan={{ base: 12, sm: 10 }}>
-            <StyledInfiniteCarousel
-              title="Recent verified channels"
-              itemWidth={200}
-              items={items}
-              subTitle="What is a verified channel?"
-              informationProps={{
-                multiline: true,
-                placement: 'top-end',
-                text: `These ${atlasConfig.general.appName} channels applied to the YouTube Partner Program and got through the verification process successfully.`,
-              }}
-            />
+            {items && (
+              <StyledInfiniteCarousel
+                title="Recent verified channels"
+                itemWidth={200}
+                items={items}
+                subTitle="What is a verified channel?"
+                informationProps={{
+                  multiline: true,
+                  placement: 'top-end',
+                  text: `These ${atlasConfig.general.appName} channels applied to the YouTube Partner Program and got through the verification process successfully.`,
+                }}
+              />
+            )}{' '}
           </GridItem>
         </LayoutGrid>
       </StyledLimitedWidthContainer>

--- a/packages/atlas/src/views/global/YppLandingView/YppLandingView.hooks.ts
+++ b/packages/atlas/src/views/global/YppLandingView/YppLandingView.hooks.ts
@@ -9,13 +9,15 @@ import { ConsoleLogger, SentryLogger } from '@/utils/logs'
 
 const YPP_SYNC_URL = atlasConfig.features.ypp.youtubeSyncApiUrl
 
+// todo yppStatus `Active` will be deprecated. We're keeping this for the sake of backward compatibility
+type YppStatus = 'Unverified' | 'Verified' | 'Suspended' | 'OptedOut' | 'Active'
+
 export type YppSyncedChannel = {
   title: string
   description: string
   aggregatedStats: number
   shouldBeIngested: boolean
-  yppStatus: 'OptedOut' | 'Active'
-  isSuspended: boolean
+  yppStatus: YppStatus
   joystreamChannelId: number
   videoCategoryId: string
   thumbnails: {
@@ -63,7 +65,9 @@ export const useGetYppSyncedChannels = () => {
         })
       )
       const fetchedChannels = syncedChannels.filter(
-        (channel): channel is YppSyncedChannel => !!channel && channel.yppStatus === 'Active'
+        (channel): channel is YppSyncedChannel =>
+          !!channel &&
+          (channel.yppStatus === 'Unverified' || channel?.yppStatus === 'Verified' || channel.yppStatus === 'Active')
       )
       setSyncedChannels(fetchedChannels)
 

--- a/packages/atlas/src/views/global/YppLandingView/YppLandingView.hooks.ts
+++ b/packages/atlas/src/views/global/YppLandingView/YppLandingView.hooks.ts
@@ -112,7 +112,10 @@ export const useGetYppLastVerifiedChannels = () => {
     try {
       setIsVerifiedChannelsLoading(true)
       const response = await axios.get<RecentChannelsResponse>(`${atlasConfig.features.ypp.youtubeSyncApiUrl}/channels`)
-      const channelIds = response.data.map((channel) => channel.joystreamChannelId.toString())
+      const channelIds = response.data
+        .filter((channel) => channel.yppStatus === 'Verified')
+        .map((channel) => channel.joystreamChannelId.toString())
+
       setRecentChannelsIds(channelIds)
     } catch (error) {
       SentryLogger.error('Failed to fetch recent channels', 'useYppGetLastVerifiedChannels', error)

--- a/packages/atlas/src/views/global/YppLandingView/YppLandingView.tsx
+++ b/packages/atlas/src/views/global/YppLandingView/YppLandingView.tsx
@@ -119,7 +119,7 @@ export const YppLandingView: FC = () => {
     }
   }, [channelId, handleSignUpClick, setSelectedChannelId, setShouldContinueYppFlow, shouldContinueYppFlow])
 
-  const getYppStatus = () => {
+  const getYppAtlasStatus = () => {
     if (isLoading) {
       return null
     }
@@ -150,7 +150,7 @@ export const YppLandingView: FC = () => {
         <YppHero
           onSelectChannel={() => setCurrentStep('select-channel')}
           onSignUpClick={handleSignUpClick}
-          yppStatus={getYppStatus()}
+          yppAtlasStatus={getYppAtlasStatus()}
           hasAnotherUnsyncedChannel={hasAnotherUnsyncedChannel}
           selectedChannelTitle={selectedChannelTitle}
         />

--- a/packages/atlas/src/views/studio/YppDashboard/tabs/YppDashboardMainTab.tsx
+++ b/packages/atlas/src/views/studio/YppDashboard/tabs/YppDashboardMainTab.tsx
@@ -23,7 +23,7 @@ export const YppDashboardMainTab = () => {
 
   return (
     <>
-      {currentChannel?.isSuspended && (
+      {currentChannel?.yppStatus === 'Suspended' && (
         <StyledBanner
           title="This channel has been suspended in the YouTube Partner Program"
           icon={<SvgAlertsError24 />}


### PR DESCRIPTION
Summary of changes: 
- updated ypp statuses to match the changes on the backend(as described here https://github.com/Joystream/youtube-synch/issues/131#issuecomment-1398208725 and here https://github.com/Joystream/youtube-synch/issues/120#issuecomment-1382251908)
- removed `isSuspended` flag
- renamed YppStatus to YppAtlasStatus in YppHero to avoid confusion
- show only verified channels on infinite carousel in YPP landing view