### PR TITLE
Set default timeout to snackbar

### DIFF
--- a/packages/atlas/src/providers/snackbars/store.ts
+++ b/packages/atlas/src/providers/snackbars/store.ts
@@ -52,7 +52,7 @@ export const useSnackbarStore = createStore<SnackbarStoreState, SnackbarStoreAct
         state.snackbars = state.snackbars.filter((snackbar) => snackbar.id !== id)
       }),
 
-    displaySnackbar: ({ timeout, customId, onExit, ...args }) => {
+    displaySnackbar: ({ timeout = 4000, customId, onExit, ...args }) => {
       const id = customId ?? createId()
       set((state) => {
         state.snackbars.push({ id, timeout, ...args })

--- a/packages/atlas/src/providers/snackbars/store.ts
+++ b/packages/atlas/src/providers/snackbars/store.ts
@@ -3,6 +3,8 @@ import { ReactNode } from 'react'
 import { createStore } from '@/store'
 import { createId } from '@/utils/createId'
 
+const DEFAULT_SNACKBAR_TIMEOUT = 5000
+
 export type SnackbarIconType = 'success' | 'error' | 'info' | 'warning' | 'uploading' | 'loading' | 'token'
 
 export type DisplaySnackbarArgs = {
@@ -52,7 +54,7 @@ export const useSnackbarStore = createStore<SnackbarStoreState, SnackbarStoreAct
         state.snackbars = state.snackbars.filter((snackbar) => snackbar.id !== id)
       }),
 
-    displaySnackbar: ({ timeout = 4000, customId, onExit, ...args }) => {
+    displaySnackbar: ({ timeout = DEFAULT_SNACKBAR_TIMEOUT, customId, onExit, ...args }) => {
       const id = customId ?? createId()
       set((state) => {
         state.snackbars.push({ id, timeout, ...args })


### PR DESCRIPTION
Fix #3737 

Just FYI - timeout is set to 5 seconds as the design requiress. If you move the mouse cursor on the snack bar - the counting stops. This behavior is documented here: https://www.figma.com/file/Pf31tuYpozYmpq163U2ho8/Web-components?node-id=4606%3A140987&t=Wfs9GeZgHIK8moy2-4