### PR TITLE
Marketplace layout and top selling channels table fixes

### DIFF
--- a/packages/atlas/src/components/Carousel/Carousel.styles.ts
+++ b/packages/atlas/src/components/Carousel/Carousel.styles.ts
@@ -8,11 +8,10 @@ import { cVar, media, sizes, transitions, zIndex } from '@/styles'
 export const CAROUSEL_ARROW_HEIGHT = 48
 
 type StyledSwiperProps = {
-  canOverflowContainer?: boolean
   minSlideWidth?: number
 } & SwiperOptions
 
-const isPropValid = (prop: string) => prop !== 'canOverflowContainer' && prop !== 'minSlideWidth'
+const isPropValid = (prop: string) => prop !== 'minSlideWidth'
 
 export const StyledSwiper = styled(Swiper, { shouldForwardProp: isPropValid })<StyledSwiperProps>`
   width: 100%;

--- a/packages/atlas/src/components/Carousel/Carousel.tsx
+++ b/packages/atlas/src/components/Carousel/Carousel.tsx
@@ -10,7 +10,6 @@ export type SwiperInstance = SwiperType
 export type CarouselProps = {
   className?: string
   dotsVisible?: boolean
-  canOverflowContainer?: boolean
   minSlideWidth?: number
   children: ReactNode[]
 } & SwiperProps
@@ -27,7 +26,6 @@ const dotsProps = {
 export const Carousel = ({
   children,
   dotsVisible,
-  canOverflowContainer,
   spaceBetween = 12,
   minSlideWidth,
   ...swiperOptions
@@ -36,7 +34,6 @@ export const Carousel = ({
     <StyledSwiper
       navigation
       minSlideWidth={minSlideWidth}
-      canOverflowContainer={canOverflowContainer}
       {...(dotsVisible ? dotsProps : {})}
       {...swiperOptions}
       spaceBetween={spaceBetween}

--- a/packages/atlas/src/components/LimitedWidthContainer/LimitedWidthContainer.tsx
+++ b/packages/atlas/src/components/LimitedWidthContainer/LimitedWidthContainer.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 
 import { sizes } from '@/styles'
 
-type LimitedWidthContainerProps = { big?: boolean }
+type LimitedWidthContainerProps = { big?: boolean; noBottomPadding?: boolean }
 
 export const LimitedWidthContainer = styled.div<LimitedWidthContainerProps>`
   --max-inner-width: calc(${({ big }) => (big ? '2284' : '1440')}px - calc(2 * var(--size-global-horizontal-padding)));
@@ -10,5 +10,5 @@ export const LimitedWidthContainer = styled.div<LimitedWidthContainerProps>`
   max-width: var(--max-inner-width);
   position: relative;
   margin: 0 auto;
-  padding-bottom: ${sizes(16)};
+  padding-bottom: ${({ noBottomPadding }) => (noBottomPadding ? 0 : sizes(16))};
 `

--- a/packages/atlas/src/components/Section/SectionHeader/SectionHeader.tsx
+++ b/packages/atlas/src/components/Section/SectionHeader/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react'
+import { FC, ReactNode, useState } from 'react'
 
 import { SvgActionChevronL, SvgActionChevronR } from '@/assets/icons'
 import { SectionFilter } from '@/components/FilterButton'
@@ -107,18 +107,8 @@ export function SectionHeader<T>(props: SectionHeaderProps<T>) {
               {filters && filtersInFirstRow && <SectionFilters filters={filters} onApplyFilters={onApplyFilters} />}
               {isCarousel && (
                 <>
-                  <StyledArrowButton
-                    size="medium"
-                    icon={<SvgActionChevronL />}
-                    variant="tertiary"
-                    onClick={props.onMoveCarouselLeft}
-                  />
-                  <StyledArrowButton
-                    size="medium"
-                    icon={<SvgActionChevronR />}
-                    variant="tertiary"
-                    onClick={props.onMoveCarouselRight}
-                  />
+                  <ArrowButton disabled={props.isBeginning} direction="left" onClick={props.onMoveCarouselLeft} />
+                  <ArrowButton disabled={props.isEnd} direction="right" onClick={props.onMoveCarouselRight} />
                 </>
               )}
               {button && <StyledButton {...button} size="medium" variant="secondary" />}
@@ -150,23 +140,28 @@ export function SectionHeader<T>(props: SectionHeaderProps<T>) {
       {sort?.type === 'select' && <StyledSelect {...sort.selectProps} size="medium" />}
       {isCarousel && (
         <>
-          <StyledArrowButton
-            disabled={props.isBeginning}
-            size="medium"
-            icon={<SvgActionChevronL />}
-            variant="tertiary"
-            onClick={props.onMoveCarouselLeft}
-          />
-          <StyledArrowButton
-            disabled={props.isEnd}
-            size="medium"
-            icon={<SvgActionChevronR />}
-            variant="tertiary"
-            onClick={props.onMoveCarouselRight}
-          />
+          <ArrowButton disabled={props.isBeginning} direction="left" onClick={props.onMoveCarouselLeft} />
+          <ArrowButton disabled={props.isEnd} direction="right" onClick={props.onMoveCarouselRight} />
         </>
       )}
       {button && <StyledButton {...button} size="medium" variant="secondary" />}
     </SectionHeaderWrapper>
+  )
+}
+
+type ArrowButtonProps = {
+  disabled?: boolean
+  onClick?: () => void
+  direction: 'left' | 'right'
+}
+const ArrowButton: FC<ArrowButtonProps> = ({ disabled, onClick, direction }) => {
+  return (
+    <StyledArrowButton
+      disabled={disabled}
+      size="medium"
+      icon={direction === 'left' ? <SvgActionChevronL /> : <SvgActionChevronR />}
+      variant="tertiary"
+      onClick={onClick}
+    />
   )
 }

--- a/packages/atlas/src/components/Table/Table.styles.ts
+++ b/packages/atlas/src/components/Table/Table.styles.ts
@@ -71,7 +71,7 @@ export const EmptyTableDescription = styled(Text)`
 
 export const PageWrapper = styled.div`
   display: flex;
-  gap: ${sizes(3)};
+  gap: ${sizes(6)};
 `
 
 export const RightAlignedHeader = styled.div`

--- a/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.styles.ts
+++ b/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.styles.ts
@@ -6,8 +6,21 @@ import { Table } from '@/components/Table'
 import { Text } from '@/components/Text'
 import { cVar, sizes } from '@/styles'
 
+import { LabelContainer, LabelText } from '../ListItem/ListItem.styles'
+
+export const ScrollWrapper = styled.div`
+  scrollbar-width: none;
+  position: relative;
+  overflow: auto;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`
+
 export const StyledTable = styled(Table)`
   background: transparent;
+  min-width: 528px;
 
   .table-base {
     height: fit-content;
@@ -29,12 +42,19 @@ export const StyledTable = styled(Table)`
   }
 `
 
-export const SenderItem = styled(ListItem)`
+export const StyledListItem = styled(ListItem)`
   padding-left: 0;
   width: fit-content;
   align-items: center;
 
-  & span[color] {
+  ${LabelContainer} {
+    overflow: hidden;
+  }
+
+  ${LabelText} {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: ${cVar('colorTextStrong')};
   }
 `

--- a/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.styles.ts
+++ b/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.styles.ts
@@ -28,6 +28,12 @@ export const StyledTable = styled(Table)`
 
   .table-row {
     background-color: transparent;
+
+    td {
+      :first-of-type {
+        max-width: 40px;
+      }
+    }
   }
 
   .table-header {
@@ -36,7 +42,7 @@ export const StyledTable = styled(Table)`
 
     th {
       :first-of-type {
-        padding-left: 5px;
+        max-width: 40px;
       }
     }
   }

--- a/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.tsx
+++ b/packages/atlas/src/components/TopSellingChannelsTable/TopSellingChannelsTable.tsx
@@ -1,5 +1,6 @@
 import BN from 'bn.js'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
+import useDraggableScroll from 'use-draggable-scroll'
 
 import {
   GetTopSellingChannelsQuery,
@@ -20,10 +21,11 @@ import { useMediaMatch } from '@/hooks/useMediaMatch'
 import {
   JoyAmountWrapper,
   NftSoldText,
-  SenderItem,
+  ScrollWrapper,
   SenderItemIconsWrapper,
   SkeletonChannelContainer,
   StyledLink,
+  StyledListItem,
   StyledTable,
 } from './TopSellingChannelsTable.styles'
 
@@ -75,7 +77,10 @@ export const TopSellingChannelsTable = () => {
     },
   })
 
-  const mdMatch = useMediaMatch('md')
+  const ref = useRef<HTMLDivElement>(null)
+  const { onMouseDown } = useDraggableScroll(ref, { direction: 'horizontal' })
+
+  const lgMatch = useMediaMatch('lg')
   const mappedData: TableProps['data'] = useMemo(
     () =>
       loading
@@ -170,13 +175,9 @@ export const TopSellingChannelsTable = () => {
           },
         },
         children: [
-          <StyledTable
-            key="single"
-            emptyState={tableEmptyState}
-            columns={COLUMNS}
-            data={mappedData}
-            doubleColumn={mdMatch}
-          />,
+          <ScrollWrapper key="single" ref={ref} onMouseDown={onMouseDown}>
+            <StyledTable emptyState={tableEmptyState} columns={COLUMNS} data={mappedData} doubleColumn={lgMatch} />
+          </ScrollWrapper>,
         ],
       }}
     />
@@ -189,8 +190,8 @@ const Channel = ({ channel }: { channel: GetTopSellingChannelsQuery['topSellingC
   // todo to be implemented
   const verified = false
   return (
-    <StyledLink to={absoluteRoutes.viewer.member(channel.ownerMember?.handle)}>
-      <SenderItem
+    <StyledLink to={absoluteRoutes.viewer.member(channel.ownerMember?.handle)} title={channel.ownerMember?.handle}>
+      <StyledListItem
         nodeStart={<Avatar assetUrl={channel.avatarPhoto?.resolvedUrl ?? undefined} />}
         label={channel.ownerMember?.handle}
         isInteractive={false}

--- a/packages/atlas/src/components/_inputs/ToggleButtonGroup/ToggleButtonGroup.styles.ts
+++ b/packages/atlas/src/components/_inputs/ToggleButtonGroup/ToggleButtonGroup.styles.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 
 import { Text } from '@/components/Text'
+import { Tooltip } from '@/components/Tooltip'
 import { Button } from '@/components/_buttons/Button'
 import { cVar, sizes, zIndex } from '@/styles'
 import { MaskProps, getMaskImage } from '@/utils/styles'
@@ -47,6 +48,11 @@ export const ToggleButton = styled(Button)`
   span {
     white-space: nowrap;
   }
+`
+
+export const StyledTooltip = styled(Tooltip)`
+  width: 100%;
+  display: block;
 `
 
 export const Label = styled(Text)`

--- a/packages/atlas/src/components/_inputs/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/atlas/src/components/_inputs/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -2,7 +2,6 @@ import { useRef } from 'react'
 
 import { SvgActionChevronL, SvgActionChevronR } from '@/assets/icons'
 import { FilterButton, FilterButtonProps } from '@/components/FilterButton'
-import { Tooltip } from '@/components/Tooltip'
 import { useHorizonthalFade } from '@/hooks/useHorizonthalFade'
 
 import {
@@ -13,6 +12,7 @@ import {
   ContentWrapper,
   Label,
   OptionWrapper,
+  StyledTooltip,
   ToggleButton,
 } from './ToggleButtonGroup.styles'
 
@@ -69,7 +69,7 @@ export function ToggleButtonGroup<T = string>(props: ToggleButtonGroupProps<T>) 
         <OptionWrapper onMouseDown={handleMouseDown} ref={optionWrapperRef} visibleShadows={visibleShadows}>
           {type === 'options' &&
             props.options.map((option, i) => (
-              <Tooltip key={i} text={option.tooltipText}>
+              <StyledTooltip key={i} text={option.tooltipText}>
                 <ToggleButton
                   fullWidth
                   variant={option.value !== props.value ? 'tertiary' : 'secondary'}
@@ -79,7 +79,7 @@ export function ToggleButtonGroup<T = string>(props: ToggleButtonGroupProps<T>) 
                 >
                   {option.label}
                 </ToggleButton>
-              </Tooltip>
+              </StyledTooltip>
             ))}
           {type === 'filter' &&
             props.filters.map((filterButtonProps, idx) => <FilterButton key={idx} {...filterButtonProps} />)}

--- a/packages/atlas/src/components/_video/BackgroundVideoPlayer/VideoProgress.tsx
+++ b/packages/atlas/src/components/_video/BackgroundVideoPlayer/VideoProgress.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { cVar, zIndex } from '@/styles'
 
@@ -32,15 +32,15 @@ export const VideoProgress = ({ tick, video, isPlaying, limit }: VideoProgressPr
     }
   }, [isPlaying, limit, progress, tick, video, video?.duration])
 
+  const width = useMemo(() => (isPlaying ? (progress ? `${progress * 100}%` : 0) : 1), [isPlaying, progress])
   return (
     <VideoProgressWrapper>
-      <VideoProgressBar progress={isPlaying ? progress : 1} />
+      <VideoProgressBar style={{ width }} />
     </VideoProgressWrapper>
   )
 }
 
-const VideoProgressBar = styled.div<{ progress: number }>`
-  width: ${({ progress }) => (progress ? `${progress * 100}%` : 0)};
+const VideoProgressBar = styled.div`
   min-height: 2px;
   background-color: ${cVar('colorCoreNeutral100')};
 `

--- a/packages/atlas/src/views/viewer/MarketplaceView/FeaturedNftsSection/FeaturedNftsSection.tsx
+++ b/packages/atlas/src/views/viewer/MarketplaceView/FeaturedNftsSection/FeaturedNftsSection.tsx
@@ -156,7 +156,6 @@ export const FeaturedNftsSection: FC = () => {
           contentProps={{
             type: 'carousel',
             children: items.map((nft, idx) => <NftTileViewer nftId={nft.id} key={idx} />),
-            canOverflowContainer: true,
             spaceBetween: mdMatch ? 24 : 16,
             breakpoints: responsive,
           }}

--- a/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.styles.ts
+++ b/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.styles.ts
@@ -4,10 +4,11 @@ import { LimitedWidthContainer } from '@/components/LimitedWidthContainer'
 import { media, sizes } from '@/styles'
 
 export const StyledLimitedWidth = styled(LimitedWidthContainer)`
-  padding: ${sizes(16)} 0;
+  padding: ${sizes(4)} 0;
   display: grid;
   gap: ${sizes(8)};
   ${media.md} {
+    padding: ${sizes(8)} 0;
     gap: ${sizes(16)};
   }
 `

--- a/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.styles.ts
+++ b/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.styles.ts
@@ -1,14 +1,29 @@
 import styled from '@emotion/styled'
 
-import { LimitedWidthContainer } from '@/components/LimitedWidthContainer'
-import { media, sizes } from '@/styles'
+import { cVar, media, sizes } from '@/styles'
 
-export const StyledLimitedWidth = styled(LimitedWidthContainer)`
+export const MarketplaceWrapper = styled.div`
   padding: ${sizes(4)} 0;
   display: grid;
   gap: ${sizes(8)};
   ${media.md} {
     padding: ${sizes(8)} 0;
     gap: ${sizes(16)};
+  }
+`
+
+export const FullWidthWrapper = styled.div`
+  width: calc(100% + var(--size-global-horizontal-padding) * 2);
+  margin-left: calc(var(--size-global-horizontal-padding) * -1);
+  overflow: hidden;
+  position: relative;
+`
+
+export const TableFullWitdhtWrapper = styled(FullWidthWrapper)`
+  background-color: ${cVar('colorBackgroundMuted')};
+  padding: ${sizes(8)} var(--size-global-horizontal-padding);
+
+  ${media.md} {
+    padding: ${sizes(16)} var(--size-global-horizontal-padding);
   }
 `

--- a/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.tsx
+++ b/packages/atlas/src/views/viewer/MarketplaceView/MarketplaceView.tsx
@@ -2,24 +2,35 @@ import { FC } from 'react'
 
 import { useFeaturedNftsVideos } from '@/api/hooks/nfts'
 import { AllNftSection } from '@/components/AllNftSection/AllNftSection'
+import { LimitedWidthContainer } from '@/components/LimitedWidthContainer'
 import { MarketplaceCarousel } from '@/components/NftCarousel/MarketplaceCarousel'
 import { TopSellingChannelsTable } from '@/components/TopSellingChannelsTable'
 import { useHeadTags } from '@/hooks/useHeadTags'
 
 import { FeaturedNftsSection } from './FeaturedNftsSection/FeaturedNftsSection'
-import { StyledLimitedWidth } from './MarketplaceView.styles'
+import { FullWidthWrapper, MarketplaceWrapper, TableFullWitdhtWrapper } from './MarketplaceView.styles'
 
 export const MarketplaceView: FC = () => {
   const headTags = useHeadTags('Marketplace')
   const { nfts, loading } = useFeaturedNftsVideos()
 
   return (
-    <StyledLimitedWidth big>
+    <MarketplaceWrapper>
       {headTags}
-      <MarketplaceCarousel type="nft" nfts={nfts} isLoading={loading} />
-      <FeaturedNftsSection />
-      <TopSellingChannelsTable />
-      <AllNftSection />
-    </StyledLimitedWidth>
+      <FullWidthWrapper>
+        <MarketplaceCarousel type="nft" nfts={nfts} isLoading={loading} />
+      </FullWidthWrapper>
+      <LimitedWidthContainer big noBottomPadding>
+        <FeaturedNftsSection />
+      </LimitedWidthContainer>
+      <TableFullWitdhtWrapper>
+        <LimitedWidthContainer big noBottomPadding>
+          <TopSellingChannelsTable />
+        </LimitedWidthContainer>
+      </TableFullWitdhtWrapper>
+      <LimitedWidthContainer big noBottomPadding>
+        <AllNftSection />
+      </LimitedWidthContainer>
+    </MarketplaceWrapper>
   )
 }


### PR DESCRIPTION
Fix #4206 

This PR should fix points 2, 4, 8, 9, 10, 11: 
> Top padding on marketplace page over the hero slider should be 32px on large breakpoints not 64px and on small 16px look on RWD
https://www.figma.com/file/zQYsZXJo6jmbqcj1kRRmDG/Marketplace?type=design&node-id=478-135167&t=hbfp4VS18EDTTlo0-4

> Top selling channels section is missing the whole container styling - background + top and pottom paddings - the gap between columns should be 24px on large breakpoints 16px on smaller look on RWD - currently the gap is too small
https://www.figma.com/file/zQYsZXJo6jmbqcj1kRRmDG/Marketplace?type=design&node-id=401-19167&t=hbfp4VS18EDTTlo0-4

> On small breakpoints the table of top selling channels should not be squished to fill the view - instead it should be displayed in its min width value and offer user option to scroll horrizontaly by swiping

> The toggle button group in the smaller breakpoints should fill the space eavenly check RWDhttps://www.figma.com/file/zQYsZXJo6jmbqcj1kRRmDG/Marketplace?type=design&node-id=471-105319&t=hbfp4VS18EDTTlo0-4

> On small widths when the featured section is on its very beginning and there is no option to scroll it to the left - the left button should be disabled
Image

> Channel label should be aligned with the avatar like in designs
