### PR TITLE
Segment analytics for CRT

### DIFF
--- a/packages/atlas/src/components/_crt/BuyMarketTokenModal/BuyMarketTokenModal.tsx
+++ b/packages/atlas/src/components/_crt/BuyMarketTokenModal/BuyMarketTokenModal.tsx
@@ -168,6 +168,7 @@ export const BuyMarketTokenModal = ({ tokenId, onClose: _onClose, show }: BuySal
       onTxSync: async () => {
         if (memberTokenAccount?.tokenAccounts.length) {
           trackAMMTokensPurchased(
+            data?.creatorTokenById?.id ?? 'N/A',
             data?.creatorTokenById?.symbol ?? 'N/A',
             channelId ?? 'N/A',
             String(tokenAmount),
@@ -204,6 +205,7 @@ export const BuyMarketTokenModal = ({ tokenId, onClose: _onClose, show }: BuySal
     calculateRequiredHapi,
     channelId,
     client,
+    data?.creatorTokenById?.id,
     data?.creatorTokenById?.symbol,
     displaySnackbar,
     handleTransaction,

--- a/packages/atlas/src/components/_crt/CloseMarketModal/CloseMarketModal.tsx
+++ b/packages/atlas/src/components/_crt/CloseMarketModal/CloseMarketModal.tsx
@@ -10,6 +10,7 @@ import { NumberFormat } from '@/components/NumberFormat'
 import { Text } from '@/components/Text'
 import { DialogModal } from '@/components/_overlays/DialogModal'
 import { useGetTokenBalance } from '@/hooks/useGetTokenBalance'
+import { useSegmentAnalytics } from '@/hooks/useSegmentAnalytics'
 import { hapiBnToTokenNumber } from '@/joystream-lib/utils'
 import { useJoystream } from '@/providers/joystream'
 import { useSnackbar } from '@/providers/snackbars'
@@ -40,6 +41,7 @@ export const CloseMarketModal = ({ onClose, show, channelId, tokenId }: CloseMar
   const symbol = data?.creatorTokenById?.symbol
   const { joystream, proxyCallback } = useJoystream()
   const { displaySnackbar } = useSnackbar()
+  const { trackAMMClosed } = useSegmentAnalytics()
   const handleTransaction = useTransaction()
   const client = useApolloClient()
   const thresholdAmount = data?.creatorTokenById ? Math.floor(+data.creatorTokenById.totalSupply * 0.01) : 0
@@ -76,6 +78,7 @@ export const CloseMarketModal = ({ onClose, show, channelId, tokenId }: CloseMar
         txFactory: async (updateStatus) =>
           (await joystream.extrinsics).closeAmm(memberId, channelId, proxyCallback(updateStatus)),
         onTxSync: async () => {
+          trackAMMClosed(symbol ?? 'N/A', channelId)
           displaySnackbar({
             iconType: 'success',
             title: 'Market closed',
@@ -138,9 +141,11 @@ export const CloseMarketModal = ({ onClose, show, channelId, tokenId }: CloseMar
     amountToSell,
     handleTransaction,
     proxyCallback,
-    client,
+    trackAMMClosed,
+    symbol,
     displaySnackbar,
     onClose,
+    client,
     calculateSlippageAmount,
     tokenId,
   ])

--- a/packages/atlas/src/components/_crt/CloseMarketModal/CloseMarketModal.tsx
+++ b/packages/atlas/src/components/_crt/CloseMarketModal/CloseMarketModal.tsx
@@ -78,7 +78,7 @@ export const CloseMarketModal = ({ onClose, show, channelId, tokenId }: CloseMar
         txFactory: async (updateStatus) =>
           (await joystream.extrinsics).closeAmm(memberId, channelId, proxyCallback(updateStatus)),
         onTxSync: async () => {
-          trackAMMClosed(symbol ?? 'N/A', channelId)
+          trackAMMClosed(tokenId ?? 'N/A', symbol ?? 'N/A', channelId)
           displaySnackbar({
             iconType: 'success',
             title: 'Market closed',

--- a/packages/atlas/src/components/_crt/CreateTokenDrawer/steps/TokenSummaryStep.tsx
+++ b/packages/atlas/src/components/_crt/CreateTokenDrawer/steps/TokenSummaryStep.tsx
@@ -84,8 +84,14 @@ export const TokenSummaryStep = ({ setPrimaryButtonProps, form, onSuccess }: Tok
           },
           proxyCallback(handleUpdate)
         ),
-      onTxSync: async () => {
-        trackTokenMintingCompleted(channelId, form.name, String(form.creatorIssueAmount ?? 0), form.assuranceType)
+      onTxSync: async ({ tokenId }) => {
+        trackTokenMintingCompleted(
+          channelId,
+          tokenId,
+          form.name,
+          String(form.creatorIssueAmount ?? 0),
+          form.assuranceType
+        )
         onSuccess()
       },
       snackbarSuccessMessage: {

--- a/packages/atlas/src/components/_crt/CreateTokenDrawer/steps/TokenSummaryStep.tsx
+++ b/packages/atlas/src/components/_crt/CreateTokenDrawer/steps/TokenSummaryStep.tsx
@@ -8,6 +8,7 @@ import { Text } from '@/components/Text'
 import { Tooltip } from '@/components/Tooltip'
 import { CrtFormWrapper } from '@/components/_crt/CrtFormWrapper'
 import { useMountEffect } from '@/hooks/useMountEffect'
+import { useSegmentAnalytics } from '@/hooks/useSegmentAnalytics'
 import { useFee, useJoystream } from '@/providers/joystream'
 import { useSnackbar } from '@/providers/snackbars'
 import { useTransaction } from '@/providers/transactions/transactions.hooks'
@@ -42,6 +43,7 @@ export const TokenSummaryStep = ({ setPrimaryButtonProps, form, onSuccess }: Tok
   const { channelId, memberId } = useUser()
   const { displaySnackbar } = useSnackbar()
   const handleTransaction = useTransaction()
+  const { trackTokenMintingCompleted } = useSegmentAnalytics()
   const [cliff, vesting, payout] = getDataBasedOnType(form.assuranceType) ?? [
     form.cliff,
     form.vesting,
@@ -83,6 +85,7 @@ export const TokenSummaryStep = ({ setPrimaryButtonProps, form, onSuccess }: Tok
           proxyCallback(handleUpdate)
         ),
       onTxSync: async () => {
+        trackTokenMintingCompleted(channelId, form.name, String(form.creatorIssueAmount ?? 0), form.assuranceType)
         onSuccess()
       },
       snackbarSuccessMessage: {

--- a/packages/atlas/src/components/_crt/MarketDrawer/MarketDrawer.tsx
+++ b/packages/atlas/src/components/_crt/MarketDrawer/MarketDrawer.tsx
@@ -68,9 +68,9 @@ export const MarketDrawer = ({ show, onClose, tokenId }: CrtMarketSaleViewProps)
   }, [])
 
   const onSuccess = useCallback(() => {
-    trackAMMStarted(creatorTokenById?.symbol ?? 'N/A', channelId ?? 'N/A')
+    trackAMMStarted(tokenId, creatorTokenById?.symbol ?? 'N/A', channelId ?? 'N/A')
     setShowSuccessModal(true)
-  }, [channelId, creatorTokenById?.symbol, trackAMMStarted])
+  }, [channelId, creatorTokenById?.symbol, tokenId, trackAMMStarted])
 
   const stepContent = () => {
     switch (activeStep) {

--- a/packages/atlas/src/components/_crt/MarketDrawer/MarketDrawer.tsx
+++ b/packages/atlas/src/components/_crt/MarketDrawer/MarketDrawer.tsx
@@ -12,6 +12,7 @@ import { SuccessActionModalTemplate } from '@/components/_crt/SuccessActionModal
 import { atlasConfig } from '@/config'
 import { absoluteRoutes } from '@/config/routes'
 import { useClipboard } from '@/hooks/useClipboard'
+import { useSegmentAnalytics } from '@/hooks/useSegmentAnalytics'
 import { useUser } from '@/providers/user/user.hooks'
 import { transitions } from '@/styles'
 import { permillToPercentage } from '@/utils/number'
@@ -49,6 +50,7 @@ export const MarketDrawer = ({ show, onClose, tokenId }: CrtMarketSaleViewProps)
   const { channelId } = useUser()
   const client = useApolloClient()
   const { copyToClipboard } = useClipboard()
+  const { trackAMMStarted } = useSegmentAnalytics()
 
   const handleNextStep = useCallback(
     ({ tnc }: CrtMarketForm) => {
@@ -66,8 +68,9 @@ export const MarketDrawer = ({ show, onClose, tokenId }: CrtMarketSaleViewProps)
   }, [])
 
   const onSuccess = useCallback(() => {
+    trackAMMStarted(creatorTokenById?.symbol ?? 'N/A', channelId ?? 'N/A')
     setShowSuccessModal(true)
-  }, [])
+  }, [channelId, creatorTokenById?.symbol, trackAMMStarted])
 
   const stepContent = () => {
     switch (activeStep) {

--- a/packages/atlas/src/hooks/useSegmentAnalytics.ts
+++ b/packages/atlas/src/hooks/useSegmentAnalytics.ts
@@ -425,6 +425,19 @@ export const useSegmentAnalytics = () => {
     [analytics]
   )
 
+  const trackAMMTokensSold = useCallback(
+    (tokenId: string, tokenTicker: string, channelId: string, crtAmount: string, joyReceived: string) => {
+      analytics.track('Token Market Sell', {
+        tokenId,
+        tokenTicker,
+        channelId,
+        crtAmount,
+        joyReceived,
+      })
+    },
+    [analytics]
+  )
+
   const runNextQueueEvent = useCallback(async () => {
     const queueEvent = playbackEventsQueue.current.shift()
     if (!queueEvent) {
@@ -466,6 +479,7 @@ export const useSegmentAnalytics = () => {
     trackAMMClosed,
     trackAMMStarted,
     trackAMMTokensPurchased,
+    trackAMMTokensSold,
     trackAllNftFilterUpdated,
     trackChannelCreation,
     trackChannelFollow,

--- a/packages/atlas/src/hooks/useSegmentAnalytics.ts
+++ b/packages/atlas/src/hooks/useSegmentAnalytics.ts
@@ -378,9 +378,10 @@ export const useSegmentAnalytics = () => {
   )
 
   const trackTokenMintingCompleted = useCallback(
-    (channelId: string, tokenTicker: string, initSupply: string, safetyOption: string) => {
+    (channelId: string, tokenId: string, tokenTicker: string, initSupply: string, safetyOption: string) => {
       analytics.track('Token minting completed', {
         channelId,
+        tokenId,
         tokenTicker,
         initSupply,
         safetyOption,
@@ -390,8 +391,9 @@ export const useSegmentAnalytics = () => {
   )
 
   const trackAMMStarted = useCallback(
-    (tokenTicker: string, channelId: string) => {
+    (tokenId: string, tokenTicker: string, channelId: string) => {
       analytics.track('Token Market Opened', {
+        tokenId,
         tokenTicker,
         channelId,
       })
@@ -400,8 +402,9 @@ export const useSegmentAnalytics = () => {
   )
 
   const trackAMMClosed = useCallback(
-    (tokenTicker: string, channelId: string) => {
+    (tokenId: string, tokenTicker: string, channelId: string) => {
       analytics.track('Token Market Closed', {
+        tokenId,
         tokenTicker,
         channelId,
       })
@@ -410,8 +413,9 @@ export const useSegmentAnalytics = () => {
   )
 
   const trackAMMTokensPurchased = useCallback(
-    (tokenTicker: string, channelId: string, crtAmount: string, joyPaid: string) => {
+    (tokenId: string, tokenTicker: string, channelId: string, crtAmount: string, joyPaid: string) => {
       analytics.track('Token Market Purchase', {
+        tokenId,
         tokenTicker,
         channelId,
         crtAmount,

--- a/packages/atlas/src/hooks/useSegmentAnalytics.ts
+++ b/packages/atlas/src/hooks/useSegmentAnalytics.ts
@@ -366,6 +366,61 @@ export const useSegmentAnalytics = () => {
     analytics.reset()
   }, [analytics])
 
+  /// CRT events
+
+  const trackTokenMintingStarted = useCallback(
+    (channelId: string) => {
+      analytics.track('Token minting flow started', {
+        channelId,
+      })
+    },
+    [analytics]
+  )
+
+  const trackTokenMintingCompleted = useCallback(
+    (channelId: string, tokenTicker: string, initSupply: string, safetyOption: string) => {
+      analytics.track('Token minting completed', {
+        channelId,
+        tokenTicker,
+        initSupply,
+        safetyOption,
+      })
+    },
+    [analytics]
+  )
+
+  const trackAMMStarted = useCallback(
+    (tokenTicker: string, channelId: string) => {
+      analytics.track('Token Market Opened', {
+        tokenTicker,
+        channelId,
+      })
+    },
+    [analytics]
+  )
+
+  const trackAMMClosed = useCallback(
+    (tokenTicker: string, channelId: string) => {
+      analytics.track('Token Market Closed', {
+        tokenTicker,
+        channelId,
+      })
+    },
+    [analytics]
+  )
+
+  const trackAMMTokensPurchased = useCallback(
+    (tokenTicker: string, channelId: string, crtAmount: string, joyPaid: string) => {
+      analytics.track('Token Market Purchase', {
+        tokenTicker,
+        channelId,
+        crtAmount,
+        joyPaid,
+      })
+    },
+    [analytics]
+  )
+
   const runNextQueueEvent = useCallback(async () => {
     const queueEvent = playbackEventsQueue.current.shift()
     if (!queueEvent) {
@@ -404,6 +459,9 @@ export const useSegmentAnalytics = () => {
   return {
     addEventToQueue,
     identifyUser,
+    trackAMMClosed,
+    trackAMMStarted,
+    trackAMMTokensPurchased,
     trackAllNftFilterUpdated,
     trackChannelCreation,
     trackChannelFollow,
@@ -425,6 +483,8 @@ export const useSegmentAnalytics = () => {
     trackPageView,
     trackPublishAndUploadClicked,
     trackReferralLinkGenerated,
+    trackTokenMintingCompleted,
+    trackTokenMintingStarted,
     trackUploadVideoClicked,
     trackVideoPlaybackCompleted,
     trackVideoPlaybackPaused,

--- a/packages/atlas/src/joystream-lib/extrinsics.ts
+++ b/packages/atlas/src/joystream-lib/extrinsics.ts
@@ -63,6 +63,7 @@ import {
   SendExtrinsicResult,
   StringifiedNumber,
   TokenId,
+  TokenIssuedResult,
   TxMethodName,
   VideoExtrinsicResult,
   VideoId,
@@ -1165,7 +1166,7 @@ export class JoystreamLibExtrinsics {
     return this.api.tx.content.issueCreatorToken(member, parseInt(channelId), params)
   }
 
-  issueCreatorToken: PublicExtrinsic<typeof this.issueCreatorTokenTx, ExtrinsicResult> = async (
+  issueCreatorToken: PublicExtrinsic<typeof this.issueCreatorTokenTx, TokenIssuedResult> = async (
     memberId,
     channelId,
     symbol,
@@ -1182,9 +1183,10 @@ export class JoystreamLibExtrinsics {
       initialCreatorAllocation,
       revenueSplitRate
     )
-    const { block } = await this.sendExtrinsic(tx, cb)
+    const { block, getEventData } = await this.sendExtrinsic(tx, cb)
+    const tokenId = getEventData('projectToken', 'TokenIssued')[0].toString()
 
-    return { block }
+    return { block, tokenId }
   }
 
   purchaseTokenOnMarketTx = async (tokenId: string, memberId: string, amount: string, slippageAmount: string) => {

--- a/packages/atlas/src/joystream-lib/extrinsics.ts
+++ b/packages/atlas/src/joystream-lib/extrinsics.ts
@@ -62,6 +62,7 @@ import {
   RawMetadataProcessorFn,
   SendExtrinsicResult,
   StringifiedNumber,
+  TokenAMMSoldResult,
   TokenId,
   TokenIssuedResult,
   TxMethodName,
@@ -1224,7 +1225,7 @@ export class JoystreamLibExtrinsics {
     )
   }
 
-  sellTokenOnMarket: PublicExtrinsic<typeof this.sellTokenOnMarketTx, ExtrinsicResult> = async (
+  sellTokenOnMarket: PublicExtrinsic<typeof this.sellTokenOnMarketTx, TokenAMMSoldResult> = async (
     tokenId,
     memberId,
     amount,
@@ -1232,8 +1233,9 @@ export class JoystreamLibExtrinsics {
     cb
   ) => {
     const tx = await this.sellTokenOnMarketTx(tokenId, memberId, amount, slippageAmount)
-    const { block } = await this.sendExtrinsic(tx, cb)
-    return { block }
+    const { block, getEventData } = await this.sendExtrinsic(tx, cb)
+    const receivedAmount = getEventData('projectToken', 'TokensSoldOnAmm')[3].toString()
+    return { block, receivedAmount }
   }
 
   startAmmTx = async (memberId: MemberId, channelId: ChannelId, joySlopeNumber: number) => {

--- a/packages/atlas/src/joystream-lib/types.ts
+++ b/packages/atlas/src/joystream-lib/types.ts
@@ -160,6 +160,9 @@ export type JoinRevenueSplitResult = {
   dividendAmount: string
   stakedAmount: string
 } & ExtrinsicResult
+export type TokenIssuedResult = {
+  tokenId: TokenId
+} & ExtrinsicResult
 
 type TxMethodsFromClass<T> = T extends `${infer _}Tx` ? T : never
 

--- a/packages/atlas/src/joystream-lib/types.ts
+++ b/packages/atlas/src/joystream-lib/types.ts
@@ -163,6 +163,9 @@ export type JoinRevenueSplitResult = {
 export type TokenIssuedResult = {
   tokenId: TokenId
 } & ExtrinsicResult
+export type TokenAMMSoldResult = {
+  receivedAmount: string
+} & ExtrinsicResult
 
 type TxMethodsFromClass<T> = T extends `${infer _}Tx` ? T : never
 

--- a/packages/atlas/src/views/studio/CrtDashboard/CrtDashboard.tsx
+++ b/packages/atlas/src/views/studio/CrtDashboard/CrtDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import { useGetFullCreatorTokenQuery } from '@/api/queries/__generated__/creatorTokens.generated'
@@ -15,6 +15,7 @@ import { Loader } from '@/components/_loaders/Loader'
 import { SkeletonLoader } from '@/components/_loaders/SkeletonLoader'
 import { absoluteRoutes } from '@/config/routes'
 import { useMountEffect } from '@/hooks/useMountEffect'
+import { useSegmentAnalytics } from '@/hooks/useSegmentAnalytics'
 import { useUser } from '@/providers/user/user.hooks'
 import { SentryLogger } from '@/utils/logs'
 import {
@@ -47,6 +48,7 @@ export const CrtDashboard = () => {
       SentryLogger.error('Failed to fetch creator token', 'CrtDashboard', error)
     },
   })
+  const { trackPageView } = useSegmentAnalytics()
 
   const hasOpenMarket = data?.creatorTokenById?.ammCurves.some((curve) => !curve.finalized)
   const mappedTabs = TABS.filter((tab) => (hasOpenMarket ? true : tab !== 'Market')).map((tab) => ({ name: tab }))
@@ -60,6 +62,10 @@ export const CrtDashboard = () => {
   useMountEffect(() => {
     if (currentTab === -1) setSearchParams({ 'tab': '0' }, { replace: true })
   })
+
+  useEffect(() => {
+    trackPageView('CRT Dashboard', { tab: TABS[currentTab] })
+  }, [currentTab, trackPageView])
 
   const activeRevenueShare = data?.creatorTokenById?.revenueShares.find((revenueShare) => !revenueShare.finalized)
   const { creatorTokenById } = data ?? {}

--- a/packages/atlas/src/views/studio/CrtWelcomeView/CrtWelcomeView.tsx
+++ b/packages/atlas/src/views/studio/CrtWelcomeView/CrtWelcomeView.tsx
@@ -4,10 +4,14 @@ import { SvgActionPlay } from '@/assets/icons'
 import { WelcomeView } from '@/components/WelcomeView'
 import { CreateTokenDrawer } from '@/components/_crt/CreateTokenDrawer/CreateTokenDrawer'
 import { atlasConfig } from '@/config'
+import { useSegmentAnalytics } from '@/hooks/useSegmentAnalytics'
+import { useUser } from '@/providers/user/user.hooks'
 import { CrtMaintenanceView } from '@/views/studio/CrtMaintenanceView'
 
 export const CrtWelcomeView = () => {
   const [showDrawer, setShowDrawer] = useState(false)
+  const { trackTokenMintingStarted } = useSegmentAnalytics()
+  const { channelId } = useUser()
   if (atlasConfig.general.crtMaintenanceMode) {
     return <CrtMaintenanceView />
   }
@@ -21,7 +25,14 @@ export const CrtWelcomeView = () => {
         subtitle="Create your very own channel token, sell it on your own terms and share your success with your token holders."
         type="crt"
         buttons={[
-          { children: 'Create token', size: 'large', onClick: () => setShowDrawer(true) },
+          {
+            children: 'Create token',
+            size: 'large',
+            onClick: () => {
+              trackTokenMintingStarted(channelId ?? 'N/A')
+              setShowDrawer(true)
+            },
+          },
           {
             children: 'Learn more',
             size: 'large',

--- a/packages/atlas/src/views/studio/StudioLayout.tsx
+++ b/packages/atlas/src/views/studio/StudioLayout.tsx
@@ -69,6 +69,7 @@ const locationToPageName = {
   '/channel': 'Channel',
   '/videos': 'Videos',
   '/crt-welcome': 'CRT Welcome',
+  '/crt-dashboard': 'CRT Dashboard',
   '/crt-preview-edit': 'CRT Preview Edit',
   '/crt-preview': 'CRT Preview',
   'video-workspace': 'Video workspace',
@@ -122,8 +123,8 @@ const _StudioLayout = () => {
   useEffect(() => {
     const pageName = Object.entries(locationToPageName).find(([key]) => location.pathname.includes(key))?.[1]
 
-    //dashboard is tracked by the view component in order to include tabs info
-    if (pageName === 'YPP Dashboard') {
+    //dashboard is tracked by the view component in order to include tabs info. Same for the CRT dashboard
+    if (pageName === 'YPP Dashboard' || pageName === 'CRT Dashboard') {
       return
     }
 


### PR DESCRIPTION
#6001 

few things to note @dmtrjsg:

1. Page visit will show 'CRT Dashboard', selected tab will be in params. Same as we did on YPP Dashboard.
2. Can't track 'Tokens sold on AMM' as this can happen while user is away and we're only tracking user events. Although, 'Tokens purchased on AMM' is tracked and should cover it.