### PR TITLE
fix HTML head tags and auto-fullscreen on mobile safari

### DIFF
--- a/packages/atlas/src/index.html
+++ b/packages/atlas/src/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <preference name="AllowInlineMediaPlayback" value="true" />
     <!--  The following node will be replaced by Optimize init script during Vite's build step (see ../plugins)  -->
     <optimize-script />
 

--- a/packages/atlas/src/views/global/ReferralsView/sections/ReferralsVideo/ReferralsVideo.tsx
+++ b/packages/atlas/src/views/global/ReferralsView/sections/ReferralsVideo/ReferralsVideo.tsx
@@ -67,7 +67,7 @@ export const ReferralsVideo = () => {
       <LayoutGrid>
         <GridItem colSpan={{ base: 12, lg: 10 }} colStart={{ lg: 2 }}>
           <StyledVideoWrapper>
-            <StyledVideo ref={videoRef} autoPlay loop muted>
+            <StyledVideo ref={videoRef} autoPlay loop muted playsInline>
               <source
                 src="https://eu-central-1.linodeobjects.com/atlas-assets/categories/gleev/videos/referrals/Referrals_dashboard.mp4"
                 type="video/mp4"


### PR DESCRIPTION
While investigating why VWO instrumentation doesn't work, I've noticed that almost all tags that are supposed to be in `<head>` are actually in `<body>` because of the `<preference>` tag that was added some time ago. This tag is not valid HTML and is instead intended to be used for `config.xml` for iOS apps. I don't expect it to have any impact for browser apps.

With `<preference>` tag:
![CleanShot 2024-05-01 at 10 45 46@2x](https://github.com/Joystream/atlas/assets/12646744/d9240a49-c3d9-467a-aca9-c4c5242ee173)

Without `<preference>` tag:
![CleanShot 2024-05-01 at 10 45 59@2x](https://github.com/Joystream/atlas/assets/12646744/b68f4bc8-f36c-4693-9457-0d38ff0a96ce)

It's quite possible that this messed up other things as well (like social previews in some cases), we just didn't notice yet.