### PR TITLE
🚐 Minor sub-sentry issues

### DIFF
--- a/packages/atlas/src/hooks/useGetAssetUrl.ts
+++ b/packages/atlas/src/hooks/useGetAssetUrl.ts
@@ -4,7 +4,7 @@ import { atlasConfig } from '@/config'
 import { testAssetDownload } from '@/providers/assets/assets.helpers'
 import { useOperatorsContext } from '@/providers/assets/assets.provider'
 import { ConsoleLogger } from '@/utils/logs'
-import { TimeoutError, withTimeout } from '@/utils/misc'
+import { withTimeout } from '@/utils/misc'
 
 export const getSingleAssetUrl = async (
   urls: string[] | undefined | null,
@@ -16,8 +16,6 @@ export const getSingleAssetUrl = async (
   }
 
   for (const distributionAssetUrl of urls) {
-    const distributorUrl = distributionAssetUrl.split(`/${atlasConfig.storage.assetPath}/`)[0]
-
     const assetTestPromise = testAssetDownload(distributionAssetUrl, type)
     const assetTestPromiseWithTimeout = withTimeout(
       assetTestPromise,
@@ -28,17 +26,8 @@ export const getSingleAssetUrl = async (
       await assetTestPromiseWithTimeout
 
       return distributionAssetUrl
-    } catch (err) {
-      if (err instanceof TimeoutError) {
-        // AssetLogger.logDistributorResponseTimeout(eventEntry)
-        ConsoleLogger.warn(
-          `Distributor didn't respond in ${timeout ?? atlasConfig.storage.assetResponseTimeout} seconds`,
-          {
-            distributorUrl: distributorUrl,
-            assetUrl: distributionAssetUrl,
-          }
-        )
-      }
+    } catch {
+      /**/
     }
   }
 
@@ -66,7 +55,7 @@ export const useGetAssetUrl = (urls: string[] | undefined | null, type: 'image' 
   const [isLoading, setIsLoading] = useState(true)
   const { userBenchmarkTime } = useOperatorsContext()
   useEffect(() => {
-    if (!urls || (url && urls.includes(url))) {
+    if (!urls || (url && urls.includes(url)) || (!url && !urls.length)) {
       setIsLoading(false)
       return
     }

--- a/packages/atlas/src/joystream-lib/lib.ts
+++ b/packages/atlas/src/joystream-lib/lib.ts
@@ -6,7 +6,7 @@ import { Signer } from '@polkadot/api/types'
 import { Keyring } from '@polkadot/keyring'
 import { getSpecTypes } from '@polkadot/types-known'
 import { Codec, SignerPayloadRawBase } from '@polkadot/types/types'
-import { base64Encode } from '@polkadot/util-crypto'
+import { base64Encode, cryptoWaitReady } from '@polkadot/util-crypto'
 import BN from 'bn.js'
 import { proxy } from 'comlink'
 
@@ -80,7 +80,7 @@ export class JoystreamLib {
       SentryLogger.error('Missing signer for setActiveAccount', 'JoystreamLib')
       return
     }
-
+    await cryptoWaitReady()
     if (payloadType === 'seed') {
       this._selectedAccountId = keyring.addFromMnemonic(payload)
     } else {

--- a/packages/atlas/src/providers/assets/assets.helpers.ts
+++ b/packages/atlas/src/providers/assets/assets.helpers.ts
@@ -112,11 +112,13 @@ export const logDistributorPerformance = async (assetUrl: string, eventEntry: Di
 
 export const getFastestImageUrl = async (urls: string[]) => {
   const promises = urls.map((url) => {
-    return axiosInstance.head(url, {
-      headers: {
-        'Cache-Control': 'no-cache',
-      },
-    })
+    return axiosInstance
+      .head(url, {
+        headers: {
+          'Cache-Control': 'no-cache',
+        },
+      })
+      .catch((error) => ConsoleLogger.warn('Failed while performing performance download', error))
   })
   return Promise.race(promises)
 }

--- a/packages/atlas/src/providers/auth/auth.helpers.ts
+++ b/packages/atlas/src/providers/auth/auth.helpers.ts
@@ -12,7 +12,7 @@ import { atlasConfig } from '@/config'
 import { ORION_AUTH_URL } from '@/config/env'
 import { keyring } from '@/joystream-lib/lib'
 import { getWalletsList } from '@/providers/wallet/wallet.helpers'
-import { SentryLogger } from '@/utils/logs'
+import { ConsoleLogger, SentryLogger } from '@/utils/logs'
 import { withTimeout } from '@/utils/misc'
 
 import { AuthModals, LogInErrors, OrionAccountError, RegisterParams, RegisterPayload } from './auth.types'
@@ -104,7 +104,7 @@ export const decodeSessionEncodedSeedToMnemonic = async (encodedSeed: string) =>
     return _entropyToMnemonic(Buffer.from(decryptedSeed.slice(2, decryptedSeed.length), 'hex'))
   } catch (e) {
     if (isAxiosError(e) && e.response?.data.message === 'isAxiosError') {
-      logoutRequest()
+      logoutRequest().catch((error) => ConsoleLogger.warn('Failed to logout on decoding error', error))
     }
     return null
   }
@@ -269,8 +269,7 @@ export const getMnemonicFromeEmailAndPassword = async (email: string, password: 
   if (!data?.decryptedEntropy) {
     throw Error("Couldn't fetch artifacts")
   }
-  const mnemonic = entropyToMnemonic(data?.decryptedEntropy)
-  return mnemonic
+  return entropyToMnemonic(data?.decryptedEntropy)
 }
 
 export const getAuthEpoch = async () => {

--- a/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
+++ b/packages/atlas/src/views/studio/MyVideosView/MyVideosView.tsx
@@ -77,7 +77,7 @@ export const MyVideosView = () => {
     () =>
       axiosInstance
         .get<YppVideoDto[]>(`${YOUTUBE_BACKEND_URL}/channels/${channelId}/videos`)
-        .catch(() => ConsoleLogger.error('Failed to fetch YPP videos from channel')),
+        .catch(() => ConsoleLogger.warn('Failed to fetch YPP videos from channel')),
     {
       enabled: !!channelId && !!YOUTUBE_BACKEND_URL,
       retry: 1,


### PR DESCRIPTION
#4643

Fixed:
- make sure to await crypto in worker (previous fix was not enough)
- for empty asset input change on any field inside form resulted in a small asset reload
- use `warn` for some axios errors to avoid stack trace generation
- handle left out Axios errors so they do not throw unnecessary sentry entries