### PR TITLE
Removed env variables overwrite 

### DIFF
--- a/packages/atlas/src/config/env.ts
+++ b/packages/atlas/src/config/env.ts
@@ -29,8 +29,6 @@ export const availableEnvs = () => {
 export const readEnv = (name: string, required = true, direct = false): string => {
   const fullName = direct
     ? getEnvName(name)
-    : BUILD_ENV === 'production'
-    ? getEnvName(`PRODUCTION_${name}`)
     : getEnvName(`${useEnvironmentStore.getState().targetDevEnv.toUpperCase()}_${name}`)
   const value = import.meta.env[fullName]
   if (!value && required) {


### PR DESCRIPTION
why: for the production build, environment varaibles were overwritten by the production ones if target_env was set to the production. Because of this, changing envs on dev.gleev.xyz doesn't work. I've removed overwriting those variables, but select will be disabled by default  and production env will be predefined on gleev.xyz