### PR TITLE
Migrate channel follows from orion v1 to orion v2

### DIFF
--- a/packages/atlas/src/providers/personalData/store.ts
+++ b/packages/atlas/src/providers/personalData/store.ts
@@ -27,7 +27,7 @@ export type PersonalDataStoreState = {
   captionsLanguage: string | null
 }
 
-const WHITELIST = [
+const WHITELIST: (keyof PersonalDataStoreState)[] = [
   'watchedVideos',
   'followedChannels',
   'recentSearches',
@@ -41,7 +41,7 @@ const WHITELIST = [
   'autoPlayNext',
   'captionsEnabled',
   'captionsLanguage',
-] as (keyof PersonalDataStoreState)[]
+]
 
 export type PersonalDataStoreActions = {
   updateWatchedVideos: (__typename: WatchedVideoStatus, id: string, timestamp?: number) => void
@@ -178,9 +178,7 @@ export const usePersonalDataStore = createStore<PersonalDataStoreState, Personal
       key: 'personalData',
       whitelist: WHITELIST,
       version: 3,
-      migrate: async (
-        oldState: Pick<PersonalDataStoreState, keyof PersonalDataStoreState>
-      ): Promise<Pick<PersonalDataStoreState, keyof PersonalDataStoreState>> => {
+      migrate: async (oldState: PersonalDataStoreState): Promise<PersonalDataStoreState> => {
         const client = createApolloClient()
         try {
           const followedChannels = await Promise.all(

--- a/packages/atlas/src/providers/personalData/store.ts
+++ b/packages/atlas/src/providers/personalData/store.ts
@@ -1,5 +1,12 @@
 import { round } from 'lodash-es'
 
+import { createApolloClient } from '@/api'
+import {
+  FollowChannelDocument,
+  FollowChannelMutation,
+  FollowChannelMutationVariables,
+} from '@/api/queries/__generated__/channels.generated'
+import { SentryLogger } from '@/utils/logs'
 import { createStore } from '@/utils/store'
 
 import { DismissedMessage, FollowedChannel, RecentSearch, WatchedVideo, WatchedVideoStatus } from './types'
@@ -170,9 +177,39 @@ export const usePersonalDataStore = createStore<PersonalDataStoreState, Personal
     persist: {
       key: 'personalData',
       whitelist: WHITELIST,
-      version: 2,
-      migrate: (oldState) => {
-        return oldState
+      version: 3,
+      migrate: async (
+        oldState: Pick<PersonalDataStoreState, keyof PersonalDataStoreState>
+      ): Promise<Pick<PersonalDataStoreState, keyof PersonalDataStoreState>> => {
+        const client = createApolloClient()
+        try {
+          const followedChannels = await Promise.all(
+            oldState.followedChannels.map(async (followedChannel) => {
+              if (!followedChannel.cancelToken) {
+                const { data } = await client.mutate<FollowChannelMutation, FollowChannelMutationVariables>({
+                  mutation: FollowChannelDocument,
+                  variables: {
+                    channelId: followedChannel.id,
+                  },
+                })
+                return {
+                  ...followedChannel,
+                  cancelToken: data?.followChannel.cancelToken,
+                }
+              }
+            })
+          )
+
+          const followedChannelsWithTokens = followedChannels.filter(
+            (followedChannel): followedChannel is FollowedChannel => !!followedChannel?.cancelToken
+          )
+          oldState.followedChannels = followedChannelsWithTokens
+
+          return oldState
+        } catch (error) {
+          SentryLogger.error('Failed to migrate followed channels', 'userPersonalDataStore', error)
+          return oldState
+        }
       },
     },
   }

--- a/packages/atlas/src/types/utils.d.ts
+++ b/packages/atlas/src/types/utils.d.ts
@@ -6,4 +6,5 @@ declare global {
     [P in keyof T]?: DeepPartial<T[P]>
   }
   type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+  type Reveal<T> = { [P in keyof T]: T[P] }
 }


### PR DESCRIPTION
fix #3946 

Instructions on how to test this: 
1. Find a channel that you want to follow(but don't follow the channel yet) and copy channel id
2. Replace channelId in the JSON below and copy it:
```json
{
  "state": {
    "cachedVolume": 0.39,
    "watchedVideos": [],
    "followedChannels": [{ "id": "-----> channelId here <-----" }],
    "recentSearches": [],
    "dismissedMessages": [],
    "currentVolume": 1,
    "playbackRate": 1,
    "cinematicView": false,
    "cookiesAccepted": true,
    "reactionPopoverDismissed": true,
    "autoPlayNext": false,
    "captionsEnabled": false,
    "captionsLanguage": null
  },
  "version": 2
}
```
3. Open local storage in the browser and paste the JSON above into `personalData`
4. Refresh the site
5. Check if the follower's number on the channel that you want to follow increased and if you have cancelToken saved in local storage