### PR TITLE
Fix issue with not fetching the member after signing up

### DIFF
--- a/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
+++ b/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
@@ -108,6 +108,7 @@ export const MemberView: FC = () => {
   } = useMemberships(
     { where: { handle_eq: handle } },
     {
+      fetchPolicy: 'network-only',
       onError: (error) => SentryLogger.error('Failed to fetch memberships', 'ActiveUserProvider', error),
     }
   )

--- a/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
+++ b/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
@@ -108,6 +108,7 @@ export const MemberView: FC = () => {
   } = useMemberships(
     { where: { handle_eq: handle } },
     {
+      // We're using network-only here, because for some reason the cache is not returning results after user creates membership.
       fetchPolicy: 'network-only',
       onError: (error) => SentryLogger.error('Failed to fetch memberships', 'ActiveUserProvider', error),
     }


### PR DESCRIPTION
Fix #3913

I choose the `orion-v2` branch because the problem was introduced after Orion v2 integration. As far as I know, this is not reproducible on the current `dev` branch and `master` branch. Only on the `orion-v2` and `ephesus`

After a user creates a membership, we're refetching all the members that are connected to the user's accounts, but for some reason, the newly created membership is not taken from the apollo cache and therefore not used in MembershipView.  So I decided to use the `network-only` policy. The solution for the issue is not elegant, but I couldn't figure out anything better.
