### PR TITLE
Apply public video filter in popular videos

### DIFF
--- a/packages/atlas/src/views/viewer/PopularView/PopularView.tsx
+++ b/packages/atlas/src/views/viewer/PopularView/PopularView.tsx
@@ -4,6 +4,7 @@ import { GetMostViewedVideosConnectionDocument } from '@/api/queries/__generated
 import { Section } from '@/components/Section/Section'
 import { TopTenVideos } from '@/components/_content/TopTenVideos'
 import { VideoTileViewer } from '@/components/_video/VideoTileViewer'
+import { publicVideoFilter } from '@/config/contentFilter'
 import { useHeadTags } from '@/hooks/useHeadTags'
 import { useInfiniteVideoGrid } from '@/hooks/useInfiniteVideoGrid'
 import { DEFAULT_VIDEO_GRID } from '@/styles/grids'
@@ -17,6 +18,9 @@ export const PopularView: FC = () => {
     query: GetMostViewedVideosConnectionDocument,
     variables: {
       limit: 200,
+      where: {
+        ...publicVideoFilter,
+      },
     },
   })
 


### PR DESCRIPTION
Just a small change, I noticed that we were showing in the view a lot of videos that have either broken videos or thumbnails. I don't think they should be available in public(previously they never were shown as well). 