### PR TITLE
Fix issue with redundant requests when YPP url is not set

### DIFF
--- a/packages/atlas/src/views/global/YppLandingView/YppAuthorizationModal/YppAuthorizationModal.tsx
+++ b/packages/atlas/src/views/global/YppLandingView/YppAuthorizationModal/YppAuthorizationModal.tsx
@@ -100,7 +100,7 @@ export const YppAuthorizationModal: FC<YppAuthorizationModalProps> = ({
   const channelBucketsCount = useChannelsStorageBucketsCount(selectedChannelId)
 
   const { joystream, proxyCallback } = useJoystream()
-  const youtubeCollaboratorMemberId = atlasConfig.features.ypp.youtubeCollaboratorMemberId || ''
+  const youtubeCollaboratorMemberId = atlasConfig.features.ypp.youtubeCollaboratorMemberId
 
   const { channel: channel } = useBasicChannel(referrerId || '', {
     skip: !referrerId,
@@ -175,6 +175,9 @@ export const YppAuthorizationModal: FC<YppAuthorizationModalProps> = ({
       return
     }
     try {
+      if (!youtubeCollaboratorMemberId) {
+        throw Error('Collaborator member id was not provided')
+      }
       setIsSubmitting(true)
       await yppChannelMutation(finalFormData)
       const completed = await handleTransaction({

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.tsx
@@ -313,7 +313,10 @@ export const CreateEditChannelView: FC<CreateEditChannelViewProps> = ({ newChann
       },
       () => reset(getValues()),
       setValue,
-      () => setTimeout(() => setShowConnectToYtDialog(true), 2000)
+      () =>
+        atlasConfig.features.ypp.googleConsoleClientId &&
+        atlasConfig.features.ypp.youtubeSyncApiUrl &&
+        setTimeout(() => setShowConnectToYtDialog(true), 2000)
     )
   })
 

--- a/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
+++ b/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
@@ -71,7 +71,7 @@ export const MyVideosView = () => {
     `ypp-ba-videos-${channelId}`,
     () => axios.get<YppVideoDto[]>(`${YOUTUBE_BACKEND_URL}/channels/${channelId}/videos`),
     {
-      enabled: !!channelId || !YOUTUBE_BACKEND_URL,
+      enabled: !!channelId && !!YOUTUBE_BACKEND_URL,
       onSettled: () => {
         setIsBackednRqCompleted(true)
       },


### PR DESCRIPTION
Fix #3951 

I also handled the error, when the collaborator member id is not set. 