### PR TITLE
Fix nft carousel, fix the issue with not setting the app id

### DIFF
--- a/packages/atlas/src/api/client/cache.ts
+++ b/packages/atlas/src/api/client/cache.ts
@@ -156,7 +156,7 @@ const queryCacheFields: CachePolicyFields<keyof Query> = {
   ownedNfts: {
     ...offsetLimitPagination(getNftKeyArgs),
     read(existing, { args, toReference, canRead }) {
-      if (args?.where.id_eq) {
+      if (args?.where?.id_eq) {
         // get single nft
         const nftRef = toReference({
           __typename: 'OwnedNft',
@@ -177,7 +177,7 @@ const queryCacheFields: CachePolicyFields<keyof Query> = {
   videos: {
     ...offsetLimitPagination(getVideoKeyArgs),
     read(existing, { args, toReference, canRead }) {
-      if (args?.where.id_eq) {
+      if (args?.where?.id_eq) {
         // get single video
         const videoRef = toReference({
           __typename: 'Video',

--- a/packages/atlas/src/api/queries/__generated__/channels.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/channels.generated.tsx
@@ -510,6 +510,20 @@ export type GetChannelNftCollectorsQuery = {
   }>
 }
 
+export type GetTotalChannelsAndTotalVideosQueryVariables = Types.Exact<{
+  memberId: Types.Scalars['String']
+  channelId: Types.Scalars['String']
+}>
+
+export type GetTotalChannelsAndTotalVideosQuery = {
+  __typename?: 'Query'
+  membershipById?: {
+    __typename?: 'Membership'
+    totalChannelsCreated: number
+    channels: Array<{ __typename?: 'Channel'; totalVideosCreated: number }>
+  } | null
+}
+
 export type ReportChannelMutationVariables = Types.Exact<{
   channelId: Types.Scalars['String']
   rationale: Types.Scalars['String']
@@ -1097,6 +1111,66 @@ export type GetChannelNftCollectorsLazyQueryHookResult = ReturnType<typeof useGe
 export type GetChannelNftCollectorsQueryResult = Apollo.QueryResult<
   GetChannelNftCollectorsQuery,
   GetChannelNftCollectorsQueryVariables
+>
+export const GetTotalChannelsAndTotalVideosDocument = gql`
+  query GetTotalChannelsAndTotalVideos($memberId: String!, $channelId: String!) {
+    membershipById(id: $memberId) {
+      totalChannelsCreated
+      channels(where: { id_eq: $channelId }) {
+        totalVideosCreated
+      }
+    }
+  }
+`
+
+/**
+ * __useGetTotalChannelsAndTotalVideosQuery__
+ *
+ * To run a query within a React component, call `useGetTotalChannelsAndTotalVideosQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTotalChannelsAndTotalVideosQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTotalChannelsAndTotalVideosQuery({
+ *   variables: {
+ *      memberId: // value for 'memberId'
+ *      channelId: // value for 'channelId'
+ *   },
+ * });
+ */
+export function useGetTotalChannelsAndTotalVideosQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetTotalChannelsAndTotalVideosQuery,
+    GetTotalChannelsAndTotalVideosQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetTotalChannelsAndTotalVideosQuery, GetTotalChannelsAndTotalVideosQueryVariables>(
+    GetTotalChannelsAndTotalVideosDocument,
+    options
+  )
+}
+export function useGetTotalChannelsAndTotalVideosLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetTotalChannelsAndTotalVideosQuery,
+    GetTotalChannelsAndTotalVideosQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetTotalChannelsAndTotalVideosQuery, GetTotalChannelsAndTotalVideosQueryVariables>(
+    GetTotalChannelsAndTotalVideosDocument,
+    options
+  )
+}
+export type GetTotalChannelsAndTotalVideosQueryHookResult = ReturnType<typeof useGetTotalChannelsAndTotalVideosQuery>
+export type GetTotalChannelsAndTotalVideosLazyQueryHookResult = ReturnType<
+  typeof useGetTotalChannelsAndTotalVideosLazyQuery
+>
+export type GetTotalChannelsAndTotalVideosQueryResult = Apollo.QueryResult<
+  GetTotalChannelsAndTotalVideosQuery,
+  GetTotalChannelsAndTotalVideosQueryVariables
 >
 export const ReportChannelDocument = gql`
   mutation ReportChannel($channelId: String!, $rationale: String!) {

--- a/packages/atlas/src/api/queries/__generated__/nfts.generated.tsx
+++ b/packages/atlas/src/api/queries/__generated__/nfts.generated.tsx
@@ -1745,12 +1745,11 @@ export type GetFeaturedNftsQuery = {
     creatorRoyalty?: number | null
     lastSaleDate?: Date | null
     lastSalePrice?: string | null
-    isOwnedByChannel: boolean
     video: {
       __typename?: 'Video'
       id: string
       title?: string | null
-      views: number
+      viewsNum: number
       createdAt: Date
       duration?: number | null
       reactionsCount: number
@@ -1758,18 +1757,20 @@ export type GetFeaturedNftsQuery = {
       media?: {
         __typename?: 'StorageDataObject'
         id: string
+        resolvedUrls: Array<string>
+        resolvedUrl?: string | null
         createdAt: Date
         size: string
         isAccepted: boolean
         ipfsHash: string
         storageBag: { __typename?: 'StorageBag'; id: string }
-        type:
+        type?:
           | { __typename: 'DataObjectTypeChannelAvatar' }
           | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-          | { __typename: 'DataObjectTypeUnknown' }
           | { __typename: 'DataObjectTypeVideoMedia' }
           | { __typename: 'DataObjectTypeVideoSubtitle' }
           | { __typename: 'DataObjectTypeVideoThumbnail' }
+          | null
       } | null
       channel: {
         __typename?: 'Channel'
@@ -1777,41 +1778,45 @@ export type GetFeaturedNftsQuery = {
         title?: string | null
         description?: string | null
         createdAt: Date
-        follows: number
+        followsNum: number
         rewardAccount: string
         channelStateBloatBond: string
         avatarPhoto?: {
           __typename?: 'StorageDataObject'
           id: string
+          resolvedUrls: Array<string>
+          resolvedUrl?: string | null
           createdAt: Date
           size: string
           isAccepted: boolean
           ipfsHash: string
           storageBag: { __typename?: 'StorageBag'; id: string }
-          type:
+          type?:
             | { __typename: 'DataObjectTypeChannelAvatar' }
             | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-            | { __typename: 'DataObjectTypeUnknown' }
             | { __typename: 'DataObjectTypeVideoMedia' }
             | { __typename: 'DataObjectTypeVideoSubtitle' }
             | { __typename: 'DataObjectTypeVideoThumbnail' }
+            | null
         } | null
       }
       thumbnailPhoto?: {
         __typename?: 'StorageDataObject'
         id: string
+        resolvedUrls: Array<string>
+        resolvedUrl?: string | null
         createdAt: Date
         size: string
         isAccepted: boolean
         ipfsHash: string
         storageBag: { __typename?: 'StorageBag'; id: string }
-        type:
+        type?:
           | { __typename: 'DataObjectTypeChannelAvatar' }
           | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-          | { __typename: 'DataObjectTypeUnknown' }
           | { __typename: 'DataObjectTypeVideoMedia' }
           | { __typename: 'DataObjectTypeVideoSubtitle' }
           | { __typename: 'DataObjectTypeVideoThumbnail' }
+          | null
       } | null
       nft?: {
         __typename?: 'OwnedNft'
@@ -1820,421 +1825,496 @@ export type GetFeaturedNftsQuery = {
         creatorRoyalty?: number | null
         lastSaleDate?: Date | null
         lastSalePrice?: string | null
-        isOwnedByChannel: boolean
-        ownerMember?: {
-          __typename?: 'Membership'
-          id: string
-          handle: string
-          metadata: {
-            __typename?: 'MemberMetadata'
-            about?: string | null
-            avatar?:
-              | {
-                  __typename?: 'AvatarObject'
-                  avatarObject?: {
-                    __typename?: 'StorageDataObject'
-                    id: string
-                    createdAt: Date
-                    size: string
-                    isAccepted: boolean
-                    ipfsHash: string
-                    storageBag: { __typename?: 'StorageBag'; id: string }
-                    type:
-                      | { __typename: 'DataObjectTypeChannelAvatar' }
-                      | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                      | { __typename: 'DataObjectTypeUnknown' }
-                      | { __typename: 'DataObjectTypeVideoMedia' }
-                      | { __typename: 'DataObjectTypeVideoSubtitle' }
-                      | { __typename: 'DataObjectTypeVideoThumbnail' }
+        owner:
+          | {
+              __typename: 'NftOwnerChannel'
+              channel: {
+                __typename?: 'Channel'
+                id: string
+                title?: string | null
+                description?: string | null
+                createdAt: Date
+                followsNum: number
+                rewardAccount: string
+                channelStateBloatBond: string
+                ownerMember?: {
+                  __typename?: 'Membership'
+                  id: string
+                  handle: string
+                  metadata?: {
+                    __typename?: 'MemberMetadata'
+                    about?: string | null
+                    avatar?:
+                      | {
+                          __typename?: 'AvatarObject'
+                          avatarObject: {
+                            __typename?: 'StorageDataObject'
+                            id: string
+                            resolvedUrls: Array<string>
+                            resolvedUrl?: string | null
+                            createdAt: Date
+                            size: string
+                            isAccepted: boolean
+                            ipfsHash: string
+                            storageBag: { __typename?: 'StorageBag'; id: string }
+                            type?:
+                              | { __typename: 'DataObjectTypeChannelAvatar' }
+                              | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                              | { __typename: 'DataObjectTypeVideoMedia' }
+                              | { __typename: 'DataObjectTypeVideoSubtitle' }
+                              | { __typename: 'DataObjectTypeVideoThumbnail' }
+                              | null
+                          }
+                        }
+                      | { __typename?: 'AvatarUri'; avatarUri: string }
+                      | null
                   } | null
-                }
-              | { __typename?: 'AvatarUri'; avatarUri: string }
-              | null
-          }
-        } | null
-        transactionalStatusAuction?: {
-          __typename?: 'Auction'
-          id: string
-          isCompleted: boolean
-          buyNowPrice?: string | null
-          startingPrice: string
-          startsAtBlock: number
-          endedAtBlock?: number | null
-          auctionType:
-            | {
-                __typename: 'AuctionTypeEnglish'
-                duration: number
-                extensionPeriod: number
-                minimalBidStep: string
-                plannedEndAtBlock: number
-              }
-            | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
-          initialOwner?: {
-            __typename?: 'Membership'
-            id: string
-            handle: string
-            metadata: {
-              __typename?: 'MemberMetadata'
-              about?: string | null
-              avatar?:
-                | {
-                    __typename?: 'AvatarObject'
-                    avatarObject?: {
-                      __typename?: 'StorageDataObject'
-                      id: string
-                      createdAt: Date
-                      size: string
-                      isAccepted: boolean
-                      ipfsHash: string
-                      storageBag: { __typename?: 'StorageBag'; id: string }
-                      type:
-                        | { __typename: 'DataObjectTypeChannelAvatar' }
-                        | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                        | { __typename: 'DataObjectTypeUnknown' }
-                        | { __typename: 'DataObjectTypeVideoMedia' }
-                        | { __typename: 'DataObjectTypeVideoSubtitle' }
-                        | { __typename: 'DataObjectTypeVideoThumbnail' }
-                    } | null
-                  }
-                | { __typename?: 'AvatarUri'; avatarUri: string }
-                | null
-            }
-          } | null
-          topBid?: {
-            __typename?: 'Bid'
-            amount: string
-            createdAt: Date
-            isCanceled: boolean
-            createdInBlock: number
-            id: string
-            bidder: {
-              __typename?: 'Membership'
-              id: string
-              handle: string
-              metadata: {
-                __typename?: 'MemberMetadata'
-                about?: string | null
-                avatar?:
-                  | {
-                      __typename?: 'AvatarObject'
-                      avatarObject?: {
-                        __typename?: 'StorageDataObject'
-                        id: string
-                        createdAt: Date
-                        size: string
-                        isAccepted: boolean
-                        ipfsHash: string
-                        storageBag: { __typename?: 'StorageBag'; id: string }
-                        type:
-                          | { __typename: 'DataObjectTypeChannelAvatar' }
-                          | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                          | { __typename: 'DataObjectTypeUnknown' }
-                          | { __typename: 'DataObjectTypeVideoMedia' }
-                          | { __typename: 'DataObjectTypeVideoSubtitle' }
-                          | { __typename: 'DataObjectTypeVideoThumbnail' }
-                      } | null
-                    }
-                  | { __typename?: 'AvatarUri'; avatarUri: string }
-                  | null
+                } | null
+                avatarPhoto?: {
+                  __typename?: 'StorageDataObject'
+                  id: string
+                  resolvedUrls: Array<string>
+                  resolvedUrl?: string | null
+                  createdAt: Date
+                  size: string
+                  isAccepted: boolean
+                  ipfsHash: string
+                  storageBag: { __typename?: 'StorageBag'; id: string }
+                  type?:
+                    | { __typename: 'DataObjectTypeChannelAvatar' }
+                    | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                    | { __typename: 'DataObjectTypeVideoMedia' }
+                    | { __typename: 'DataObjectTypeVideoSubtitle' }
+                    | { __typename: 'DataObjectTypeVideoThumbnail' }
+                    | null
+                } | null
               }
             }
-          } | null
-          bids: Array<{
-            __typename?: 'Bid'
-            amount: string
-            createdAt: Date
-            isCanceled: boolean
-            createdInBlock: number
-            id: string
-            bidder: {
-              __typename?: 'Membership'
-              id: string
-              handle: string
-              metadata: {
-                __typename?: 'MemberMetadata'
-                about?: string | null
-                avatar?:
-                  | {
-                      __typename?: 'AvatarObject'
-                      avatarObject?: {
-                        __typename?: 'StorageDataObject'
-                        id: string
-                        createdAt: Date
-                        size: string
-                        isAccepted: boolean
-                        ipfsHash: string
-                        storageBag: { __typename?: 'StorageBag'; id: string }
-                        type:
-                          | { __typename: 'DataObjectTypeChannelAvatar' }
-                          | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                          | { __typename: 'DataObjectTypeUnknown' }
-                          | { __typename: 'DataObjectTypeVideoMedia' }
-                          | { __typename: 'DataObjectTypeVideoSubtitle' }
-                          | { __typename: 'DataObjectTypeVideoThumbnail' }
-                      } | null
-                    }
-                  | { __typename?: 'AvatarUri'; avatarUri: string }
-                  | null
+          | {
+              __typename: 'NftOwnerMember'
+              member: {
+                __typename?: 'Membership'
+                id: string
+                handle: string
+                metadata?: {
+                  __typename?: 'MemberMetadata'
+                  about?: string | null
+                  avatar?:
+                    | {
+                        __typename?: 'AvatarObject'
+                        avatarObject: {
+                          __typename?: 'StorageDataObject'
+                          id: string
+                          resolvedUrls: Array<string>
+                          resolvedUrl?: string | null
+                          createdAt: Date
+                          size: string
+                          isAccepted: boolean
+                          ipfsHash: string
+                          storageBag: { __typename?: 'StorageBag'; id: string }
+                          type?:
+                            | { __typename: 'DataObjectTypeChannelAvatar' }
+                            | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                            | { __typename: 'DataObjectTypeVideoMedia' }
+                            | { __typename: 'DataObjectTypeVideoSubtitle' }
+                            | { __typename: 'DataObjectTypeVideoThumbnail' }
+                            | null
+                        }
+                      }
+                    | { __typename?: 'AvatarUri'; avatarUri: string }
+                    | null
+                } | null
               }
             }
-          }>
-          whitelistedMembers: Array<{
-            __typename?: 'Membership'
-            id: string
-            handle: string
-            metadata: {
-              __typename?: 'MemberMetadata'
-              about?: string | null
-              avatar?:
-                | {
-                    __typename?: 'AvatarObject'
-                    avatarObject?: {
-                      __typename?: 'StorageDataObject'
-                      id: string
-                      createdAt: Date
-                      size: string
-                      isAccepted: boolean
-                      ipfsHash: string
-                      storageBag: { __typename?: 'StorageBag'; id: string }
-                      type:
-                        | { __typename: 'DataObjectTypeChannelAvatar' }
-                        | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                        | { __typename: 'DataObjectTypeUnknown' }
-                        | { __typename: 'DataObjectTypeVideoMedia' }
-                        | { __typename: 'DataObjectTypeVideoSubtitle' }
-                        | { __typename: 'DataObjectTypeVideoThumbnail' }
-                    } | null
-                  }
-                | { __typename?: 'AvatarUri'; avatarUri: string }
-                | null
-            }
-          }>
-        } | null
         transactionalStatus?:
+          | {
+              __typename: 'TransactionalStatusAuction'
+              auction: {
+                __typename?: 'Auction'
+                id: string
+                isCompleted: boolean
+                buyNowPrice?: string | null
+                startingPrice: string
+                startsAtBlock: number
+                endedAtBlock?: number | null
+                auctionType:
+                  | {
+                      __typename: 'AuctionTypeEnglish'
+                      duration: number
+                      extensionPeriod: number
+                      minimalBidStep: string
+                      plannedEndAtBlock: number
+                    }
+                  | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
+                topBid?: {
+                  __typename?: 'Bid'
+                  amount: string
+                  createdAt: Date
+                  isCanceled: boolean
+                  createdInBlock: number
+                  id: string
+                  bidder: {
+                    __typename?: 'Membership'
+                    id: string
+                    handle: string
+                    metadata?: {
+                      __typename?: 'MemberMetadata'
+                      about?: string | null
+                      avatar?:
+                        | {
+                            __typename?: 'AvatarObject'
+                            avatarObject: {
+                              __typename?: 'StorageDataObject'
+                              id: string
+                              resolvedUrls: Array<string>
+                              resolvedUrl?: string | null
+                              createdAt: Date
+                              size: string
+                              isAccepted: boolean
+                              ipfsHash: string
+                              storageBag: { __typename?: 'StorageBag'; id: string }
+                              type?:
+                                | { __typename: 'DataObjectTypeChannelAvatar' }
+                                | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                                | { __typename: 'DataObjectTypeVideoMedia' }
+                                | { __typename: 'DataObjectTypeVideoSubtitle' }
+                                | { __typename: 'DataObjectTypeVideoThumbnail' }
+                                | null
+                            }
+                          }
+                        | { __typename?: 'AvatarUri'; avatarUri: string }
+                        | null
+                    } | null
+                  }
+                } | null
+                bids: Array<{
+                  __typename?: 'Bid'
+                  amount: string
+                  createdAt: Date
+                  isCanceled: boolean
+                  createdInBlock: number
+                  id: string
+                  bidder: {
+                    __typename?: 'Membership'
+                    id: string
+                    handle: string
+                    metadata?: {
+                      __typename?: 'MemberMetadata'
+                      about?: string | null
+                      avatar?:
+                        | {
+                            __typename?: 'AvatarObject'
+                            avatarObject: {
+                              __typename?: 'StorageDataObject'
+                              id: string
+                              resolvedUrls: Array<string>
+                              resolvedUrl?: string | null
+                              createdAt: Date
+                              size: string
+                              isAccepted: boolean
+                              ipfsHash: string
+                              storageBag: { __typename?: 'StorageBag'; id: string }
+                              type?:
+                                | { __typename: 'DataObjectTypeChannelAvatar' }
+                                | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                                | { __typename: 'DataObjectTypeVideoMedia' }
+                                | { __typename: 'DataObjectTypeVideoSubtitle' }
+                                | { __typename: 'DataObjectTypeVideoThumbnail' }
+                                | null
+                            }
+                          }
+                        | { __typename?: 'AvatarUri'; avatarUri: string }
+                        | null
+                    } | null
+                  }
+                }>
+                whitelistedMembers: Array<{
+                  __typename?: 'AuctionWhitelistedMember'
+                  member: {
+                    __typename?: 'Membership'
+                    id: string
+                    handle: string
+                    metadata?: {
+                      __typename?: 'MemberMetadata'
+                      about?: string | null
+                      avatar?:
+                        | {
+                            __typename?: 'AvatarObject'
+                            avatarObject: {
+                              __typename?: 'StorageDataObject'
+                              id: string
+                              resolvedUrls: Array<string>
+                              resolvedUrl?: string | null
+                              createdAt: Date
+                              size: string
+                              isAccepted: boolean
+                              ipfsHash: string
+                              storageBag: { __typename?: 'StorageBag'; id: string }
+                              type?:
+                                | { __typename: 'DataObjectTypeChannelAvatar' }
+                                | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                                | { __typename: 'DataObjectTypeVideoMedia' }
+                                | { __typename: 'DataObjectTypeVideoSubtitle' }
+                                | { __typename: 'DataObjectTypeVideoThumbnail' }
+                                | null
+                            }
+                          }
+                        | { __typename?: 'AvatarUri'; avatarUri: string }
+                        | null
+                    } | null
+                  }
+                }>
+              }
+            }
           | { __typename: 'TransactionalStatusBuyNow'; price: string }
-          | { __typename: 'TransactionalStatusIdle'; dummy?: number | null }
+          | { __typename: 'TransactionalStatusIdle' }
           | { __typename: 'TransactionalStatusInitiatedOfferToMember' }
           | null
       } | null
     }
-    creatorChannel: {
-      __typename?: 'Channel'
-      id: string
-      title?: string | null
-      description?: string | null
-      createdAt: Date
-      follows: number
-      rewardAccount: string
-      channelStateBloatBond: string
-      avatarPhoto?: {
-        __typename?: 'StorageDataObject'
-        id: string
-        createdAt: Date
-        size: string
-        isAccepted: boolean
-        ipfsHash: string
-        storageBag: { __typename?: 'StorageBag'; id: string }
-        type:
-          | { __typename: 'DataObjectTypeChannelAvatar' }
-          | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-          | { __typename: 'DataObjectTypeUnknown' }
-          | { __typename: 'DataObjectTypeVideoMedia' }
-          | { __typename: 'DataObjectTypeVideoSubtitle' }
-          | { __typename: 'DataObjectTypeVideoThumbnail' }
-      } | null
-    }
-    ownerMember?: {
-      __typename?: 'Membership'
-      id: string
-      handle: string
-      metadata: {
-        __typename?: 'MemberMetadata'
-        about?: string | null
-        avatar?:
-          | {
-              __typename?: 'AvatarObject'
-              avatarObject?: {
-                __typename?: 'StorageDataObject'
-                id: string
-                createdAt: Date
-                size: string
-                isAccepted: boolean
-                ipfsHash: string
-                storageBag: { __typename?: 'StorageBag'; id: string }
-                type:
-                  | { __typename: 'DataObjectTypeChannelAvatar' }
-                  | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                  | { __typename: 'DataObjectTypeUnknown' }
-                  | { __typename: 'DataObjectTypeVideoMedia' }
-                  | { __typename: 'DataObjectTypeVideoSubtitle' }
-                  | { __typename: 'DataObjectTypeVideoThumbnail' }
+    owner:
+      | {
+          __typename: 'NftOwnerChannel'
+          channel: {
+            __typename?: 'Channel'
+            id: string
+            title?: string | null
+            description?: string | null
+            createdAt: Date
+            followsNum: number
+            rewardAccount: string
+            channelStateBloatBond: string
+            ownerMember?: {
+              __typename?: 'Membership'
+              id: string
+              handle: string
+              metadata?: {
+                __typename?: 'MemberMetadata'
+                about?: string | null
+                avatar?:
+                  | {
+                      __typename?: 'AvatarObject'
+                      avatarObject: {
+                        __typename?: 'StorageDataObject'
+                        id: string
+                        resolvedUrls: Array<string>
+                        resolvedUrl?: string | null
+                        createdAt: Date
+                        size: string
+                        isAccepted: boolean
+                        ipfsHash: string
+                        storageBag: { __typename?: 'StorageBag'; id: string }
+                        type?:
+                          | { __typename: 'DataObjectTypeChannelAvatar' }
+                          | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                          | { __typename: 'DataObjectTypeVideoMedia' }
+                          | { __typename: 'DataObjectTypeVideoSubtitle' }
+                          | { __typename: 'DataObjectTypeVideoThumbnail' }
+                          | null
+                      }
+                    }
+                  | { __typename?: 'AvatarUri'; avatarUri: string }
+                  | null
               } | null
-            }
-          | { __typename?: 'AvatarUri'; avatarUri: string }
-          | null
-      }
-    } | null
-    transactionalStatusAuction?: {
-      __typename?: 'Auction'
-      id: string
-      isCompleted: boolean
-      buyNowPrice?: string | null
-      startingPrice: string
-      startsAtBlock: number
-      endedAtBlock?: number | null
-      auctionType:
-        | {
-            __typename: 'AuctionTypeEnglish'
-            duration: number
-            extensionPeriod: number
-            minimalBidStep: string
-            plannedEndAtBlock: number
-          }
-        | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
-      initialOwner?: {
-        __typename?: 'Membership'
-        id: string
-        handle: string
-        metadata: {
-          __typename?: 'MemberMetadata'
-          about?: string | null
-          avatar?:
-            | {
-                __typename?: 'AvatarObject'
-                avatarObject?: {
-                  __typename?: 'StorageDataObject'
-                  id: string
-                  createdAt: Date
-                  size: string
-                  isAccepted: boolean
-                  ipfsHash: string
-                  storageBag: { __typename?: 'StorageBag'; id: string }
-                  type:
-                    | { __typename: 'DataObjectTypeChannelAvatar' }
-                    | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                    | { __typename: 'DataObjectTypeUnknown' }
-                    | { __typename: 'DataObjectTypeVideoMedia' }
-                    | { __typename: 'DataObjectTypeVideoSubtitle' }
-                    | { __typename: 'DataObjectTypeVideoThumbnail' }
-                } | null
-              }
-            | { __typename?: 'AvatarUri'; avatarUri: string }
-            | null
-        }
-      } | null
-      topBid?: {
-        __typename?: 'Bid'
-        amount: string
-        createdAt: Date
-        isCanceled: boolean
-        createdInBlock: number
-        id: string
-        bidder: {
-          __typename?: 'Membership'
-          id: string
-          handle: string
-          metadata: {
-            __typename?: 'MemberMetadata'
-            about?: string | null
-            avatar?:
-              | {
-                  __typename?: 'AvatarObject'
-                  avatarObject?: {
-                    __typename?: 'StorageDataObject'
-                    id: string
-                    createdAt: Date
-                    size: string
-                    isAccepted: boolean
-                    ipfsHash: string
-                    storageBag: { __typename?: 'StorageBag'; id: string }
-                    type:
-                      | { __typename: 'DataObjectTypeChannelAvatar' }
-                      | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                      | { __typename: 'DataObjectTypeUnknown' }
-                      | { __typename: 'DataObjectTypeVideoMedia' }
-                      | { __typename: 'DataObjectTypeVideoSubtitle' }
-                      | { __typename: 'DataObjectTypeVideoThumbnail' }
-                  } | null
-                }
-              | { __typename?: 'AvatarUri'; avatarUri: string }
-              | null
+            } | null
+            avatarPhoto?: {
+              __typename?: 'StorageDataObject'
+              id: string
+              resolvedUrls: Array<string>
+              resolvedUrl?: string | null
+              createdAt: Date
+              size: string
+              isAccepted: boolean
+              ipfsHash: string
+              storageBag: { __typename?: 'StorageBag'; id: string }
+              type?:
+                | { __typename: 'DataObjectTypeChannelAvatar' }
+                | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                | { __typename: 'DataObjectTypeVideoMedia' }
+                | { __typename: 'DataObjectTypeVideoSubtitle' }
+                | { __typename: 'DataObjectTypeVideoThumbnail' }
+                | null
+            } | null
           }
         }
-      } | null
-      bids: Array<{
-        __typename?: 'Bid'
-        amount: string
-        createdAt: Date
-        isCanceled: boolean
-        createdInBlock: number
-        id: string
-        bidder: {
-          __typename?: 'Membership'
-          id: string
-          handle: string
-          metadata: {
-            __typename?: 'MemberMetadata'
-            about?: string | null
-            avatar?:
-              | {
-                  __typename?: 'AvatarObject'
-                  avatarObject?: {
-                    __typename?: 'StorageDataObject'
-                    id: string
-                    createdAt: Date
-                    size: string
-                    isAccepted: boolean
-                    ipfsHash: string
-                    storageBag: { __typename?: 'StorageBag'; id: string }
-                    type:
-                      | { __typename: 'DataObjectTypeChannelAvatar' }
-                      | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                      | { __typename: 'DataObjectTypeUnknown' }
-                      | { __typename: 'DataObjectTypeVideoMedia' }
-                      | { __typename: 'DataObjectTypeVideoSubtitle' }
-                      | { __typename: 'DataObjectTypeVideoThumbnail' }
-                  } | null
-                }
-              | { __typename?: 'AvatarUri'; avatarUri: string }
-              | null
+      | {
+          __typename: 'NftOwnerMember'
+          member: {
+            __typename?: 'Membership'
+            id: string
+            handle: string
+            metadata?: {
+              __typename?: 'MemberMetadata'
+              about?: string | null
+              avatar?:
+                | {
+                    __typename?: 'AvatarObject'
+                    avatarObject: {
+                      __typename?: 'StorageDataObject'
+                      id: string
+                      resolvedUrls: Array<string>
+                      resolvedUrl?: string | null
+                      createdAt: Date
+                      size: string
+                      isAccepted: boolean
+                      ipfsHash: string
+                      storageBag: { __typename?: 'StorageBag'; id: string }
+                      type?:
+                        | { __typename: 'DataObjectTypeChannelAvatar' }
+                        | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                        | { __typename: 'DataObjectTypeVideoMedia' }
+                        | { __typename: 'DataObjectTypeVideoSubtitle' }
+                        | { __typename: 'DataObjectTypeVideoThumbnail' }
+                        | null
+                    }
+                  }
+                | { __typename?: 'AvatarUri'; avatarUri: string }
+                | null
+            } | null
           }
         }
-      }>
-      whitelistedMembers: Array<{
-        __typename?: 'Membership'
-        id: string
-        handle: string
-        metadata: {
-          __typename?: 'MemberMetadata'
-          about?: string | null
-          avatar?:
-            | {
-                __typename?: 'AvatarObject'
-                avatarObject?: {
-                  __typename?: 'StorageDataObject'
-                  id: string
-                  createdAt: Date
-                  size: string
-                  isAccepted: boolean
-                  ipfsHash: string
-                  storageBag: { __typename?: 'StorageBag'; id: string }
-                  type:
-                    | { __typename: 'DataObjectTypeChannelAvatar' }
-                    | { __typename: 'DataObjectTypeChannelCoverPhoto' }
-                    | { __typename: 'DataObjectTypeUnknown' }
-                    | { __typename: 'DataObjectTypeVideoMedia' }
-                    | { __typename: 'DataObjectTypeVideoSubtitle' }
-                    | { __typename: 'DataObjectTypeVideoThumbnail' }
-                } | null
-              }
-            | { __typename?: 'AvatarUri'; avatarUri: string }
-            | null
-        }
-      }>
-    } | null
     transactionalStatus?:
+      | {
+          __typename: 'TransactionalStatusAuction'
+          auction: {
+            __typename?: 'Auction'
+            id: string
+            isCompleted: boolean
+            buyNowPrice?: string | null
+            startingPrice: string
+            startsAtBlock: number
+            endedAtBlock?: number | null
+            auctionType:
+              | {
+                  __typename: 'AuctionTypeEnglish'
+                  duration: number
+                  extensionPeriod: number
+                  minimalBidStep: string
+                  plannedEndAtBlock: number
+                }
+              | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
+            topBid?: {
+              __typename?: 'Bid'
+              amount: string
+              createdAt: Date
+              isCanceled: boolean
+              createdInBlock: number
+              id: string
+              bidder: {
+                __typename?: 'Membership'
+                id: string
+                handle: string
+                metadata?: {
+                  __typename?: 'MemberMetadata'
+                  about?: string | null
+                  avatar?:
+                    | {
+                        __typename?: 'AvatarObject'
+                        avatarObject: {
+                          __typename?: 'StorageDataObject'
+                          id: string
+                          resolvedUrls: Array<string>
+                          resolvedUrl?: string | null
+                          createdAt: Date
+                          size: string
+                          isAccepted: boolean
+                          ipfsHash: string
+                          storageBag: { __typename?: 'StorageBag'; id: string }
+                          type?:
+                            | { __typename: 'DataObjectTypeChannelAvatar' }
+                            | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                            | { __typename: 'DataObjectTypeVideoMedia' }
+                            | { __typename: 'DataObjectTypeVideoSubtitle' }
+                            | { __typename: 'DataObjectTypeVideoThumbnail' }
+                            | null
+                        }
+                      }
+                    | { __typename?: 'AvatarUri'; avatarUri: string }
+                    | null
+                } | null
+              }
+            } | null
+            bids: Array<{
+              __typename?: 'Bid'
+              amount: string
+              createdAt: Date
+              isCanceled: boolean
+              createdInBlock: number
+              id: string
+              bidder: {
+                __typename?: 'Membership'
+                id: string
+                handle: string
+                metadata?: {
+                  __typename?: 'MemberMetadata'
+                  about?: string | null
+                  avatar?:
+                    | {
+                        __typename?: 'AvatarObject'
+                        avatarObject: {
+                          __typename?: 'StorageDataObject'
+                          id: string
+                          resolvedUrls: Array<string>
+                          resolvedUrl?: string | null
+                          createdAt: Date
+                          size: string
+                          isAccepted: boolean
+                          ipfsHash: string
+                          storageBag: { __typename?: 'StorageBag'; id: string }
+                          type?:
+                            | { __typename: 'DataObjectTypeChannelAvatar' }
+                            | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                            | { __typename: 'DataObjectTypeVideoMedia' }
+                            | { __typename: 'DataObjectTypeVideoSubtitle' }
+                            | { __typename: 'DataObjectTypeVideoThumbnail' }
+                            | null
+                        }
+                      }
+                    | { __typename?: 'AvatarUri'; avatarUri: string }
+                    | null
+                } | null
+              }
+            }>
+            whitelistedMembers: Array<{
+              __typename?: 'AuctionWhitelistedMember'
+              member: {
+                __typename?: 'Membership'
+                id: string
+                handle: string
+                metadata?: {
+                  __typename?: 'MemberMetadata'
+                  about?: string | null
+                  avatar?:
+                    | {
+                        __typename?: 'AvatarObject'
+                        avatarObject: {
+                          __typename?: 'StorageDataObject'
+                          id: string
+                          resolvedUrls: Array<string>
+                          resolvedUrl?: string | null
+                          createdAt: Date
+                          size: string
+                          isAccepted: boolean
+                          ipfsHash: string
+                          storageBag: { __typename?: 'StorageBag'; id: string }
+                          type?:
+                            | { __typename: 'DataObjectTypeChannelAvatar' }
+                            | { __typename: 'DataObjectTypeChannelCoverPhoto' }
+                            | { __typename: 'DataObjectTypeVideoMedia' }
+                            | { __typename: 'DataObjectTypeVideoSubtitle' }
+                            | { __typename: 'DataObjectTypeVideoThumbnail' }
+                            | null
+                        }
+                      }
+                    | { __typename?: 'AvatarUri'; avatarUri: string }
+                    | null
+                } | null
+              }
+            }>
+          }
+        }
       | { __typename: 'TransactionalStatusBuyNow'; price: string }
-      | { __typename: 'TransactionalStatusIdle'; dummy?: number | null }
+      | { __typename: 'TransactionalStatusIdle' }
       | { __typename: 'TransactionalStatusInitiatedOfferToMember' }
       | null
   }>

--- a/packages/atlas/src/api/queries/channels.graphql
+++ b/packages/atlas/src/api/queries/channels.graphql
@@ -118,6 +118,15 @@ query GetChannelNftCollectors($channelId: String!, $orderBy: ChannelNftCollector
   }
 }
 
+query GetTotalChannelsAndTotalVideos($memberId: String!, $channelId: String!) {
+  membershipById(id: $memberId) {
+    totalChannelsCreated
+    channels(where: { id_eq: $channelId }) {
+      totalVideosCreated
+    }
+  }
+}
+
 # CHANGE: `ID` is now `String`
 mutation ReportChannel($channelId: String!, $rationale: String!) {
   reportChannel(channelId: $channelId, rationale: $rationale) {

--- a/packages/atlas/src/components/Avatar/AvatarGroup.tsx
+++ b/packages/atlas/src/components/Avatar/AvatarGroup.tsx
@@ -1,7 +1,7 @@
 import { FC, Fragment, PropsWithChildren, useRef, useState } from 'react'
 
 import { BasicMembershipFieldsFragment } from '@/api/queries/__generated__/fragments.generated'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 
 import { AvatarProps } from './Avatar'
 import {
@@ -95,7 +95,7 @@ type SingleAvatarProps = {
   size: AvatarProps['size']
 }
 const SingleAvatar: FC<SingleAvatarProps> = ({ avatar, loading: loadingProp, size }) => {
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(
     avatar.__typename === 'Membership' ? avatar : null
   )
 

--- a/packages/atlas/src/components/_comments/Comment/Comment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/Comment.tsx
@@ -10,7 +10,7 @@ import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useReactionTransactions } from '@/hooks/useReactionTransactions'
 import { useRouterQuery } from '@/hooks/useRouterQuery'
 import { CommentReaction } from '@/joystream-lib/types'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useConfirmationModal } from '@/providers/confirmationModal'
 import { useFee } from '@/providers/joystream/joystream.hooks'
 import { usePersonalDataStore } from '@/providers/personalData'
@@ -65,7 +65,7 @@ export const Comment: FC<CommentProps> = memo(
         skip: !commentId,
       }
     )
-    const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
+    const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = getMemberAvatar(activeMembership)
 
     const commentIdQueryParam = useRouterQuery(QUERY_PARAMS.COMMENT_ID)
     const reactionPopoverDismissed = usePersonalDataStore((state) => state.reactionPopoverDismissed)

--- a/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
+++ b/packages/atlas/src/components/_comments/Comment/InternalComment.tsx
@@ -17,7 +17,7 @@ import { atlasConfig } from '@/config'
 import { absoluteRoutes } from '@/config/routes'
 import { useTouchDevice } from '@/hooks/useTouchDevice'
 import { CommentReaction } from '@/joystream-lib/types'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { cVar, transitions } from '@/styles'
 import { createPlaceholderData } from '@/utils/data'
 import { formatDate, formatDateAgo } from '@/utils/time'
@@ -115,7 +115,7 @@ export const InternalComment: FC<InternalCommentProps> = ({
 
   const popoverRef = useRef<PopoverImperativeHandle>(null)
   const isTouchDevice = useTouchDevice()
-  const { url: memberAvatarUrl, isLoadingAsset: isMemberAvatarLoading } = useMemberAvatar(author)
+  const { url: memberAvatarUrl, isLoadingAsset: isMemberAvatarLoading } = getMemberAvatar(author)
   const filteredDuplicatedAvatars = repliesCount
     ? replyAvatars
       ? [...new Map(replyAvatars?.map((item) => [item.handle, item])).values()]

--- a/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
+++ b/packages/atlas/src/components/_comments/CommentEditHistory/CommentEditHistory.tsx
@@ -5,7 +5,7 @@ import { CSSTransition, SwitchTransition } from 'react-transition-group'
 import { useCommentEdits } from '@/api/hooks/comments'
 import { CommentFieldsFragment } from '@/api/queries/__generated__/fragments.generated'
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { cVar, transitions } from '@/styles'
 import { createPlaceholderData } from '@/utils/data'
 
@@ -18,7 +18,7 @@ type CommentEditHistoryProps = {
 
 export const CommentEditHistory: FC<CommentEditHistoryProps> = ({ originalComment }) => {
   const { commentEdits, loading } = useCommentEdits(originalComment?.id)
-  const { url: memberAvatarUrl, isLoadingAsset } = useMemberAvatar(originalComment?.author)
+  const { url: memberAvatarUrl, isLoadingAsset } = getMemberAvatar(originalComment?.author)
 
   const placeholderItems = createPlaceholderData(3)
 

--- a/packages/atlas/src/components/_inputs/MemberComboBox/MemberComboBox.tsx
+++ b/packages/atlas/src/components/_inputs/MemberComboBox/MemberComboBox.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/api/queries/__generated__/memberships.generated'
 import { SvgActionCancel } from '@/assets/icons'
 import { Avatar } from '@/components/Avatar'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { createLookup } from '@/utils/data'
 import { SentryLogger } from '@/utils/logs'
 
@@ -137,7 +137,7 @@ type AvatarWithResolvedAssetProps = {
 }
 
 const AvatarWithResolvedAsset: FC<AvatarWithResolvedAssetProps> = ({ member }) => {
-  const { url, isLoadingAsset } = useMemberAvatar(member)
+  const { url, isLoadingAsset } = getMemberAvatar(member)
   return <Avatar assetUrl={url} loading={isLoadingAsset} />
 }
 
@@ -154,7 +154,7 @@ const StyledOutputPillWithResolvedAsset: FC<StyledOutputPillWithResolvedAssetPro
   onKeyPress,
   focused,
 }) => {
-  const { url, isLoadingAsset } = useMemberAvatar(member)
+  const { url, isLoadingAsset } = getMemberAvatar(member)
   return (
     <StyledOutputPill
       handle={member.handle}

--- a/packages/atlas/src/components/_navigation/TopbarStudio/TopbarStudio.tsx
+++ b/packages/atlas/src/components/_navigation/TopbarStudio/TopbarStudio.tsx
@@ -10,7 +10,7 @@ import { NotificationsWidget } from '@/components/_notifications/NotificationsWi
 import { MemberDropdown } from '@/components/_overlays/MemberDropdown'
 import { absoluteRoutes } from '@/config/routes'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useUser } from '@/providers/user/user.hooks'
 import { useVideoWorkspace } from '@/providers/videoWorkspace'
 import { transitions } from '@/styles'
@@ -33,7 +33,7 @@ export const TopbarStudio: FC<StudioTopbarProps> = ({ hideChannelInfo, isMembers
 
   const channelAvatarUrl = currentChannel?.avatarPhoto?.resolvedUrl
 
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(activeMembership)
 
   const [isMemberDropdownActive, setIsMemberDropdownActive] = useState(false)
 

--- a/packages/atlas/src/components/_navigation/TopbarViewer/TopbarViewer.tsx
+++ b/packages/atlas/src/components/_navigation/TopbarViewer/TopbarViewer.tsx
@@ -12,7 +12,7 @@ import { MemberDropdown } from '@/components/_overlays/MemberDropdown'
 import { QUERY_PARAMS, absoluteRoutes } from '@/config/routes'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useOverlayManager } from '@/providers/overlayManager'
 import { useSearchStore } from '@/providers/search'
 import { useUser } from '@/providers/user/user.hooks'
@@ -33,7 +33,7 @@ export const TopbarViewer: FC = () => {
   const { isLoggedIn, activeMembership, signIn, isAuthLoading } = useUser()
   const [isMemberDropdownActive, setIsMemberDropdownActive] = useState(false)
 
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(activeMembership)
 
   const { pathname, search } = useLocation()
   const mdMatch = useMediaMatch('md')

--- a/packages/atlas/src/components/_nft/NftTileViewer/NftTileViewer.tsx
+++ b/packages/atlas/src/components/_nft/NftTileViewer/NftTileViewer.tsx
@@ -6,7 +6,7 @@ import { absoluteRoutes } from '@/config/routes'
 import { useNftState } from '@/hooks/useNftState'
 import { useNftTransactions } from '@/hooks/useNftTransactions'
 import { useVideoContextMenu } from '@/hooks/useVideoContextMenu'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useNftActions } from '@/providers/nftActions/nftActions.hooks'
 
 import { NftTile, NftTileProps } from '../NftTile'
@@ -35,7 +35,7 @@ export const NftTileViewer: FC<NftTileViewerProps> = ({ nftId }) => {
   const ownerMember = nft?.owner.__typename === 'NftOwnerMember' && nft.owner.member
   const ownerChannel = nft?.owner.__typename === 'NftOwnerChannel' && nft.owner.channel
 
-  const { url: ownerMemberAvatarUrl } = useMemberAvatar(ownerMember || null)
+  const { url: ownerMemberAvatarUrl } = getMemberAvatar(ownerMember || null)
 
   const isAuction = nftStatus?.status === 'auction'
 

--- a/packages/atlas/src/components/_nft/NftWidget/NftHistory.tsx
+++ b/packages/atlas/src/components/_nft/NftWidget/NftHistory.tsx
@@ -10,7 +10,7 @@ import { NumberFormat } from '@/components/NumberFormat'
 import { Text } from '@/components/Text'
 import { absoluteRoutes } from '@/config/routes'
 import { useToggle } from '@/hooks/useToggle'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useTokenPrice } from '@/providers/joystream/joystream.hooks'
 import { formatDateTime } from '@/utils/time'
 
@@ -66,7 +66,7 @@ type HistoryItemProps = {
 } & NftHistoryEntry
 export const HistoryItem: FC<HistoryItemProps> = ({ size, member, date, joyAmount, text }) => {
   const navigate = useNavigate()
-  const { url, isLoadingAsset } = useMemberAvatar(member)
+  const { url, isLoadingAsset } = getMemberAvatar(member)
   const { convertHapiToUSD } = useTokenPrice()
 
   const dollarValue = joyAmount ? convertHapiToUSD(joyAmount) : null

--- a/packages/atlas/src/components/_nft/NftWidget/NftWidget.hooks.ts
+++ b/packages/atlas/src/components/_nft/NftWidget/NftWidget.hooks.ts
@@ -8,7 +8,7 @@ import { FullVideoFieldsFragment } from '@/api/queries/__generated__/fragments.g
 import { NftWidgetProps } from '@/components/_nft/NftWidget/NftWidget'
 import { atlasConfig } from '@/config'
 import { useNftState } from '@/hooks/useNftState'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useUser } from '@/providers/user/user.hooks'
 import { SentryLogger } from '@/utils/logs'
 import { convertDateFormat } from '@/utils/time'
@@ -83,9 +83,9 @@ export const useNftWidget = (video: FullVideoFieldsFragment | undefined | null):
   const ownerMember = nftOwner?.__typename === 'NftOwnerMember' ? nftOwner.member : null
   const ownerChannel = nftOwner?.__typename === 'NftOwnerChannel' ? nftOwner.channel : null
 
-  const { url: ownerAvatarUri } = useMemberAvatar(ownerMember)
+  const { url: ownerAvatarUri } = getMemberAvatar(ownerMember)
   const creatorAvatarUri = ownerChannel?.avatarPhoto?.resolvedUrl
-  const { url: topBidderAvatarUri } = useMemberAvatar(nftStatus?.status === 'auction' ? nftStatus.topBidder : undefined)
+  const { url: topBidderAvatarUri } = getMemberAvatar(nftStatus?.status === 'auction' ? nftStatus.topBidder : undefined)
 
   const { entries: nftHistory } = useNftHistoryEntries(video?.id ?? '', {
     skip: !nft,

--- a/packages/atlas/src/components/_notifications/NotificationTile/NotificationTile.tsx
+++ b/packages/atlas/src/components/_notifications/NotificationTile/NotificationTile.tsx
@@ -7,7 +7,7 @@ import { Text } from '@/components/Text'
 import { Checkbox } from '@/components/_inputs/Checkbox'
 import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { NotificationRecord } from '@/providers/notifications/notifications.types'
 import { formatDateAgo } from '@/utils/time'
 
@@ -81,7 +81,7 @@ export const NotificationTile: FC<NotificationProps> = ({
   className,
 }) => {
   const { date, video, member, read } = notification
-  const { url: avatarUrl, isLoadingAsset: isLoadingAvatar } = useMemberAvatar(member)
+  const { url: avatarUrl, isLoadingAsset: isLoadingAvatar } = getMemberAvatar(member)
 
   const formattedDate = useMemo(() => {
     const differenceDays = differenceInDays(new Date(), date)

--- a/packages/atlas/src/components/_overlays/AcceptBidDialog/AcceptBidList.tsx
+++ b/packages/atlas/src/components/_overlays/AcceptBidDialog/AcceptBidList.tsx
@@ -8,7 +8,7 @@ import { Text } from '@/components/Text'
 import { RadioInput } from '@/components/_inputs/RadioInput'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { hapiBnToTokenNumber } from '@/joystream-lib/utils'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { formatDateTime } from '@/utils/time'
 
 import { Bid, SelectedBid } from './AcceptBidDialog.types'
@@ -46,7 +46,7 @@ export const AcceptBidList: FC<AcceptBidListProps> = ({ items, onSelect, selecte
 export const BidRow: FC<BidRowProps> = ({ bidder, createdAt, amount, amountUSD, selectedBid, onSelect }) => {
   const xsMatch = useMediaMatch('xs')
   const selected = selectedBid?.bidderId === bidder.id
-  const { url, isLoadingAsset } = useMemberAvatar(bidder)
+  const { url, isLoadingAsset } = getMemberAvatar(bidder)
   return (
     <BidRowWrapper selected={selected} onClick={() => onSelect?.(bidder.id, amount)}>
       <RadioInput

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdown.tsx
@@ -7,7 +7,7 @@ import { useTransition } from 'react-spring'
 import useResizeObserver from 'use-resize-observer'
 
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useSubscribeAccountBalance } from '@/providers/joystream/joystream.hooks'
 import { useUser } from '@/providers/user/user.hooks'
 import { cVar } from '@/styles'
@@ -34,7 +34,7 @@ export const MemberDropdown = forwardRef<HTMLDivElement, MemberDropdownProps>(
     const [disableScrollDuringAnimation, setDisableScrollDuringAnimation] = useState(false)
 
     const [showSendDialog, setShowSendDialog] = useState(false)
-    const { url: memberAvatarUrl } = useMemberAvatar(activeMembership)
+    const { url: memberAvatarUrl } = getMemberAvatar(activeMembership)
     const selectedChannel = activeMembership?.channels.find((chanel) => chanel.id === channelId)
 
     const memoizedChannelStateBloatBond = useMemo(() => {

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdownList.tsx
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdownList.tsx
@@ -9,7 +9,7 @@ import { Avatar } from '@/components/Avatar'
 import { IconWrapper } from '@/components/IconWrapper'
 import { ListItem } from '@/components/ListItem'
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 
 import { SectionContainer } from './MemberDropdown.styles'
 import { SwitchMemberItemListContainer } from './MemberDropdownList.styles'
@@ -97,7 +97,7 @@ type MemberListItemProps = {
   onClick: () => void
 }
 const MemberListItem: FC<MemberListItemProps> = ({ member, selected, onClick }) => {
-  const { url, isLoadingAsset } = useMemberAvatar(member)
+  const { url, isLoadingAsset } = getMemberAvatar(member)
   return (
     <ListItem
       onClick={onClick}

--- a/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdownNav.tsx
+++ b/packages/atlas/src/components/_overlays/MemberDropdown/MemberDropdownNav.tsx
@@ -25,7 +25,7 @@ import { Tooltip } from '@/components/Tooltip'
 import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
 import { atlasConfig } from '@/config'
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useUserStore } from '@/providers/user/user.store'
 import { cVar } from '@/styles'
 import { isMobile } from '@/utils/browser'
@@ -93,7 +93,7 @@ export const MemberDropdownNav: FC<MemberDropdownNavProps> = ({
 }) => {
   const navigate = useNavigate()
   const selectedChannel = activeMembership?.channels.find((chanel) => chanel.id === channelId)
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(activeMembership)
   const channelAvatarUrl = selectedChannel?.avatarPhoto?.resolvedUrl
   const setSignInModalOpen = useUserStore((state) => state.actions.setSignInModalOpen)
   const memberAvatarWrapperRef = useRef<HTMLButtonElement>(null)

--- a/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
+++ b/packages/atlas/src/components/_overlays/SendTransferDialogs/SendFundsDialog.tsx
@@ -22,7 +22,7 @@ import { TokenInput } from '@/components/_inputs/TokenInput'
 import { DialogModal } from '@/components/_overlays/DialogModal'
 import { atlasConfig } from '@/config'
 import { hapiBnToTokenNumber, tokenNumberToHapiBn } from '@/joystream-lib/utils'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useFee, useJoystream, useTokenPrice } from '@/providers/joystream/joystream.hooks'
 import { useTransaction } from '@/providers/transactions/transactions.hooks'
 import { formatJoystreamAddress, isValidAddressPolkadotAddress } from '@/utils/address'
@@ -247,7 +247,7 @@ type ResolvedAvatarProps = {
   member: BasicMembershipFieldsFragment
 } & AvatarProps
 const ResolvedAvatar: FC<ResolvedAvatarProps> = ({ member }) => {
-  const { url, isLoadingAsset } = useMemberAvatar(member)
+  const { url, isLoadingAsset } = getMemberAvatar(member)
   return (
     <Tooltip text={member?.handle} placement="top">
       <Avatar assetUrl={url} loading={isLoadingAsset} size="bid" />

--- a/packages/atlas/src/components/_video/VideoTilePublisher/VideoTilePublisher.tsx
+++ b/packages/atlas/src/components/_video/VideoTilePublisher/VideoTilePublisher.tsx
@@ -25,7 +25,7 @@ import { useGetNftSlot } from '@/hooks/useGetNftSlot'
 import { useNftState } from '@/hooks/useNftState'
 import { useVideoContextMenu } from '@/hooks/useVideoContextMenu'
 import { useVideoTileSharedLogic } from '@/hooks/useVideoTileSharedLogic'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useNftActions } from '@/providers/nftActions/nftActions.hooks'
 import { useUploadsStore } from '@/providers/uploads/uploads.store'
 import { SentryLogger } from '@/utils/logs'
@@ -69,7 +69,7 @@ export const VideoTilePublisher: FC<VideoTilePublisherProps> = memo(
     const videoNftOwner = video?.nft?.owner
     const ownerMember = videoNftOwner?.__typename === 'NftOwnerMember' ? videoNftOwner.member : null
 
-    const ownerAvatar = useMemberAvatar(ownerMember)
+    const ownerAvatar = getMemberAvatar(ownerMember)
 
     const nftStatus = getNftStatus(video?.nft, video)
 

--- a/packages/atlas/src/providers/assets/assets.helpers.ts
+++ b/packages/atlas/src/providers/assets/assets.helpers.ts
@@ -1,4 +1,5 @@
 import { DataObjectType } from '@/api/queries/__generated__/baseTypes.generated'
+import { BasicMembershipFieldsFragment } from '@/api/queries/__generated__/fragments.generated'
 import { BUILD_ENV } from '@/config/env'
 import { AssetLogger, ConsoleLogger, DataObjectResponseMetric, DistributorEventEntry } from '@/utils/logs'
 import { wait } from '@/utils/misc'
@@ -10,6 +11,18 @@ const imageAssetTypes: DataObjectType['__typename'][] = [
 ]
 const videoAssetTypes: DataObjectType['__typename'][] = ['DataObjectTypeVideoMedia']
 const subtitleAssetTypes: DataObjectType['__typename'][] = ['DataObjectTypeVideoSubtitle']
+
+export const getMemberAvatar = (member?: BasicMembershipFieldsFragment | null) => {
+  const avatar = member?.metadata?.avatar
+
+  if (avatar?.__typename === 'AvatarUri') {
+    return { url: avatar.avatarUri, isLoadingAsset: false }
+  } else if (avatar?.__typename === 'AvatarObject') {
+    return { url: avatar.avatarObject.resolvedUrl, isLoadingAsset: false }
+  }
+  // if avatar is `undefined` it means that avatar is not loaded yet, If it's `null` it means that it's not set
+  return { url: null, isLoadingAsset: avatar === null ? false : true }
+}
 
 export const testAssetDownload = (url: string, type: DataObjectType): Promise<number> => {
   return new Promise((_resolve, _reject) => {

--- a/packages/atlas/src/providers/assets/assets.hooks.ts
+++ b/packages/atlas/src/providers/assets/assets.hooks.ts
@@ -1,21 +1,8 @@
 import { useEffect, useState } from 'react'
 
-import { BasicMembershipFieldsFragment } from '@/api/queries/__generated__/fragments.generated'
 import { ChannelId } from '@/joystream-lib/types'
 import { useStorageOperators } from '@/providers/assets/assets.provider'
 import { createChannelBagId } from '@/utils/asset'
-
-export const useMemberAvatar = (member?: BasicMembershipFieldsFragment | null) => {
-  const avatar = member?.metadata?.avatar
-
-  if (avatar?.__typename === 'AvatarUri') {
-    return { url: avatar.avatarUri, isLoadingAsset: false }
-  } else if (avatar?.__typename === 'AvatarObject') {
-    return { url: avatar.avatarObject.resolvedUrl, isLoadingAsset: false }
-  }
-  // if avatar is `undefined` it means that avatar is not loaded yet, If it's `null` it means that it's not set
-  return { url: null, isLoadingAsset: avatar === null ? false : true }
-}
 
 export const useChannelsStorageBucketsCount = (channelId: ChannelId | null): number => {
   const [bucketsCount, setBucketsCount] = useState<number | null>(null)

--- a/packages/atlas/src/views/global/NftPurchaseBottomDrawer/NftPurchaseBottomDrawer.tsx
+++ b/packages/atlas/src/views/global/NftPurchaseBottomDrawer/NftPurchaseBottomDrawer.tsx
@@ -22,7 +22,7 @@ import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useMsTimestamp } from '@/hooks/useMsTimestamp'
 import { useNftState } from '@/hooks/useNftState'
 import { hapiBnToTokenNumber, tokenNumberToHapiBn } from '@/joystream-lib/utils'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useFee, useJoystream, useSubscribeAccountBalance } from '@/providers/joystream/joystream.hooks'
 import { useJoystreamStore } from '@/providers/joystream/joystream.store'
 import { useNftActions } from '@/providers/nftActions/nftActions.hooks'
@@ -64,7 +64,7 @@ export const NftPurchaseBottomDrawer: FC = () => {
   const { userBid, canChangeBid, userBidUnlockDate } = useNftState(nft)
   const thumbnailUrl = nft?.video.thumbnailPhoto?.resolvedUrl
   const creatorAvatarUrl = nft?.video.channel.avatarPhoto?.resolvedUrl
-  const { url: ownerMemberAvatarUrl } = useMemberAvatar(
+  const { url: ownerMemberAvatarUrl } = getMemberAvatar(
     nft?.owner.__typename === 'NftOwnerMember' ? nft.owner.member : null
   )
   const mdMatch = useMediaMatch('md')
@@ -282,8 +282,8 @@ export const NftPurchaseBottomDrawer: FC = () => {
     }
   }, [isOpen, setValue])
 
-  const { isLoadingAsset: userBidAvatarLoading, url: userBidAvatarUrl } = useMemberAvatar(userBid?.bidder)
-  const { isLoadingAsset: topBidderAvatarLoading, url: topBidderAvatarUrl } = useMemberAvatar(topBidder)
+  const { isLoadingAsset: userBidAvatarLoading, url: userBidAvatarUrl } = getMemberAvatar(userBid?.bidder)
+  const { isLoadingAsset: topBidderAvatarLoading, url: topBidderAvatarUrl } = getMemberAvatar(topBidder)
   const timeToUnlockSeconds = userBidUnlockDate ? differenceInSeconds(userBidUnlockDate, new Date()) : 0
 
   return (

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/AcceptTerms/AcceptTerms.tsx
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/AcceptTerms/AcceptTerms.tsx
@@ -7,7 +7,7 @@ import { SvgAlertsInformative24 } from '@/assets/icons'
 import { NumberFormat } from '@/components/NumberFormat'
 import { Text } from '@/components/Text'
 import { atlasConfig } from '@/config'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useJoystream } from '@/providers/joystream/joystream.hooks'
 import { formatDateTime } from '@/utils/time'
 
@@ -247,7 +247,7 @@ export const AcceptTerms: FC<AcceptTermsProps> = ({
 }
 
 export const MemberWithResolvedAvatar: FC<{ member: BasicMembershipFieldsFragment }> = ({ member }) => {
-  const { isLoadingAsset, url } = useMemberAvatar(member)
+  const { isLoadingAsset, url } = getMemberAvatar(member)
   return <StyledOutputPill avatarUri={url} isLoadingAvatar={isLoadingAsset} handle={member.handle} withAvatar />
 }
 

--- a/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.tsx
+++ b/packages/atlas/src/views/global/NftSaleBottomDrawer/NftForm/NftForm.tsx
@@ -13,7 +13,7 @@ import { atlasConfig } from '@/config'
 import { useBlockTimeEstimation } from '@/hooks/useBlockTimeEstimation'
 import { NftBuyNowInputMetadata, NftSaleInputMetadata } from '@/joystream-lib/types'
 import { hapiBnToTokenNumber, tokenNumberToHapiBn } from '@/joystream-lib/utils'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useConfirmationModal } from '@/providers/confirmationModal'
 import { useFee } from '@/providers/joystream/joystream.hooks'
 import { useUser } from '@/providers/user/user.hooks'
@@ -107,7 +107,7 @@ export const NftForm: FC<NftFormProps> = ({ setFormStatus, onSubmit, videoId }) 
 
   const channelAvatarUrl = video?.channel.avatarPhoto?.resolvedUrl
   const thumbnailPhotoUrl = video?.thumbnailPhoto?.resolvedUrl
-  const { url: memberAvatarUri } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUri } = getMemberAvatar(activeMembership)
 
   const [openModal, closeModal] = useConfirmationModal()
 

--- a/packages/atlas/src/views/global/NftSettlementBottomDrawer/NftSettlementBottomDrawer.tsx
+++ b/packages/atlas/src/views/global/NftSettlementBottomDrawer/NftSettlementBottomDrawer.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/_buttons/Button'
 import { NftCard } from '@/components/_nft/NftCard'
 import { BottomDrawer } from '@/components/_overlays/BottomDrawer'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useFee, useJoystream } from '@/providers/joystream/joystream.hooks'
 import { useNftActions } from '@/providers/nftActions/nftActions.hooks'
 import { useSnackbar } from '@/providers/snackbars'
@@ -33,7 +33,7 @@ export const NftSettlementBottomDrawer: FC = () => {
   const { displaySnackbar } = useSnackbar()
   const thumbnailUrl = nft?.video.thumbnailPhoto?.resolvedUrl
   const avatarUrl = nft?.video.channel.avatarPhoto?.resolvedUrl
-  const { url: memberAvatarUrl } = useMemberAvatar(
+  const { url: memberAvatarUrl } = getMemberAvatar(
     nft?.owner.__typename === 'NftOwnerMember' && nft.owner.member ? nft.owner.member : null
   )
 

--- a/packages/atlas/src/views/playground/PlaygroundLayout.tsx
+++ b/packages/atlas/src/views/playground/PlaygroundLayout.tsx
@@ -11,7 +11,7 @@ import { TopbarBase } from '@/components/_navigation/TopbarBase'
 import { MemberDropdown } from '@/components/_overlays/MemberDropdown'
 import { absoluteRoutes } from '@/config/routes'
 import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { ConfirmationModalProvider } from '@/providers/confirmationModal'
 import { ConnectionStatusManager } from '@/providers/connectionStatus'
 import { useUser } from '@/providers/user/user.hooks'
@@ -53,7 +53,7 @@ const playgroundRoutes = [
 const PlaygroundLayout = () => {
   const [isMemberDropdownActive, setIsMemberDropdownActive] = useState(false)
   const { activeMembership, isLoggedIn, signIn } = useUser()
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(activeMembership)
   const { openSignInDialog } = useDisplaySignInDialog()
   return (
     <UserProvider>

--- a/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.hooks.ts
+++ b/packages/atlas/src/views/studio/CreateEditChannelView/CreateEditChannelView.hooks.ts
@@ -54,7 +54,7 @@ type CreateEditChannelData = {
 
 export const useCreateEditChannelSubmit = () => {
   const { joystream, proxyCallback } = useJoystream()
-  const { channelId, memberId, setActiveUser, refetchUserMemberships, activeMembership } = useUser()
+  const { channelId, memberId, setActiveUser, refetchUserMemberships } = useUser()
   const addNewChannelIdToUploadsStore = useUploadsStore((state) => state.actions.addNewChannelId)
   const getBucketsConfigForNewChannel = useBucketsConfigForNewChannel()
   const { channelStateBloatBondValue, dataObjectStateBloatBondValue } = useBloatFeesAndPerMbFees()
@@ -66,8 +66,7 @@ export const useCreateEditChannelSubmit = () => {
 
   const rawMetadataProcessor = useAppActionMetadataProcessor(
     (memberId && memberId.toString()) || '',
-    AppActionActionType.CreateChannel,
-    activeMembership?.totalChannelsCreated || 0
+    AppActionActionType.CreateChannel
   )
 
   return useCallback(

--- a/packages/atlas/src/views/studio/MyPaymentsView/PaymentsOverview/PaymentsOverView.tsx
+++ b/packages/atlas/src/views/studio/MyPaymentsView/PaymentsOverview/PaymentsOverView.tsx
@@ -9,7 +9,7 @@ import { ClaimChannelPaymentsDialog } from '@/components/_overlays/ClaimChannelP
 import { WithdrawFundsDialog } from '@/components/_overlays/SendTransferDialogs'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { hapiBnToTokenNumber } from '@/joystream-lib/utils'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useSubscribeAccountBalance } from '@/providers/joystream/joystream.hooks'
 import { useUser } from '@/providers/user/user.hooks'
 import { formatNumber } from '@/utils/number'
@@ -19,7 +19,7 @@ import { CustomNodeWrapper, TilesWrapper } from './PaymentsOverview.styles'
 
 export const PaymentsOverView = () => {
   const { channelId, activeMembership } = useUser()
-  const { url: memberAvatarUrl } = useMemberAvatar(activeMembership)
+  const { url: memberAvatarUrl } = getMemberAvatar(activeMembership)
   const { totalBalance } = useSubscribeAccountBalance()
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false)
   const [showClaimDialog, setShowClaimDialog] = useState<boolean>(false)

--- a/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.hooks.ts
+++ b/packages/atlas/src/views/studio/VideoWorkspace/VideoWorkspace.hooks.ts
@@ -34,23 +34,16 @@ export const useHandleVideoWorkspaceSubmit = () => {
 
   const { joystream, proxyCallback } = useJoystream()
   const startFileUpload = useStartFileUpload()
-  const { channelId, memberId, activeMembership } = useAuthorizedUser()
+  const { channelId, memberId } = useAuthorizedUser()
 
   const client = useApolloClient()
   const handleTransaction = useTransaction()
   const removeDrafts = useDraftStore((state) => state.actions.removeDrafts)
   const { tabData } = useVideoWorkspaceData()
   const channelBucketsCount = useChannelsStorageBucketsCount(channelId)
-  const channelVideosCount =
-    activeMembership?.channels.find((channel) => channel.id === channelId)?.totalVideosCreated || 0
-
   const { videoStateBloatBondValue, dataObjectStateBloatBondValue } = useBloatFeesAndPerMbFees()
 
-  const rawMetadataProcessor = useAppActionMetadataProcessor(
-    channelId,
-    AppActionActionType.CreateVideo,
-    channelVideosCount
-  )
+  const rawMetadataProcessor = useAppActionMetadataProcessor(channelId, AppActionActionType.CreateVideo)
 
   return useCallback(
     async (data: VideoFormData, videoInfo?: VideoWorkspace, assetsToBeRemoved?: string[]) => {

--- a/packages/atlas/src/views/viewer/ChannelView/ChannelViewTabs/ChannelAbout.tsx
+++ b/packages/atlas/src/views/viewer/ChannelView/ChannelViewTabs/ChannelAbout.tsx
@@ -6,7 +6,7 @@ import { NumberFormat } from '@/components/NumberFormat'
 import { Text } from '@/components/Text'
 import { atlasConfig } from '@/config'
 import { absoluteRoutes } from '@/config/routes'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { formatDate } from '@/utils/time'
 
 import {
@@ -25,7 +25,7 @@ type ChannelAboutProps = {
 }
 
 export const ChannelAbout: FC<ChannelAboutProps> = ({ channel, activeVideosCount }) => {
-  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = useMemberAvatar(channel?.ownerMember)
+  const { url: memberAvatarUrl, isLoadingAsset: memberAvatarLoading } = getMemberAvatar(channel?.ownerMember)
   return (
     <StyledLayoutGrid>
       <GridItem colSpan={{ xxs: 12, sm: 8 }} rowStart={{ xxs: 2, sm: 1 }}>

--- a/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
+++ b/packages/atlas/src/views/viewer/MemberView/MemberView.tsx
@@ -15,7 +15,7 @@ import { Select } from '@/components/_inputs/Select'
 import { absoluteRoutes } from '@/config/routes'
 import { NFT_SORT_ACTIVITY_OPTIONS, NFT_SORT_OPTIONS } from '@/config/sorting'
 import { useHeadTags } from '@/hooks/useHeadTags'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useUser } from '@/providers/user/user.hooks'
 import { SentryLogger } from '@/utils/logs'
 
@@ -66,7 +66,7 @@ export const MemberView: FC = () => {
     }
   )
   const member = memberships?.find((member) => member.handle === handle)
-  const { url: avatarUrl, isLoadingAsset: avatarLoading } = useMemberAvatar(member)
+  const { url: avatarUrl, isLoadingAsset: avatarLoading } = getMemberAvatar(member)
 
   const toggleFilters = () => {
     setIsFiltersOpen((value) => !value)

--- a/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
+++ b/packages/atlas/src/views/viewer/VideoView/CommentsSection.tsx
@@ -18,7 +18,7 @@ import { useDisplaySignInDialog } from '@/hooks/useDisplaySignInDialog'
 import { useMediaMatch } from '@/hooks/useMediaMatch'
 import { useReactionTransactions } from '@/hooks/useReactionTransactions'
 import { useRouterQuery } from '@/hooks/useRouterQuery'
-import { useMemberAvatar } from '@/providers/assets/assets.hooks'
+import { getMemberAvatar } from '@/providers/assets/assets.helpers'
 import { useFee } from '@/providers/joystream/joystream.hooks'
 import { useUser } from '@/providers/user/user.hooks'
 import { createPlaceholderData } from '@/utils/data'
@@ -54,7 +54,7 @@ export const CommentsSection: FC<CommentsSectionProps> = ({ disabled, video, vid
   const { id: videoId } = useParams()
   const { memberId, signIn, activeMembership, isLoggedIn } = useUser()
   const { openSignInDialog } = useDisplaySignInDialog({ interaction: true })
-  const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = useMemberAvatar(activeMembership)
+  const { isLoadingAsset: isMemberAvatarLoading, url: memberAvatarUrl } = getMemberAvatar(activeMembership)
 
   const { fullFee: fee, loading: feeLoading } = useFee(
     'createVideoCommentTx',


### PR DESCRIPTION
Diff could look scary, but I only renamed one function(useMemberAvatar to getMemberAvatar) and most of the changes come from this refactor. 
The important changes are inside 
- NftCarouselDetails.tsx
- app.ts
- channels.graphql

Please also double-check if it's possible to create a video and channel that has an app id assigned.  