### PR TITLE
🟣 Release/5.6.2 (update mainnet RPC endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.2] - 2026-05-21
+
+### Fixed
+
+- Updated mainnet RPC endpoint from `wss://rpc.joystream.org:9944` to `wss://rpc.joystream.org`
+
 ## [5.6.1] - 2026-05-09
 
 ### Fixed

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -252,7 +252,7 @@ Query Node (QN) is a service that processes blockchain events and stores them in
 
 ### RPC Node
 
-RPC nodes are Joystream blockchain nodes that are responsible for running the network. Whether you need your own instance of RPC node depends on your setup. If you are running your own QN, you probably also want to run RPC node alongside for speed of synching and indexing. If you make that RPC endpoint public, you can pass it as `VITE_PRODUCTION_NODE_URL` environment variable, meaning that all user-initiated transactions would be sent to your RPC node. However, you can also use a publicly available node, like `wss://rpc.joystream.org:9944`.
+RPC nodes are Joystream blockchain nodes that are responsible for running the network. Whether you need your own instance of RPC node depends on your setup. If you are running your own QN, you probably also want to run RPC node alongside for speed of synching and indexing. If you make that RPC endpoint public, you can pass it as `VITE_PRODUCTION_NODE_URL` environment variable, meaning that all user-initiated transactions would be sent to your RPC node. However, you can also use a publicly available node, like `wss://rpc.joystream.org`.
 
 ### Member faucet
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "description": "UI for consuming Joystream - a user governed video platform",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "license": "GPL-3.0",
   "workspaces": [
     "packages/*"

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/atlas",
   "description": "UI for consuming Joystream - a user governed video platform",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "license": "GPL-3.0",
   "scripts": {
     "start": "vite",

--- a/packages/atlas/src/.env
+++ b/packages/atlas/src/.env
@@ -36,7 +36,7 @@ VITE_VWO_ACCOUNT_ID=
 VITE_PRODUCTION_ORION_AUTH_URL=https://auth.gleev.xyz/api/v1
 VITE_PRODUCTION_ORION_URL=https://orion.gleev.xyz/graphql
 VITE_PRODUCTION_QUERY_NODE_SUBSCRIPTION_URL=wss://orion.joystream.org/graphql
-VITE_PRODUCTION_NODE_URL=wss://rpc.joystream.org:9944
+VITE_PRODUCTION_NODE_URL=wss://rpc.joystream.org
 VITE_PRODUCTION_FAUCET_URL=https://faucet.joystream.org/member-faucet/register
 VITE_PRODUCTION_YPP_FAUCET_URL=https://18.184.136.237.nip.io/membership
 


### PR DESCRIPTION
Replace `wss://rpc.joystream.org:9944` with `wss://rpc.joystream.org` as the former is no longer available.