### PR TITLE
🤏 Limit channel rendered in the payout carousel

### DIFF
--- a/packages/atlas/src/api/hooks/channel.ts
+++ b/packages/atlas/src/api/hooks/channel.ts
@@ -109,11 +109,14 @@ export const useRecentlyPaidChannels = (): { channels: YPPPaidChannels[] | undef
 
     return (
       paymentMap &&
-      Array.from(paymentMap.values()).sort((a, b) => {
-        if (a.amount.gt(b.amount)) return -1
-        if (a.amount.lt(b.amount)) return 1
-        return 0
-      })
+      Array.from(paymentMap.values())
+        .sort((a, b) => {
+          if (a.amount.gt(b.amount)) return -1
+          if (a.amount.lt(b.amount)) return 1
+          return 0
+        })
+        .slice(0, 50)
+        .reverse()
     )
   }, [data])
 


### PR DESCRIPTION
- #4691

Hopefully that's good enough. The carousel now shows 50 channels but the way it currently works it renders 100 elements in order to have a smooth transition when it loops back.