### PR TITLE
Remove redundant icons from top selling channels table

### DIFF
--- a/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.tsx
+++ b/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.tsx
@@ -184,6 +184,10 @@ export const TopSellingChannelsTable = () => {
 }
 
 const Channel = ({ channel }: { channel: GetTopSellingChannelsQuery['topSellingChannels'][number]['channel'] }) => {
+  // todo to be implemented
+  const creatorToken = false
+  // todo to be implemented
+  const verified = false
   return (
     <StyledLink to={absoluteRoutes.viewer.member(channel.ownerMember?.handle)}>
       <SenderItem
@@ -192,8 +196,16 @@ const Channel = ({ channel }: { channel: GetTopSellingChannelsQuery['topSellingC
         isInteractive={false}
         nodeEnd={
           <SenderItemIconsWrapper>
-            <SvgActionCreatorToken />
-            <SvgActionVerified />
+            {creatorToken && (
+              <span title="Creator token">
+                <SvgActionCreatorToken />
+              </span>
+            )}
+            {verified && (
+              <span title="Verified">
+                <SvgActionVerified />
+              </span>
+            )}
           </SenderItemIconsWrapper>
         }
       />


### PR DESCRIPTION
This PR removes these icons from the top-selling channels table. 

![image](https://github.com/Joystream/atlas/assets/51168865/6efc1533-44db-4b2d-a8c3-a245d4dfe4de)

We didn't implement creator tokens yet and we don't have support for verified creators, so it doesn't make sense to add them. I kept the code for the future though. 

