### PR TITLE
Fix embedded player view

### DIFF
--- a/packages/atlas/src/views/viewer/EmbeddedView/EmbeddedView.tsx
+++ b/packages/atlas/src/views/viewer/EmbeddedView/EmbeddedView.tsx
@@ -92,7 +92,7 @@ export const EmbeddedView: FC = () => {
     <>
       <EmbeddedGlobalStyles />
       <Container>
-        {loading && video ? (
+        {!loading && video ? (
           <VideoPlayer
             onAddVideoView={handleAddVideoView}
             isVideoPending={!video?.media?.isAccepted}


### PR DESCRIPTION
I noticed that the embedded video was not loading anymore. This PR should fix it. To test this go to `/playground/iframe`
