### PR TITLE
Remove YT banner from non-all-videos tabs (#3648)

### DIFF
--- a/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
+++ b/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
@@ -344,7 +344,7 @@ export const MyVideosView = () => {
               </Button>
             )}
           </TabsContainer>
-          {currentChannel && (
+          {currentChannel && isAllVideosTab && (
             <StyledBanner
               dismissibleId="yppSyncInfo"
               title="YouTube Sync is enabled"


### PR DESCRIPTION
YT banner is now visible only on "all videos" tab(#3648)